### PR TITLE
feat: backend readiness probe — hold spark overlay until system is tr…

### DIFF
--- a/frontend/interface/api.js
+++ b/frontend/interface/api.js
@@ -67,6 +67,13 @@ export class ApiClient {
     return fetch(this._buildUrl('/health'), { credentials: 'same-origin' }).then(r => r.json()).catch(() => null);
   }
 
+  /** @returns {Promise<{ready: boolean}>} — never rejects */
+  readyCheck() {
+    return fetch(this._buildUrl('/ready'), { credentials: 'same-origin' })
+      .then(r => r.ok ? r.json() : { ready: false })
+      .catch(() => ({ ready: false }));
+  }
+
   /** @returns {Promise<{thread_id: string, exchanges: Array}>} */
   getRecentConversation() {
     return this._get('/conversation/recent');

--- a/frontend/interface/app.js
+++ b/frontend/interface/app.js
@@ -111,6 +111,7 @@ class ChalieApp {
     await this._showPwaDialogIfNeeded();
 
     // Show the "Waking up" overlay while we wait for the backend
+    this._readyPollActive = true;
     this._showSparkOverlay();
 
     // Start the app
@@ -143,9 +144,23 @@ class ChalieApp {
     });
   }
 
+  async _pollUntilReady() {
+    const POLL_INTERVAL_MS = 2000;
+    const MAX_WAIT_MS = 120_000;
+    const deadline = Date.now() + MAX_WAIT_MS;
+
+    while (this._readyPollActive && Date.now() < deadline) {
+      const result = await this.api.readyCheck();
+      if (result?.ready) return;
+      if (!this._readyPollActive) return; // skip was clicked
+      await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
+    }
+    // Timed out or skipped — proceed anyway so the UI is not permanently blocked
+  }
+
   async _start() {
     try {
-      await this.api.healthCheck();
+      await this._pollUntilReady();
       this._dismissSparkOverlay();
       this.presence.setState('resting');
       const voiceReady = await this.voice.init();
@@ -803,7 +818,10 @@ class ChalieApp {
     // Skip button
     const skipBtn = overlay.querySelector('.spark-overlay__skip');
     if (skipBtn) {
-      skipBtn.addEventListener('click', () => this._dismissSparkOverlay(), { once: true });
+      skipBtn.addEventListener('click', () => {
+        this._readyPollActive = false;
+        this._dismissSparkOverlay();
+      }, { once: true });
     }
   }
 


### PR DESCRIPTION
Add /ready endpoint that checks PostgreSQL, Redis, and prompt-queue worker registration before signalling readiness. The frontend now polls /ready every 2s (max 120s) instead of firing a single /health call that returned 200 the instant Flask bound to port 8080 — before digest-worker had registered on the queue. Spark overlay stays visible until all three subsystems confirm ready; skip button immediately unblocks the UI as before.