### PR TITLE
fix: stack provider cards vertically on mobile

### DIFF
--- a/frontend/brain/style.css
+++ b/frontend/brain/style.css
@@ -288,6 +288,8 @@ body::before {
     flex-shrink: 0;
 }
 
+
+
 /* Cognition List */
 .cognition-list {
     display: flex;
@@ -2302,6 +2304,11 @@ body::before {
         min-width: 100%;
     }
 
+    .provider-card {
+    flex-direction: column;
+    align-items: flex-start;
+}
+
     .provider-actions {
         flex-wrap: wrap;
         width: 100%;
@@ -2347,6 +2354,8 @@ body::before {
         width: 70px;
         font-size: 10px;
     }
+
+    
 }
 
 /* ── Documents Tab ───────────────────────────────────────── */


### PR DESCRIPTION
Problem

On mobile screens (≤640px), provider cards in the Providers tab overflow due to a horizontal flex layout conflicting with full-width action buttons.

Solution

- Updated .provider-card to use flex-direction: column on mobile
- Set align-items: flex-start for proper stacking
- Ensured .provider-actions spans full width and wraps correctly

Result

- Cards stack vertically on small screens
- Buttons no longer overflow
- Layout remains unchanged on desktop

Fixes #4