### PR TITLE
feat: Uncertainty Engine — all 4 phases complete

### DIFF
--- a/docs/04-ARCHITECTURE.md
+++ b/docs/04-ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Chalie is a human-in-the-loop cognitive assistant that combines memory consolidation, semantic reasoning, and proactive assistance. The system processes user prompts through a chain of workers and services, enriching conversations with memory chunks and generating episodic memories for future use.
+Chalie is a **persistent cognitive agent** — a continuously running cognitive runtime, not a request-response service. Intelligence emerges from experience: every interaction flows through a memory pipeline that compresses, abstracts, and decays information over time. The system is not a chatbot or assistant wrapper; it is a cognitive runtime that forms memories, runs background processes, exercises judgment, and diverges into a unique identity shaped by its interaction history.
 
 ## Core Architecture
 
@@ -12,10 +12,11 @@ Chalie is a human-in-the-loop cognitive assistant that combines memory consolida
 - **Core Pattern**: Single-process architecture with daemon threads and PromptQueue, service-oriented design
 
 ### Communication Pattern
-1. User sends message → POST to `/chat` with text
-2. Backend processes: Mode router selects mode → mode-specific LLM generates response
-3. Response delivered: Via WebSocket (status → message → done events)
-4. Authentication: Session cookie-based authentication (`@require_session` decorator)
+1. Client connects to `/ws` (WebSocket via flask-sock)
+2. Client sends `{"type": "message", "text": "..."}` JSON frame
+3. Backend enqueues message → Digest Worker processes → response streamed back as WebSocket frames (`status` → `message` → `done`)
+4. Drift thoughts, cards, and proactive notifications also arrive over the same `/ws` connection
+5. Authentication: Session cookie-based (`@require_session` decorator)
 
 ## Code Organization
 
@@ -166,11 +167,15 @@ frontend/
 - **Semantic Consolidation Worker** — Extracts concepts + relationships from episodes
 
 ### Services/Daemons (Daemon Threads)
-- **REST API + WebSocket** — Flask app with flask-sock on port 8080
+- **REST API + WebSocket** — Flask app with flask-sock on port 8081
 - **Cognitive Drift Engine** — Generates spontaneous thoughts during worker idle (attention-gated: skips when user in deep focus)
 - **Ambient Inference Service** — Deterministic inference of place, attention, energy, mobility, tempo from browser telemetry (<1ms, zero LLM)
 - **Place Learning Service** — Accumulates place fingerprints in SQLite; learned patterns override heuristics after 20+ observations
-- **Decay Engine** — Periodic memory decay cycle
+- **Decay Engine** — Periodic memory decay cycle; applies `contradicted`/`uncertain` reliability multipliers (×0.5/×0.75) so unreliable memories decay faster
+- **Uncertainty Engine** — Four-phase contradiction detection and resolution system:
+  - *UncertaintyService* — CRUD + state machine for `uncertainties` table; rank-guard on `reliability` columns; `mark_surfaced()` with anti-nag downgrade; `resolve_by_reinforcement()` for evidence-based auto-resolution
+  - *ContradictionClassifierService* — LLM pair classifier (600ms ingestion time-box); vector pre-screen via `user_traits_vec`/`concepts_vec`; discriminates temporal change vs true contradiction vs context-dependent
+  - *ReconcileAction* — Autonomous drift action (priority 4, 30min cooldown); samples traits+concepts, runs pairwise classification, creates uncertainty records or auto-supersedes temporal changes
 - **Routing Stability Regulator** — Single authority for router weight mutation
 - **Routing Reflection** — Idle-time peer review of routing decisions
 - **Topic Stability Regulator** — Adaptive tuning of topic classification parameters

--- a/docs/15-UNCERTAINTY-ENGINE.md
+++ b/docs/15-UNCERTAINTY-ENGINE.md
@@ -441,26 +441,30 @@ User clarifies (or new evidence arrives)
 
 ---
 
-## Implementation Order
+## Implementation Status
 
-### Phase 1: Foundation
-1. Schema changes (reliability columns, uncertainties table)
-2. `UncertaintyService` (CRUD, severity heuristic)
-3. Decay engine multiplier (read reliability field)
-4. Context assembly deprioritization (lower weight for non-reliable)
+All four phases are **complete and live**.
 
-### Phase 2: Detection
-5. Ingestion detection subprocess (vector search + contradiction classifier)
-6. Consolidation detection (concept extraction post-check)
-7. Drift RECONCILE action (cross-store contradiction sweep)
+### Phase 1: Foundation ✅
+1. Schema: `reliability` columns on `user_traits`, `episodes`, `semantic_concepts`; `uncertainties` table
+2. `UncertaintyService`: CRUD, severity heuristic, rank-guard on `_set_reliability()`
+3. Decay engine multiplier: `contradicted` ×0.5, `uncertain` ×0.75
+4. Context assembly deprioritization: lower weight for non-reliable memories
 
-### Phase 3: Resolution
-8. Temporal auto-resolution (supersede pattern)
-9. Response weaving (frontal cortex contradiction flag)
-10. ACT loop pre-action check
-11. Resolution feedback loop (clarification -> memory updates)
+### Phase 2: Detection ✅
+5. Ingestion detection: `ContradictionClassifierService.check_ingestion()` — 600ms time-box, vector pre-screen, LLM classify in `digest_worker.generate_for_mode()`
+6. Consolidation detection: `SemanticConsolidationService.consolidate_concept()` hook via `check_concept_conflict()`
+7. Drift RECONCILE: `ReconcileAction` (priority 4, 30min cooldown) registered in `CognitiveDriftEngine`
+8. Trait conflict path: `UserTraitService.store_trait()` creates uncertainty records on same-key conflicts
 
-### Phase 4: Self-Tuning
-12. Uncertainty tolerance identity trait
-13. Surfacing anti-nag logic
-14. Evidence-based resolution (reinforcement resolves uncertainties)
+### Phase 3: Resolution ✅
+9. Temporal auto-resolution: `_auto_supersede()` in `ReconcileAction`; `temporal_change` classification auto-resolves silently
+10. Response weaving: `{{contradiction_context}}` in `frontal-cortex-respond.md`; `FrontalCortexService._inject_parameters()` builds hint block
+11. ACT loop pre-action check: `ActDispatcherService._check_source_reliability()` — reduces confidence 40%, annotates `reliability_warning`
+12. Resolution feedback loop: `UserTraitService.correct_trait()` resolves linked uncertainties with `strategy='user_clarified'`
+
+### Phase 4: Self-Tuning ✅
+13. Uncertainty tolerance identity vector: seeded in `schema.sql` (`baseline=0.5, min=0.2, max=0.8`)
+14. Surfacing anti-nag: `UncertaintyService.downgrade_overexposed()` called from `mark_surfaced()` after 3+ surfacings
+15. Evidence-based resolution: `UncertaintyService.resolve_by_reinforcement()` — auto-resolves when reinforced confidence > 2× opposing
+16. Tolerance nudge: `_nudge_uncertainty_tolerance()` called on `correct_trait()` (−0.03) and trait reinforcement (+0.01)


### PR DESCRIPTION
## Summary

- **Phase 1** (previously shipped): Schema (`reliability` columns + `uncertainties` table), `UncertaintyService`, decay multipliers, context assembly weighting
- **Phase 2**: `ContradictionClassifierService` (LLM pair classifier, 600ms time-box), `ReconcileAction` (drift autonomous action, 30min cooldown), consolidation hook in `SemanticConsolidationService`, ingestion detection in `digest_worker`
- **Phase 3**: `{{contradiction_context}}` in RESPOND prompt + `FrontalCortexService._inject_parameters()`, ACT pre-action reliability check in `ActDispatcherService`, resolution feedback loop in `UserTraitService.correct_trait()`
- **Phase 4**: `downgrade_overexposed()` anti-nag, `resolve_by_reinforcement()` evidence resolution, `uncertainty_tolerance` identity vector, `_nudge_uncertainty_tolerance()` self-tuning
- **Bug fix**: `_optional_columns` migration in `DatabaseService` so `reliability` columns auto-add on existing deployments
- **Tests**: 18 tests for `ContradictionClassifierService`, 32 tests for `UncertaintyService`
- **Docs**: `04-ARCHITECTURE.md` + `15-UNCERTAINTY-ENGINE.md` updated to reflect live implementation

## Test plan

- [ ] `pytest backend/tests/test_uncertainty_service.py` — 32 tests pass
- [ ] `pytest backend/tests/test_contradiction_classifier_service.py` — 18 tests pass
- [ ] Nightly scenarios 200–218 pass
- [ ] Live: send contradictory trait updates, verify `reliability='contradicted'` and uncertainty record created
- [ ] Live: send contradictory chat messages, verify RESPOND weaves the conflict naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)