### PR TITLE
fix: promote richness-gate skip logs from DEBUG to INFO (#53, #56)

### DIFF
--- a/backend/services/curiosity_pursuit_service.py
+++ b/backend/services/curiosity_pursuit_service.py
@@ -79,7 +79,7 @@ class CuriosityPursuitService:
             from services.self_model_service import SelfModelService
             richness = SelfModelService().get_memory_richness()
             if richness < 0.15:
-                logger.debug(f"{LOG_PREFIX} Richness {richness:.2f} < 0.15, skipping exploration")
+                logger.info(f"{LOG_PREFIX} Richness {richness:.2f} < 0.15, skipping exploration")
                 return None
         except Exception:
             pass  # fail-open

--- a/backend/services/growth_pattern_service.py
+++ b/backend/services/growth_pattern_service.py
@@ -113,7 +113,7 @@ class GrowthPatternService:
                 from services.self_model_service import SelfModelService
                 richness = SelfModelService().get_memory_richness()
                 if richness < 0.2:
-                    logger.debug(f"[GROWTH PATTERN] Richness {richness:.2f} < 0.2, skipping cycle")
+                    logger.info(f"[GROWTH PATTERN] Richness {richness:.2f} < 0.2, skipping cycle")
                     return result
             except Exception:
                 pass  # fail-open


### PR DESCRIPTION
DEBUG messages are suppressed at the INFO root log level. These skip decisions (growth pattern and curiosity pursuit) are meaningful operational signals — promote to INFO so they appear in logs.