### PR TITLE
nightly: fix-act-card-only-message-event

### DIFF
--- a/backend/workers/digest_worker.py
+++ b/backend/workers/digest_worker.py
@@ -881,17 +881,27 @@ def route_and_generate(topic, text, classification, thread_conv_service, cortex_
         except Exception as e:
             logging.error(f"[ORCHESTRATOR] Failed: {e}")
 
-    # Signal completion for IGNORE mode on sync WebSocket channels.
-    # RESPOND/CLARIFY handlers call OutputService.enqueue_text()
-    # which signals the WebSocket handler. IGNORE skips OutputService entirely,
-    # so the handler never receives a completion signal — send a close signal
-    # so it can emit "done" instead of "No response received".
+    # Signal completion for IGNORE/card-only mode on sync WebSocket channels.
+    # RESPOND/CLARIFY handlers call OutputService.enqueue_text() which signals
+    # the WebSocket handler directly. For card-only ACT results that resolve to
+    # IGNORE, we also call enqueue_text() with an empty response so the frontend
+    # receives a proper `message` event (carrying exchange_id, topic, mode, etc.)
+    # before the `done` event — instead of jumping straight to a bare close signal
+    # that would leave responseMeta unpopulated on the client.
     if response_data.get('mode') == 'IGNORE' and metadata and metadata.get('uuid'):
         try:
             from services.output_service import OutputService
-            OutputService().enqueue_close_signal(metadata['uuid'])
+            OutputService().enqueue_text(
+                topic=topic,
+                response='',
+                mode='ACT',
+                confidence=response_data.get('confidence', 1.0),
+                generation_time=response_data.get('generation_time', 0.0),
+                original_metadata=metadata,
+                reply_actions=response_data.get('reply_actions'),
+            )
         except Exception as e:
-            logging.warning(f"[IGNORE] Failed to publish close signal: {e}")
+            logging.warning(f"[IGNORE] Failed to publish empty-text message event: {e}")
 
     return response_data, routing_result
 


### PR DESCRIPTION
Nightly Coder automated branch.

# Fix: ACT card-only results missing message event

*Plan type: bug fix*

# Institutional Knowledge

## Project Summary
Chalie is an AI system designed to learn from user interactions and ambient signals to proactively assist users. It features a modular architecture with services for cognitive modeling, memory management, and learning behavioral patterns from temporal data to improve its predictions.

## Coding Conventions
Use the provided GitHub templates when creating issues and pull requests to ensure consistency and provide necessary information.

## Critical Files
- backend/services/temporal_pattern_service.py
- backend/services/ambient_inference_service.py
- backend/services/client_context_service.py
- backend/services/cognitive_drift_engine.py
- backend/schema.sql

## Known Gotchas
- The system does not have an automatic in-place update mechanism. The `version-check-in-place-update` plan was likely mislabeled and did not introduce this functionality. Updates must be performed manually.

## Recent Changes
- [2026-03-07] **docs-seo-overhaul-phase2**: Added comprehensive documentation, including tutorials, API reference, and GitHub templates for contributors.
- [2026-03-07] **docs-seo-overhaul-phase3**: Created troubleshooting, deployment, and glossary documentation for SEO overhaul phase 3
- [2026-03-07] **version-check-in-place-update**: Added a temporal pattern mining service to learn behavioral rhythms from ambient signals and improve predictions.

# Bug Investigation Results

Now I have a complete understanding of the bug. Let me document my findings.

---

## Bug Investigation: ACT Card-Only Results Missing Message Event

### Summary

When the ACT loop (or direct dispatch) produces only card results (e.g., scheduling a reminder, managing a list), the backend sends a WebSocket `close` signal instead of a proper `message` event. This causes the frontend to never receive the `exchange_id` and other metadata for the interaction, creating several downstream issues.

### Root Cause

There are **three code paths** in `digest_worker.py` where card-only results bypass the normal message delivery flow:

#### Path 1: ACT Orchestrator (line 679-690 → `route_and_generate` line 889-894)
- Card-only detected → `terminal_response = {'mode': 'IGNORE', 'response': ''}`
- Flows through `route_and_generate()` → `orchestrator.route_path(mode='IGNORE')` → `IgnoreHandler` does nothing  
- Line 889: Sends `enqueue_close_signal(uuid)` because `mode == 'IGNORE'`

#### Path 2: Innate Skill Dispatch (line 1852-1866)
- `all_card_only` detected → calls `OutputService().enqueue_close_signal(ws_uuid)` directly
- Returns `{'response': '', 'mode': 'ACT'}`

#### Path 3: Direct Tool Dispatch (line 2047-2070)  
- `is_card_only` detected → calls `OutputService().enqueue_close_signal(ws_uuid)` directly
- Returns `{'response': '', 'mode': 'ACT'}`

### What Happens at the WebSocket Layer

In `api/websocket.py` lines 407-412, when a `close` signal arrives:
```python
if parsed.

_...truncated_