### PR TITLE
fix: wire trait extraction into chat path + location key + JSON fence strip

### DIFF
--- a/backend/workers/digest_worker.py
+++ b/backend/workers/digest_worker.py
@@ -198,6 +198,12 @@ def enqueue_trait_extraction(prompt_message: str, metadata: dict = None, thread_
                 if not result:
                     return
 
+                # Strip markdown fences if present
+                import re
+                fence_match = re.search(r'```(?:json)?\s*\n?(.*?)\n?\s*```', result, re.DOTALL)
+                if fence_match:
+                    result = fence_match.group(1).strip()
+
                 parsed = json.loads(result)
                 traits = parsed.get('traits', [])
 
@@ -205,7 +211,7 @@ def enqueue_trait_extraction(prompt_message: str, metadata: dict = None, thread_
                 CORE_KEYS = {
                     'name', 'age', 'gender', 'occupation', 'nationality', 'language',
                     'education', 'culture_region', 'language_preference',
-                    'relationship_status', 'ethnicity', 'birthday',
+                    'relationship_status', 'ethnicity', 'birthday', 'location',
                 }
 
                 db = get_shared_db_service()
@@ -736,6 +742,13 @@ def route_and_generate(topic, text, classification, thread_conv_service, cortex_
     Returns:
         tuple: (response_data dict, routing_result dict)
     """
+    # Trait extraction — runs in background thread, non-blocking
+    enqueue_trait_extraction(
+        prompt_message=text[:1000],
+        metadata={'source': 'chat'},
+        thread_id=thread_id,
+    )
+
     if pre_routing_result:
         # Use pre-computed routing result — skip mode router and DB query entirely
         routing_result = pre_routing_result


### PR DESCRIPTION
## Summary

- **Fix 1**: Call `enqueue_trait_extraction()` inside `route_and_generate()` so every regular chat message triggers background trait extraction. Previously only tool dialogs and cron tool results triggered it, leaving the primary source of user trait information untapped.
- **Fix 2**: Add `'location'` to `CORE_KEYS` so location facts are stored with `category='core'` (slow decay, high floor) instead of `'preference'` (faster decay, lower floor).
- **Fix 3**: Strip markdown code fences (` ```json ... ``` `) from the LLM response before `json.loads()` in `_extract_traits()`. Without this, models that wrap their output in fences cause a silent `JSONDecodeError` and no traits are stored.

## Test plan

- [x] Unit tests pass: `pytest tests/ -m unit -x -q` — 242 pass, 0 new failures (1 pre-existing unrelated failure in `test_observability_tasks_returns_all_sections`)
- [ ] Manual: send a chat message with a personal fact ("I live in Berlin") and confirm a `location` trait appears in `user_traits` with `category='core'`
- [ ] Manual: temporarily make the trait-extraction LLM return a fenced JSON block and confirm traits are still stored correctly

Closes #468, #469, #470, #694, #695, #797, #798, #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)