### PR TITLE
refactor: schema cleanup — compress migrations, add indexes, fix reliability bug

### DIFF
--- a/backend/migrations/009_drop_anti_nag_columns.sql
+++ b/backend/migrations/009_drop_anti_nag_columns.sql
@@ -1,51 +1,9 @@
 -- 009: Strip dead anti-nag columns from the uncertainties table.
 --
--- mark_surfaced() and downgrade_overexposed() were fully implemented but never
--- wired into the response pipeline. The surfaced state, surfaced_count, and
--- last_surfaced_at columns are dead code. Uncertainty states simplify to
--- open | resolved.
+-- Originally rebuilt the uncertainties table without surfaced_count and
+-- last_surfaced_at columns. Migration 025 drops the entire uncertainties
+-- table, making this rebuild redundant. On fresh installs the table was
+-- always empty, so the rebuild was a no-op anyway.
 --
--- SQLite < 3.35 doesn't support DROP COLUMN, so we rebuild the table.
-
--- Migrate any stale 'surfaced' rows to 'open' before dropping the state value.
-UPDATE uncertainties SET state = 'open' WHERE state = 'surfaced';
-
--- Rebuild uncertainties without surfaced_count and last_surfaced_at.
-CREATE TABLE IF NOT EXISTS uncertainties_new (
-    id TEXT PRIMARY KEY,
-    memory_a_type TEXT NOT NULL,
-    memory_a_id TEXT NOT NULL,
-    memory_b_type TEXT,
-    memory_b_id TEXT,
-    uncertainty_type TEXT NOT NULL,
-    severity TEXT NOT NULL,
-    detection_context TEXT NOT NULL,
-    reasoning TEXT,
-    temporal_signal INTEGER DEFAULT 0,
-    surface_context TEXT,
-    state TEXT NOT NULL DEFAULT 'open',
-    resolution_strategy TEXT,
-    resolution_detail TEXT,
-    resolved_at TEXT,
-    created_at TEXT DEFAULT (datetime('now'))
-);
-
-INSERT INTO uncertainties_new
-    (id, memory_a_type, memory_a_id, memory_b_type, memory_b_id,
-     uncertainty_type, severity, detection_context, reasoning,
-     temporal_signal, surface_context, state, resolution_strategy,
-     resolution_detail, resolved_at, created_at)
-SELECT
-    id, memory_a_type, memory_a_id, memory_b_type, memory_b_id,
-    uncertainty_type, severity, detection_context, reasoning,
-    temporal_signal, surface_context, state, resolution_strategy,
-    resolution_detail, resolved_at, created_at
-FROM uncertainties;
-
-DROP TABLE IF EXISTS uncertainties;
-ALTER TABLE uncertainties_new RENAME TO uncertainties;
-
-CREATE INDEX IF NOT EXISTS idx_uncertainties_state ON uncertainties(state);
-CREATE INDEX IF NOT EXISTS idx_uncertainties_memory_a ON uncertainties(memory_a_type, memory_a_id);
-CREATE INDEX IF NOT EXISTS idx_uncertainties_memory_b ON uncertainties(memory_b_type, memory_b_id);
-CREATE INDEX IF NOT EXISTS idx_uncertainties_severity ON uncertainties(severity, state);
+-- Now a permanent no-op. Kept for schema_migrations compatibility.
+SELECT 1;

--- a/backend/migrations/027_schema_cleanup.sql
+++ b/backend/migrations/027_schema_cleanup.sql
@@ -1,0 +1,36 @@
+-- 027: Schema cleanup — composite indexes + drop unused vault_secrets.
+--
+-- Adds targeted composite indexes on hot query paths identified via
+-- codebase audit. Drops vault_secrets (created by 021, never used by
+-- any application code).
+--
+-- All operations are backwards compatible: adding indexes is transparent
+-- to older code, and vault_secrets has zero readers/writers.
+
+-- ── Composite indexes ────────────────────────────────────────────
+
+-- knowledge: most queries filter (kind, entity) together with deleted_at IS NULL
+CREATE INDEX IF NOT EXISTS idx_knowledge_kind_entity_active
+    ON knowledge(kind, entity) WHERE deleted_at IS NULL;
+
+-- topic_transcript: always queried by topic + ordered by created_at
+CREATE INDEX IF NOT EXISTS idx_transcript_topic_created_desc
+    ON topic_transcript(topic, created_at DESC);
+
+-- goals: goal ecology queries rank by salience within active statuses
+CREATE INDEX IF NOT EXISTS idx_goals_active_salience
+    ON goals(salience DESC) WHERE status IN ('candidate', 'strengthening', 'actionable');
+
+-- documents: watched-folder scan queries filter folder + status
+CREATE INDEX IF NOT EXISTS idx_documents_folder_pending
+    ON documents(watched_folder_id, status)
+    WHERE deleted_at IS NULL AND watched_folder_id IS NOT NULL;
+
+-- ── Drop unused tables ──────────────────────────────────────────
+
+-- vault_secrets was created by migration 021 "for future use" but
+-- no application code reads or writes to it. If needed later, a
+-- single migration can recreate it.
+DROP INDEX IF EXISTS idx_vault_secrets_scope;
+DROP INDEX IF EXISTS idx_vault_secrets_scope_ref;
+DROP TABLE IF EXISTS vault_secrets;

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -147,6 +147,7 @@ CREATE INDEX IF NOT EXISTS idx_knowledge_key ON knowledge(key);
 CREATE INDEX IF NOT EXISTS idx_knowledge_confidence ON knowledge(confidence DESC);
 CREATE INDEX IF NOT EXISTS idx_knowledge_decay_class ON knowledge(decay_class);
 CREATE INDEX IF NOT EXISTS idx_knowledge_deleted ON knowledge(deleted_at) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_knowledge_kind_entity_active ON knowledge(kind, entity) WHERE deleted_at IS NULL;
 
 CREATE VIRTUAL TABLE IF NOT EXISTS knowledge_fts USING fts5(
     key, value, kind, entity, content='knowledge', content_rowid='rowid'
@@ -609,6 +610,7 @@ CREATE INDEX IF NOT EXISTS idx_documents_deleted ON documents(deleted_at) WHERE 
 CREATE INDEX IF NOT EXISTS idx_documents_file_hash ON documents(file_hash);
 CREATE INDEX IF NOT EXISTS idx_documents_purge ON documents(purge_after) WHERE purge_after IS NOT NULL;
 -- idx_documents_watched_folder created by migration 001_watched_folders.sql
+CREATE INDEX IF NOT EXISTS idx_documents_folder_pending ON documents(watched_folder_id, status) WHERE deleted_at IS NULL AND watched_folder_id IS NOT NULL;
 
 -- FTS5 for document search
 CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(
@@ -652,37 +654,12 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
     applied_at TEXT DEFAULT (datetime('now'))
 );
 
--- ────────────────────────────────────────────────────────────────
--- UNCERTAINTIES — kept for migration compatibility (migration 009 references it)
--- Dropped by migration 025. Do not add new columns or use in application code.
--- ────────────────────────────────────────────────────────────────
-CREATE TABLE IF NOT EXISTS uncertainties (
-    id TEXT PRIMARY KEY,
-    memory_a_type TEXT NOT NULL,
-    memory_a_id TEXT NOT NULL,
-    memory_b_type TEXT,
-    memory_b_id TEXT,
-    uncertainty_type TEXT NOT NULL,
-    severity TEXT NOT NULL,
-    detection_context TEXT NOT NULL,
-    reasoning TEXT,
-    temporal_signal INTEGER DEFAULT 0,
-    surface_context TEXT,
-    state TEXT NOT NULL DEFAULT 'open',
-    resolution_strategy TEXT,
-    resolution_detail TEXT,
-    resolved_at TEXT,
-    created_at TEXT DEFAULT (datetime('now'))
-);
-
-CREATE INDEX IF NOT EXISTS idx_uncertainties_state ON uncertainties(state);
-CREATE INDEX IF NOT EXISTS idx_uncertainties_memory_a ON uncertainties(memory_a_type, memory_a_id);
-CREATE INDEX IF NOT EXISTS idx_uncertainties_memory_b ON uncertainties(memory_b_type, memory_b_id);
-CREATE INDEX IF NOT EXISTS idx_uncertainties_severity ON uncertainties(severity, state);
+-- uncertainties table removed — dropped by migration 025, replaced by
+-- pending_contradictions. Migration 009 is now a no-op so this table
+-- no longer needs to exist in schema.sql for the migration chain.
 
 -- ────────────────────────────────────────────────────────────────
 -- PENDING CONTRADICTIONS — trait contradictions awaiting user resolution
--- (Replaces uncertainties — migration 025 drops the uncertainties table)
 -- ────────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS pending_contradictions (
     id TEXT PRIMARY KEY,
@@ -727,6 +704,7 @@ CREATE TABLE IF NOT EXISTS goals (
 CREATE INDEX IF NOT EXISTS idx_goals_status ON goals(status);
 CREATE INDEX IF NOT EXISTS idx_goals_salience ON goals(salience, status);
 CREATE INDEX IF NOT EXISTS idx_goals_type ON goals(type, status);
+CREATE INDEX IF NOT EXISTS idx_goals_active_salience ON goals(salience DESC) WHERE status IN ('candidate', 'strengthening', 'actionable');
 
 -- ────────────────────────────────────────────────────────────────
 -- GOAL EVIDENCE — accumulated signals supporting goals
@@ -804,6 +782,7 @@ CREATE TABLE IF NOT EXISTS topic_transcript (
 );
 
 CREATE INDEX IF NOT EXISTS idx_transcript_topic ON topic_transcript(topic, created_at);
+CREATE INDEX IF NOT EXISTS idx_transcript_topic_created_desc ON topic_transcript(topic, created_at DESC);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS topic_transcript_vec USING vec0(
     embedding float[768]

--- a/backend/services/contradiction_classifier_service.py
+++ b/backend/services/contradiction_classifier_service.py
@@ -563,7 +563,7 @@ class ContradictionClassifierService:
                 # Sample top traits by confidence
                 cursor.execute("""
                     SELECT k.id, k.key, k.value, k.confidence,
-                           k.evidence_count, k.reliability,
+                           k.evidence_count,
                            v.embedding, k.created_at
                     FROM knowledge k
                     LEFT JOIN knowledge_vec v ON v.rowid = k.rowid
@@ -578,15 +578,14 @@ class ContradictionClassifierService:
                     meta = {
                         'confidence': row[3],
                         'reinforcement_count': row[4],
-                        'reliability': row[5] or 'reliable',
-                        'created_at': row[7],
+                        'created_at': row[6],
                     }
                     meta['established'] = _is_established('trait', meta)
                     memories.append({
                         'id': row[0],
                         'type': 'trait',
                         'text': f"{row[1]}: {row[2]}",
-                        'embedding': _unpack_embedding(row[6]),
+                        'embedding': _unpack_embedding(row[5]),
                         'meta': meta,
                     })
 

--- a/backend/tests/test_schema_validation.py
+++ b/backend/tests/test_schema_validation.py
@@ -86,53 +86,24 @@ class TestSchemaValidation:
 
     # ── Scenario 200 ─────────────────────────────────────────────────────────
 
-    def test_uncertainty_tables_and_columns(self, schema_db):
-        """Absorbs scenario 200: uncertainties table and reliability columns exist.
+    def test_reliability_columns_on_memory_tables(self, schema_db):
+        """Absorbs scenario 200: reliability columns exist on memory tables.
 
-        Verifies:
-        - uncertainties table has all required columns
-        - reliability column is present on user_traits, episodes, semantic_concepts
-        - required indexes on uncertainties are created
+        uncertainties table was removed from schema.sql (dropped by migration
+        025, replaced by pending_contradictions). Reliability columns are still
+        present on knowledge (for migration 026 compat) and episodes.
         """
-        tables = _get_tables(schema_db)
-        assert 'uncertainties' in tables, "uncertainties table missing from schema"
-
-        uncertainty_columns = _get_columns(schema_db, 'uncertainties')
-        required_cols = {
-            'id',
-            'memory_a_type',
-            'memory_a_id',
-            'memory_b_type',
-            'memory_b_id',
-            'uncertainty_type',
-            'severity',
-            'state',
-            'resolution_strategy',
-            'created_at',
-        }
-        missing_cols = required_cols - uncertainty_columns
-        assert not missing_cols, (
-            f"uncertainties table missing columns: {missing_cols}"
-        )
-
-        # reliability must be on memory tables (knowledge replaced user_traits + semantic_concepts)
         for table in ('knowledge', 'episodes'):
             cols = _get_columns(schema_db, table)
             assert 'reliability' in cols, (
                 f"reliability column missing from {table}"
             )
 
-        # Required indexes
-        uncertainty_indexes = _get_indexes(schema_db, 'uncertainties')
-        required_indexes = {
-            'idx_uncertainties_state',
-            'idx_uncertainties_memory_a',
-            'idx_uncertainties_memory_b',
-            'idx_uncertainties_severity',
-        }
-        missing_indexes = required_indexes - uncertainty_indexes
-        assert not missing_indexes, (
-            f"uncertainties table missing indexes: {missing_indexes}"
+        # uncertainties should NOT be in schema.sql (removed; migration 025 drops it)
+        tables = _get_tables(schema_db)
+        assert 'uncertainties' not in tables, (
+            "uncertainties table should not exist in schema.sql "
+            "(dropped by migration 025)"
         )
 
     # ── Scenario 201 ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Compresses old migration 009 and adds new migration 027 with composite indexes
- Cleans up `schema.sql` to match current state
- Fixes reliability column bug in `contradiction_classifier_service.py`

## Test plan
- [x] All 2980 unit tests pass on merged result

🤖 Generated with [Claude Code](https://claude.com/claude-code)