### PR TITLE
fix: lower confidence threshold so trait corrections can overwrite stale values

### DIFF
--- a/backend/services/knowledge_service.py
+++ b/backend/services/knowledge_service.py
@@ -305,7 +305,7 @@ class KnowledgeService:
                     # Value change: only overwrite if confidence dominance
                     value_changed = False
                     if value and old_value and value.lower().strip() != old_value.lower().strip():
-                        if confidence > old_confidence * 2:
+                        if confidence >= old_confidence * 0.8:
                             value_changed = True
                             new_confidence = confidence
                             logger.info(

--- a/backend/tests/test_knowledge_service.py
+++ b/backend/tests/test_knowledge_service.py
@@ -200,15 +200,15 @@ class TestStore:
         assert result['confidence'] == 0.9
 
     def test_store_value_conflict_no_overwrite(self, svc):
-        """Different value with similar confidence does NOT overwrite."""
+        """Different value with very low confidence does NOT overwrite."""
         svc.store(
             kind='fact', entity='user', key='hometown',
             value='Valletta', confidence=0.5,
         )
-        # 0.6 is NOT > 0.5 * 2 = 1.0, so no overwrite
+        # 0.3 is NOT >= 0.5 * 0.8 = 0.4, so no overwrite
         result = svc.store(
             kind='fact', entity='user', key='hometown',
-            value='Mosta', confidence=0.6,
+            value='Mosta', confidence=0.3,
         )
         assert result is not None
         assert result['value'] == 'Valletta'  # old value preserved


### PR DESCRIPTION
## Summary

- The old confidence guard (`confidence > old_confidence * 2`) was mathematically impossible to satisfy — extracted traits max at ~0.85, so the 1.70 threshold could never be reached. Every user correction was silently discarded.
- Changed to `>= old_confidence * 0.8` which lets corrections with reasonable confidence overwrite, while still rejecting low-quality noise.
- Updated the corresponding test to use a confidence that falls below the new threshold.

## Benchmark results (run 9 vs baseline run 8, both rc-0.3.1)

| Task | Baseline | After | Delta |
|---|---|---|---|
| Simple correction (d4) | 0.10 | 0.38 | **+0.28** |
| Schedule correction (d4) | 0.05 | 0.10 | +0.05 |
| Downstream correction (d4) | 0.20 | 0.10 | -0.10 |
| Multi-fact correction (d4) | 0.10 | 0.10 | 0 |
| Old fact deprioritized (d4) | 0.10 | 0.38 | **+0.28** |
| **d4 total** | **0.1092** | **0.2093** | **+0.10** |
| Recency resolution (d5) | 0.10 | 0.92 | **+0.82** |

**Key validation:** Recency resolution jumped from 0.10 → 0.92 (PASS). Simple correction went from 0.10 → 0.38 — judge confirmed "March 20 is in the knowledge store and was retrieved in 2 of 3 queries" and "correction survived thread reset." Remaining d4 gap is secondary (confidence calibration after overwrite, and seeder bug chalie-ai/chalie-nightly-test#762 blocking tasks that need seeded baseline data).

## Test plan

- [x] `test_knowledge_service.py` — all 52 tests pass
- [x] Benchmark d4-correction (5 tasks) + d5-temporal/recency-resolution — validated above
- [ ] Full nightly run on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)