### PR TITLE
fix(dmn): fail-closed quiet-hours — skip proactive when TZ lookup fails

### DIFF
--- a/backend/services/dmn_service.py
+++ b/backend/services/dmn_service.py
@@ -96,7 +96,7 @@ class DMNService:
             return local_hour >= QUIET_START or local_hour < QUIET_END
         except Exception as exc:
             logger.warning("[DMN] Quiet-hours check failed: %s", exc)
-            return False
+            return True
 
     def _rate_limit_exceeded(self) -> bool:
         """Return True if MAX_PROACTIVE_PER_DAY deliveries occurred in the last 24 h."""


### PR DESCRIPTION
## Summary
- Changes DMN quiet-hours exception handler from fail-open (`return False` = not quiet = fire) to fail-closed (`return True` = assume quiet = skip)
- When timezone lookup fails, proactive messages are now suppressed rather than potentially sent at 2am

## Rationale
The previous fail-open behavior meant a TZ resolution error could cause proactive DMN messages during unsociable hours. Fail-closed is the safe default for user-facing proactive behavior.

## Test plan
- [x] Zero test delta — all 3157 tests pass unchanged
- [x] Nightly eval: no regressions (benchmark/scenario failures were infrastructure-level connection errors, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>