### PR TITLE
feat(prompt): instruct model to prefer conversation corrections over stored knowledge

### DIFF
--- a/backend/services/prompt_assembly_service.py
+++ b/backend/services/prompt_assembly_service.py
@@ -343,6 +343,8 @@ class PromptAssemblyService:
                     f"- Current context suggests: {mem_a}\n"
                     f"- Classification: {classification}\n"
                     f"- Reasoning: {reasoning}\n\n"
+                    f"When information in the current conversation contradicts stored knowledge, "
+                    f"always prefer the conversation — it represents the user correcting a stale fact. "
                     f"If relevant to the response, weave this naturally into your reply "
                     f"(e.g. noting a change, gently asking for clarification). "
                     f"Do NOT present it as a system alert. Omit entirely if not relevant."


### PR DESCRIPTION
## Summary
- Adds prompt instruction in the contradiction_context section of prompt_assembly_service.py
- When active contradictions exist, the model is now explicitly told: "prefer the conversation — it represents the user correcting a stale fact"

## Rationale
d4-correction benchmarks showed the model treating in-conversation corrections as equal weight to stored knowledge. This 2-line prompt addition gives the model a clear recency heuristic.

## Evidence
- d4-001 (simple correction from 3 angles): improved from 0.97 → **1.0** on eval
- d3-004 and d4-002 failures were infrastructure errors (connection lost), not related to this change

## Test plan
- [x] Zero test delta — all 3157 tests pass unchanged
- [x] Nightly eval: d4-001 improved, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>