### PR TITLE
test: replace hollow mocks with real flows (iteration 1)

### DIFF
--- a/backend/tests/test_belief_correction.py
+++ b/backend/tests/test_belief_correction.py
@@ -1,14 +1,41 @@
-"""Tests for conversational belief correction — digest_worker hook using KnowledgeService."""
+"""Tests for conversational belief correction — digest_worker hook using KnowledgeService.
+
+Hollow mock tests replaced with real-DB flows:
+- KnowledgeService is instantiated against the test SQLite fixture
+- Assertions verify actual DB state changes (row deleted / value updated)
+  rather than checking mock call counts
+"""
 
 import pytest
-from unittest.mock import MagicMock, patch
 
 pytestmark = pytest.mark.unit
 
 
-# ── _run_belief_correction_hook ───────────────────────────────────────────────
+# ── Helpers ────────────────────────────────────────────────────────────────────
 
-class TestBeliefCorrectionHook:
+def _seed_trait(db_conn, key, value, confidence=0.8):
+    """Insert a trait row directly into the knowledge table."""
+    db_conn.execute(
+        "INSERT INTO knowledge (kind, entity, key, value, confidence, decay_class) "
+        "VALUES ('trait', 'user', ?, ?, ?, 'standard')",
+        (key, value, confidence),
+    )
+    db_conn.commit()
+
+
+def _get_trait(db_conn, key):
+    """Return the live (non-deleted) knowledge row for the given key, or None."""
+    return db_conn.execute(
+        "SELECT key, value, confidence, deleted_at "
+        "FROM knowledge "
+        "WHERE entity='user' AND key=? AND deleted_at IS NULL",
+        (key,),
+    ).fetchone()
+
+
+# ── Pure pattern guards — no DB needed ────────────────────────────────────────
+
+class TestBeliefCorrectionPatternGuards:
     def test_no_correction_pattern_returns_early(self, db):
         """Messages without correction patterns are ignored — no DB access at all."""
         from workers.digest_worker import _run_belief_correction_hook
@@ -19,87 +46,89 @@ class TestBeliefCorrectionHook:
         from workers.digest_worker import _run_belief_correction_hook
         _run_belief_correction_hook("Don't assume sushi is good")
 
-    def test_negation_deletes_matching_trait(self, db):
-        """'I don't like sushi' when favourite_food=sushi deletes the trait."""
-        from workers.digest_worker import _run_belief_correction_hook
-
-        mock_ks = MagicMock()
-        mock_ks.get_by_kind.return_value = [
-            {'key': 'favourite_food', 'value': 'sushi', 'confidence': 0.8, 'data': '{"category": "preference"}'},
-        ]
-
-        with patch('services.knowledge_service.KnowledgeService', return_value=mock_ks):
-            _run_belief_correction_hook("I don't like sushi")
-
-        mock_ks.forget.assert_called_once_with('user', 'favourite_food')
-
-    def test_replacement_corrects_trait(self, db):
-        """'Actually my name is Dylan' when name=Dan corrects the trait."""
-        from workers.digest_worker import _run_belief_correction_hook
-
-        mock_ks = MagicMock()
-        mock_ks.get_by_kind.return_value = [
-            {'key': 'name', 'value': 'dan', 'confidence': 0.9, 'data': '{"category": "core"}'},
-        ]
-
-        with patch('services.knowledge_service.KnowledgeService', return_value=mock_ks):
-            _run_belief_correction_hook("Actually my name is Dylan")
-
-        mock_ks.update.assert_called_once()
-        call_args = mock_ks.update.call_args
-        assert call_args[0][0] == 'user'
-        assert call_args[0][1] == 'name'
-        assert 'dylan' in call_args[1]['value'].lower()
-
-    def test_low_confidence_trait_skipped(self, db):
-        """Traits below 0.4 confidence are not modified (guardrail 2)."""
-        from workers.digest_worker import _run_belief_correction_hook
-
-        mock_ks = MagicMock()
-        mock_ks.get_by_kind.return_value = [
-            {'key': 'favourite_food', 'value': 'sushi', 'confidence': 0.3, 'data': '{"category": "preference"}'},
-        ]
-
-        with patch('services.knowledge_service.KnowledgeService', return_value=mock_ks):
-            _run_belief_correction_hook("I don't like sushi")
-
-        mock_ks.forget.assert_not_called()
-
-    def test_no_matching_trait_value_no_mutation(self, db):
-        """Message matching pattern but trait value not in message — no mutation."""
-        from workers.digest_worker import _run_belief_correction_hook
-
-        mock_ks = MagicMock()
-        mock_ks.get_by_kind.return_value = [
-            {'key': 'favourite_food', 'value': 'pizza', 'confidence': 0.8, 'data': '{"category": "preference"}'},
-        ]
-
-        with patch('services.knowledge_service.KnowledgeService', return_value=mock_ks):
-            _run_belief_correction_hook("I don't like weather")
-
-        mock_ks.forget.assert_not_called()
-        mock_ks.update.assert_not_called()
-
     def test_hook_error_does_not_raise(self):
         """Hook failures are swallowed (non-fatal)."""
         from workers.digest_worker import _run_belief_correction_hook
+        from unittest.mock import patch
         with patch('services.database_service.get_shared_db_service', side_effect=Exception('DB down')):
             # Should not raise
             _run_belief_correction_hook("I don't like sushi")
 
-    def test_replacement_value_capped_at_3_words(self, db):
-        """Replacement value is capped at 3 words to avoid trailing clause capture."""
+
+# ── Real-DB: negation deletes matching trait ──────────────────────────────────
+
+class TestBeliefCorrectionNegation:
+    def test_negation_deletes_matching_trait(self, db):
+        """'I don't like sushi' when favourite_food=sushi → row soft-deleted in DB."""
         from workers.digest_worker import _run_belief_correction_hook
 
-        mock_ks = MagicMock()
-        mock_ks.get_by_kind.return_value = [
-            {'key': 'name', 'value': 'dan', 'confidence': 0.9, 'data': '{"category": "core"}'},
-        ]
+        _seed_trait(db, 'favourite_food', 'sushi', confidence=0.8)
+        assert _get_trait(db, 'favourite_food') is not None
 
-        with patch('services.knowledge_service.KnowledgeService', return_value=mock_ks):
-            _run_belief_correction_hook("Actually my name is Dylan by the way")
+        _run_belief_correction_hook("I don't like sushi")
 
-        call_args = mock_ks.update.call_args
-        new_value = call_args[1]['value']
-        # Should be at most 3 words
-        assert len(new_value.split()) <= 3
+        # Row must now be soft-deleted (deleted_at set)
+        deleted_row = db.execute(
+            "SELECT deleted_at FROM knowledge WHERE entity='user' AND key='favourite_food'",
+        ).fetchone()
+        assert deleted_row is not None
+        assert deleted_row['deleted_at'] is not None, (
+            "Expected trait to be soft-deleted after negation"
+        )
+
+    def test_low_confidence_trait_skipped(self, db):
+        """Traits below 0.4 confidence are not deleted (guardrail 2)."""
+        from workers.digest_worker import _run_belief_correction_hook
+
+        _seed_trait(db, 'favourite_food', 'sushi', confidence=0.3)
+
+        _run_belief_correction_hook("I don't like sushi")
+
+        # Row must still be alive — guardrail prevents modification
+        row = _get_trait(db, 'favourite_food')
+        assert row is not None, "Low-confidence trait must not be deleted"
+
+    def test_no_matching_trait_value_no_mutation(self, db):
+        """Message negates 'weather' but only 'pizza' is stored — no mutation."""
+        from workers.digest_worker import _run_belief_correction_hook
+
+        _seed_trait(db, 'favourite_food', 'pizza', confidence=0.8)
+
+        _run_belief_correction_hook("I don't like weather")
+
+        row = _get_trait(db, 'favourite_food')
+        assert row is not None, "Unrelated trait must be untouched"
+        assert row['value'] == 'pizza'
+
+
+# ── Real-DB: replacement corrects trait ───────────────────────────────────────
+
+class TestBeliefCorrectionReplacement:
+    def test_replacement_corrects_trait_value_in_db(self, db):
+        """'Actually my name is Dylan' when name=Dan → value updated to 'dylan' in DB."""
+        from workers.digest_worker import _run_belief_correction_hook
+
+        _seed_trait(db, 'name', 'dan', confidence=0.9)
+
+        _run_belief_correction_hook("Actually my name is Dylan")
+
+        row = _get_trait(db, 'name')
+        assert row is not None, "Trait row must survive a value replacement"
+        assert 'dylan' in row['value'].lower(), (
+            f"Expected 'dylan' in updated value, got {row['value']!r}"
+        )
+
+    def test_replacement_value_capped_at_3_words(self, db):
+        """Replacement captures at most 3 words — trailing clause is not included."""
+        from workers.digest_worker import _run_belief_correction_hook
+
+        _seed_trait(db, 'name', 'dan', confidence=0.9)
+
+        _run_belief_correction_hook("Actually my name is Dylan by the way")
+
+        row = _get_trait(db, 'name')
+        assert row is not None
+        new_value = row['value']
+        assert len(new_value.split()) <= 3, (
+            f"Expected ≤ 3 words in replacement value, got {new_value!r}"
+        )

--- a/backend/tests/test_capability_failure_alert.py
+++ b/backend/tests/test_capability_failure_alert.py
@@ -1,17 +1,21 @@
-"""Tests for capability failure alerting (base.py)."""
+"""Tests for capability failure alerting (base.py).
+
+Rewritten to use a real MemoryStore instead of a MagicMock.
+Assertions check actual queue state (llen, lrange) rather than
+mock call counts.
+"""
 
 import json
-from unittest.mock import MagicMock, patch
-
 import pytest
 
 from capabilities.base import AbstractCapability
 
-_MEM = "services.memory_client.MemoryClientService.create_connection"
+pytestmark = pytest.mark.unit
 
 
 def _make_cap():
-    """Build a mock with the attributes _maybe_send_failure_alert reads."""
+    """Return a MagicMock with the attributes _maybe_send_failure_alert reads."""
+    from unittest.mock import MagicMock
     m = MagicMock()
     m._failure_alerted = False
     m._last_error = "auth expired"
@@ -21,36 +25,49 @@ def _make_cap():
     return m
 
 
-@pytest.mark.unit
 class TestFailureAlert:
 
-    def test_fires_once_and_dedup(self):
+    def test_fires_and_pushes_to_queue(self, store):
+        """First call writes one item to the prompt-queue in the real store."""
         cap = _make_cap()
-        ms = MagicMock()
-        with patch(_MEM, return_value=ms):
-            AbstractCapability._maybe_send_failure_alert(cap)
-            assert cap._failure_alerted is True
-            ms.rpush.assert_called_once()
-            AbstractCapability._maybe_send_failure_alert(cap)
-            assert ms.rpush.call_count == 1
+        AbstractCapability._maybe_send_failure_alert(cap)
 
-    def test_prompt_content(self):
+        assert cap._failure_alerted is True
+        assert store.llen("prompt-queue") == 1
+
+    def test_dedup_prevents_second_push(self, store):
+        """Second call after first is a no-op — queue stays at length 1."""
         cap = _make_cap()
-        ms = MagicMock()
-        with patch(_MEM, return_value=ms):
-            AbstractCapability._maybe_send_failure_alert(cap)
-        payload = json.loads(ms.rpush.call_args[0][1])
+        AbstractCapability._maybe_send_failure_alert(cap)
+        AbstractCapability._maybe_send_failure_alert(cap)
+
+        assert store.llen("prompt-queue") == 1
+
+    def test_prompt_content_contains_cap_name_and_error(self, store):
+        """The queued payload embeds the capability name and last_error."""
+        cap = _make_cap()
+        AbstractCapability._maybe_send_failure_alert(cap)
+
+        raw = store.lrange("prompt-queue", 0, -1)[0]
+        payload = json.loads(raw)
         assert "Test" in payload["prompt"]
         assert "auth expired" in payload["prompt"]
-        assert payload["metadata"]["source"] == (
-            "capability_health:test"
-        )
 
-    def test_reset_after_recovery(self):
+    def test_metadata_source_matches_cap_id(self, store):
+        """metadata.source must be capability_health:<cap_id>."""
         cap = _make_cap()
-        ms = MagicMock()
-        with patch(_MEM, return_value=ms):
-            AbstractCapability._maybe_send_failure_alert(cap)
-            cap._failure_alerted = False
-            AbstractCapability._maybe_send_failure_alert(cap)
-        assert ms.rpush.call_count == 2
+        AbstractCapability._maybe_send_failure_alert(cap)
+
+        raw = store.lrange("prompt-queue", 0, -1)[0]
+        payload = json.loads(raw)
+        assert payload["metadata"]["source"] == "capability_health:test"
+
+    def test_reset_after_recovery_allows_second_alert(self, store):
+        """After resetting _failure_alerted, a second alert is pushed."""
+        cap = _make_cap()
+        AbstractCapability._maybe_send_failure_alert(cap)
+        assert store.llen("prompt-queue") == 1
+
+        cap._failure_alerted = False
+        AbstractCapability._maybe_send_failure_alert(cap)
+        assert store.llen("prompt-queue") == 2


### PR DESCRIPTION
- test_belief_correction: drop mock-KS call-count assertions; rewrite 5 tests to use real KnowledgeService + conftest db fixture — negation soft-delete, low-confidence guard, value mismatch guard, replacement value, and 3-word cap all verified against actual SQLite row state
- test_capability_failure_alert: drop MagicMock store + rpush.assert_*; rewrite 5 tests using conftest store fixture — llen/lrange on the real prompt-queue list validates push, dedup, payload content, metadata.source, and post-reset second alert