### PR TITLE
fix(tools/news): accept `topic` kwarg to match registry call convention

### DIFF
--- a/backend/tools/news/news.py
+++ b/backend/tools/news/news.py
@@ -39,7 +39,7 @@ def _resolve_country_code(country) -> str:
     return _COUNTRY_CODE_MAP.get(country.lower().strip(), "US")
 
 
-def execute(_topic, params: dict, config=None, telemetry=None) -> dict:
+def execute(topic: str, params: dict, config=None, telemetry=None) -> dict:
     query = (params.get("query") or "").strip()
     if not query:
         return {"text": "", "error": "A 'query' parameter is required."}


### PR DESCRIPTION
## Summary
- `backend/tools/news/news.py:42` declared `_topic` positional; registry dispatches all tool handlers with `topic=channel` kwarg (`tool_registry_service.py:280`). Every news-tool invocation raised `TypeError: execute() got an unexpected keyword argument 'topic'`.
- One-line signature rename aligns news.py with every other tool (code_eval, weather, browser, search, programming_docs_search).

## Impact (nightly scenarios, rc-0.3.3 → this branch)

| Scenario | Baseline (run 235) | This branch | Δ |
|---|---|---|---|
| 052 Code eval tool — exact mathematical computation | 0.507 WARN (timed out 363s) | **0.955 PASS** (36s) | +0.448 |
| 053 News tool fires for a news-intent prompt | 0.672 WARN | **0.97 PASS** | +0.298 |

### Judge quote (baseline run 235, scenario 052)

> The request timed out after 363 seconds and returned an error event instead of a message. The model entered a hallucinated loop calling unrelated news tools and repeating code_eval without returning results.
>
> Anomalies: Unexpected 'news' tool calls for a math query; Redundant code_eval calls without output

Transcript showed three consecutive `news` calls each returning `"Error: execute() got an unexpected keyword argument 'topic'"`, confirming the cascade. Fix removes the error and the LLM terminates cleanly.

## Test plan
- [x] Scenario 052 on this branch (run 238): PASS 0.955
- [x] Scenario 053 on this branch (run 239): PASS 0.97