### PR TITLE
fix(code_eval): capture PrintCollector output via exec locals

### DIFF
--- a/backend/tests/test_code_eval_tool.py
+++ b/backend/tests/test_code_eval_tool.py
@@ -1,0 +1,52 @@
+"""
+Unit tests for backend/tools/code_eval.py — PrintCollector capture.
+
+All tests run the real RestrictedPython + PrintCollector stack; zero mocks.
+"""
+
+import pytest
+
+from tools.code_eval import execute
+
+
+@pytest.mark.unit
+def test_single_print_captured():
+    result = execute("test", {"code": "print('hello')"})
+    assert result["error"] == ""
+    assert result["text"].strip() == "hello"
+
+
+@pytest.mark.unit
+def test_multiple_prints_captured():
+    code = "print('line1')\nprint('line2')\nprint('line3')"
+    result = execute("test", {"code": code})
+    assert result["error"] == ""
+    text = result["text"]
+    assert "line1" in text
+    assert "line2" in text
+    assert "line3" in text
+
+
+@pytest.mark.unit
+def test_print_with_fstring():
+    """Scenario 052 regression: f-string formatted print must return the value."""
+    code = "monthly_payment = 1234.56\nprint(f'{monthly_payment:.2f}')"
+    result = execute("test", {"code": code})
+    assert result["error"] == ""
+    assert result["text"].strip() == "1234.56"
+
+
+@pytest.mark.unit
+def test_exception_path_returns_captured_text_and_error():
+    code = "print('before error')\nraise ValueError('boom')"
+    result = execute("test", {"code": code})
+    assert "before error" in result["text"]
+    assert "ValueError" in result["error"]
+    assert "boom" in result["error"]
+
+
+@pytest.mark.unit
+def test_no_print_returns_empty_text():
+    result = execute("test", {"code": "x = 1 + 1"})
+    assert result["error"] == ""
+    assert result["text"] == ""

--- a/backend/tools/code_eval.py
+++ b/backend/tools/code_eval.py
@@ -66,14 +66,18 @@ def execute(topic: str, params: dict, config: dict = None, telemetry: dict = Non
 
     # Fresh globals copy per call so state never leaks between executions.
     exec_globals = dict(_RESTRICTED_GLOBALS)
+    # RestrictedPython binds the _print instance to exec locals, not globals.
+    exec_locals: dict = {}
 
     try:
-        exec(byte_code, exec_globals)
+        exec(byte_code, exec_globals, exec_locals)
     except Exception as exc:
-        captured = str(exec_globals.get("_print", PrintCollector()))
+        collector = exec_locals.get("_print")
+        captured = collector() if collector is not None else ""
         error_msg = f"{type(exc).__name__}: {exc}"
-        text = f"{captured}\n{error_msg}".strip() if captured else error_msg
+        text = f"{captured}{error_msg}".strip() if captured else error_msg
         return {"text": text, "error": error_msg}
 
-    captured = str(exec_globals.get("_print", PrintCollector()))
+    collector = exec_locals.get("_print")
+    captured = collector() if collector is not None else ""
     return {"text": captured, "error": ""}


### PR DESCRIPTION
## Problem

Scenario 052 (`Code eval tool — exact mathematical computation`) baseline run 235 composite **0.507 (WARN)**, step 1 FAIL 0.015. Judge diagnostic:

> The request timed out after 363 seconds and returned an error event instead of a message. The model entered a hallucinated loop calling unrelated news tools and repeating code_eval without returning results.

Anomalies: `Request timed out`, `Unexpected news tool calls`, `Redundant code_eval calls without output`.

## Root cause

`backend/tools/code_eval.py` called `exec(byte_code, exec_globals)` without a locals dict. RestrictedPython rewrites `print(x)` into code that binds a fresh `_print` `PrintCollector` instance into the exec frame's locals and calls `.write(x)` on it. Without an explicit locals dict those bindings are discarded when exec returns. Tool returned empty string → LLM re-invoked repeatedly → 363s timeout.

## Fix

- Add `exec_locals: dict = {}` passed as third arg to `exec()`.
- After exec, retrieve `collector = exec_locals.get(\"_print\")` and call `collector()` to get captured text.
- Applied to both success and exception paths.

## Evidence (run 243, this branch)

- Composite **0.507 → 0.94** (+0.433), both steps PASS.
- Tool returned `\"2212.2380822253785\\n\"` — print output now captured.
- All 3 targeted anomalies cleared.
- 5 new unit tests in `backend/tests/test_code_eval_tool.py`. Full suite 2943 pass.

Step 1 latency score 0.2 remains (43s wall-clock) — cloud-model cold-start, unrelated to this fix.