### PR TITLE
fix(document-skill): imperative trigger-oriented tool description

### DIFF
--- a/backend/services/innate_skills/document_skill.py
+++ b/backend/services/innate_skills/document_skill.py
@@ -13,8 +13,8 @@ logger = logging.getLogger(__name__)
 TOOL_SCHEMA = {
     "name": "document",
     "description": (
-        "CRUD operations for persistent documents. Each document is a file "
-        "on the system which you can create, read, search, and delete."
+        "Use this tool when the user asks to create, save, write, store, search, view, list, or delete "
+        "a document or note — all persistent documents and notes live here."
     ),
     "input_schema": {
         "type": "object",
@@ -22,7 +22,10 @@ TOOL_SCHEMA = {
             "action": {
                 "type": "string",
                 "enum": ["search", "list", "view", "delete", "restore", "create"],
-                "description": "Document operation to perform.",
+                "description": (
+                    "Document operation to perform; use `create` when the user asks you to "
+                    "create, save, write, or store a note or document."
+                ),
             },
             "query": {
                 "type": "string",
@@ -34,11 +37,14 @@ TOOL_SCHEMA = {
             },
             "name": {
                 "type": "string",
-                "description": "Document filename (e.g. 'research-notes.md'). Required for create; optional fuzzy match for view/delete/restore.",
+                "description": (
+                    "Required for `create`; use a filename like 'research-notes.md' if the user "
+                    "didn't give one. Optional fuzzy match for view/delete/restore."
+                ),
             },
             "content": {
                 "type": "string",
-                "description": "The text content to store. Required for create.",
+                "description": "The full text body to write. Required for `create`.",
             },
             "source_type": {
                 "type": "string",

--- a/backend/tests/test_document_skill.py
+++ b/backend/tests/test_document_skill.py
@@ -766,3 +766,35 @@ class TestCreateDocumentArtifacts:
                 "SELECT COUNT(*) FROM data_graph WHERE kind=?", (KIND_DOCUMENT,)
             ).fetchone()[0]
         assert stored == 0
+
+
+# ---------------------------------------------------------------------------
+# TOOL_SCHEMA description — trigger-verb guard (cycle 11, scenario 092)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestDocumentSkillSchemaTriggers:
+    """Regression guard: TOOL_SCHEMA description must signal create/save triggers.
+
+    Scenario 092 baseline failure mode: model hallucinated "I've created X"
+    without calling the document tool. Schema description was passive ("CRUD
+    operations for persistent documents ...") — no imperative trigger. This
+    test locks in the imperative trigger verbs so the description cannot
+    regress to a passive form.
+    """
+
+    def test_top_level_description_contains_trigger_verbs(self):
+        from services.innate_skills.document_skill import TOOL_SCHEMA
+        desc = TOOL_SCHEMA["description"].lower()
+        assert "create" in desc
+        assert "save" in desc
+
+    def test_create_action_in_enum(self):
+        from services.innate_skills.document_skill import TOOL_SCHEMA
+        enum = TOOL_SCHEMA["input_schema"]["properties"]["action"]["enum"]
+        assert "create" in enum
+
+    def test_content_description_states_required_for_create(self):
+        from services.innate_skills.document_skill import TOOL_SCHEMA
+        content_desc = TOOL_SCHEMA["input_schema"]["properties"]["content"]["description"]
+        assert "required for" in content_desc.lower()


### PR DESCRIPTION
## Summary

Scenario 092 (Document artifacts stored in data_graph) scored **0.532 WARN** (run 235) because the model hallucinated creating \`solar-panel-notes.md\` without invoking the \`document\` tool — no \`tool_calls\`, no \`data_graph\` row.

Root cause: \`document_skill.TOOL_SCHEMA[\"description\"]\` was a passive CRUD list (\"CRUD operations for persistent documents…\"). No imperative trigger language to help the router recognize \"create/save/write a note\" as a \`document\` call.

Fix: rewrite the schema description as imperative (\"Use this tool when the user asks to create, save, write, store, search, view, list, or delete a document or note\"), and clarify \`action\`/\`name\`/\`content\` param descriptions so \`create\` is the obvious choice for note-creation intent. Three trigger-guard unit tests added.

## Result

- Scenario 092 **0.532 WARN → 0.979 PASS** on run 249
- Step-1 \`tool_calls\` now contains \`document(action=create, name=solar-panel-notes.md, …)\`
- Step-2 \`data_graph\` query matches (count=1, \`kind='document' AND key LIKE 'doc:%' AND value LIKE '%solar%'\`)
- Reply is no longer a hallucination — tool actually fires

## Test plan

- [x] \`pytest backend/tests/test_document_skill.py\` — 46 pass (43 existing + 3 new trigger guards)
- [x] Nightly scenario 092 on branch — PASS 0.979
- [ ] CI green (ruff, vulture, sonar)