### PR TITLE
fix(data_graph): lazy-migrate unmigrated knowledge rows on recall

### DIFF
--- a/backend/services/data_graph_service.py
+++ b/backend/services/data_graph_service.py
@@ -173,17 +173,17 @@ _USER_SPECIFIC_KEYS = {
 
 def seed_from_legacy_knowledge(db_service):
     """
-    One-time idempotent migration: copy rows from knowledge → data_graph.
+    Idempotent per-row migration: copy rows from knowledge → data_graph.
 
     Uses entity-based heuristics per plan D10. Skips procedure and moment_context.
-    Skips ambiguous rows. Direct INSERT for speed; schedules batch embeddings
-    in a background thread.
+    Skips ambiguous rows. For each candidate knowledge row, checks whether
+    data_graph already has a row with matching (kind, key, value) — if yes, skips
+    it; if no, inserts it. This allows the migration to be called multiple times
+    safely and supports post-boot seeds (e.g. from nightly scenarios). Direct
+    INSERT for speed; schedules batch embeddings in a background thread.
     """
     try:
         with db_service.connection() as conn:
-            if conn.execute("SELECT 1 FROM data_graph LIMIT 1").fetchone():
-                return
-
             cursor = conn.cursor()
             cursor.execute("""
                 SELECT entity, kind, key, value, source, evidence_count, created_at
@@ -215,6 +215,14 @@ def seed_from_legacy_knowledge(db_service):
                 else:
                     continue
 
+                # Per-row idempotency: skip if (kind, key, value) already in data_graph
+                existing = cursor.execute(
+                    "SELECT 1 FROM data_graph WHERE kind=? AND key=? AND value=? LIMIT 1",
+                    (target_kind, key, value),
+                ).fetchone()
+                if existing:
+                    continue
+
                 seed_source = f"seed:from_knowledge:{source or 'unknown'}"
                 cursor.execute("""
                     INSERT INTO data_graph
@@ -228,7 +236,8 @@ def seed_from_legacy_knowledge(db_service):
                 inserted_ids.append((rid, key, value))
 
             cursor.close()
-            logger.info("[DATA GRAPH] Seed complete — %d rows migrated from knowledge", len(inserted_ids))
+            if inserted_ids:
+                logger.info("[DATA GRAPH] Seed complete — %d rows migrated from knowledge", len(inserted_ids))
 
             # Batch-schedule embeddings in background (non-blocking boot)
             if inserted_ids:
@@ -911,6 +920,26 @@ class DataGraphService:
 
     def recall(self, query: str, *, kinds=None, limit: int = 10, expand_graph: bool = True) -> list:
         try:
+            # Lazy-migrate any knowledge rows that were inserted after boot
+            # (e.g. by nightly scenario seeders). One cheap probe query; full
+            # migration only runs when unmigrated rows are detected.
+            try:
+                with self.db.connection() as _mc:
+                    _has_unmigrated = _mc.execute("""
+                        SELECT 1
+                        FROM knowledge k
+                        LEFT JOIN data_graph d ON d.key = k.key AND d.value = k.value
+                        WHERE k.deleted_at IS NULL
+                          AND k.kind NOT IN ('procedure', 'moment_context')
+                          AND d.rowid IS NULL
+                        LIMIT 1
+                    """).fetchone()
+                if _has_unmigrated:
+                    logger.debug("[DATA GRAPH] recall: detected unmigrated knowledge rows — running lazy migration")
+                    seed_from_legacy_knowledge(self.db)
+            except Exception as _lm_err:
+                logger.debug("[DATA GRAPH] recall lazy-migrate check failed (non-fatal): %s", _lm_err)
+
             query_emb = self._generate_embedding(query)
             query_blob = pack_embedding(query_emb) if query_emb else None
 

--- a/backend/tests/test_data_graph_service.py
+++ b/backend/tests/test_data_graph_service.py
@@ -1182,12 +1182,12 @@ class TestSeed:
         assert row is None
 
     def test_seed_idempotent_does_not_duplicate(self, svc, db_service):
-        """Running seed twice exits early on second call — no duplicate rows created."""
+        """Running seed twice with the same knowledge row produces exactly one data_graph row."""
         self._insert_knowledge(db_service, entity='user', kind='trait',
                                key='email', value='dylan@example.com')
 
         seed_from_legacy_knowledge(db_service)
-        seed_from_legacy_knowledge(db_service)  # second call must be a no-op
+        seed_from_legacy_knowledge(db_service)  # second call must skip already-migrated rows
 
         with db_service.connection() as conn:
             count = conn.execute(
@@ -1222,6 +1222,80 @@ class TestSeed:
                 "SELECT 1 FROM data_graph WHERE key='temperature_format'"
             ).fetchone()
         assert row is None
+
+    def test_seed_idempotent_adds_only_new_rows(self, db_service):
+        """Per-row idempotency: second call inserts only the rows not yet in data_graph."""
+        # Insert 3 knowledge rows and run first migration
+        self._insert_knowledge(db_service, entity='user', kind='trait', key='hobby', value='running')
+        self._insert_knowledge(db_service, entity='user', kind='trait', key='hobby2', value='cycling')
+        self._insert_knowledge(db_service, entity='user', kind='trait', key='hobby3', value='swimming')
+
+        seed_from_legacy_knowledge(db_service)
+
+        with db_service.connection() as conn:
+            count_after_first = conn.execute("SELECT COUNT(*) FROM data_graph").fetchone()[0]
+        assert count_after_first == 3
+
+        # Add 2 more knowledge rows (distinct keys)
+        self._insert_knowledge(db_service, entity='user', kind='trait', key='hobby4', value='hiking')
+        self._insert_knowledge(db_service, entity='user', kind='trait', key='hobby5', value='reading')
+
+        seed_from_legacy_knowledge(db_service)
+
+        with db_service.connection() as conn:
+            count_after_second = conn.execute("SELECT COUNT(*) FROM data_graph").fetchone()[0]
+        # Only the 2 new rows added; original 3 are not duplicated
+        assert count_after_second == 5
+
+    def test_seed_no_longer_empty_guarded(self, db_service):
+        """Migration runs even when data_graph already has rows (old guard is gone).
+
+        Pre-populate data_graph with a synthetic row, then seed 2 knowledge rows.
+        Under the old empty-guard the migration would be skipped entirely.
+        With per-row idempotency both knowledge rows must be migrated.
+        """
+        # Insert a synthetic data_graph row that does NOT match the knowledge rows below
+        with db_service.connection() as conn:
+            conn.execute("""
+                INSERT INTO data_graph (kind, key, value, first_seen_at, last_confirmed_at)
+                VALUES ('system', 'preexisting_key', 'preexisting_value', datetime('now'), datetime('now'))
+            """)
+
+        self._insert_knowledge(db_service, entity='user', kind='trait', key='sport', value='football')
+        self._insert_knowledge(db_service, entity='user', kind='trait', key='diet', value='vegan')
+
+        seed_from_legacy_knowledge(db_service)
+
+        with db_service.connection() as conn:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM data_graph WHERE key IN ('sport', 'diet')"
+            ).fetchone()[0]
+        assert count == 2, "Both knowledge rows must be migrated even when data_graph is non-empty"
+
+    def test_recall_triggers_lazy_migration(self, db_service):
+        """recall() detects unmigrated knowledge rows and runs the migration inline.
+
+        Seeds knowledge rows AFTER a no-op boot (data_graph empty), then calls
+        recall(). The lazy-migrate probe must detect the gap and migrate rows so
+        that data_graph is populated before the embedding/FTS searches run.
+        Embeddings are async — just assert the rows landed in data_graph.
+        """
+        self._insert_knowledge(db_service, entity='user', kind='trait',
+                               key='exercise', value='running')
+        self._insert_knowledge(db_service, entity='user', kind='trait',
+                               key='stress_relief', value='running helps with stress')
+
+        svc = DataGraphService(db_service)
+        svc._generate_embedding = MagicMock(return_value=None)
+        svc._schedule_embeddings = MagicMock()
+        svc._schedule_doc2query = MagicMock()
+
+        # recall() should trigger lazy migration internally
+        svc.recall("running stress")
+
+        with db_service.connection() as conn:
+            count = conn.execute("SELECT COUNT(*) FROM data_graph").fetchone()[0]
+        assert count == 2, "recall() must have triggered lazy migration of knowledge rows"
 
 
 # ══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Problem

Scenario 014 (`Ambiguous intent routes to correct skill — recall not schedule`) consistently warned on nightly because seeded rows inserted via raw `INSERT INTO knowledge (...)` after boot were invisible to `DataGraphService.recall()`. The legacy-migration seeder `seed_from_legacy_knowledge` ran once at boot, early-exited if `data_graph` was non-empty, and never revisited new rows.

## Fix

Two-part change in `backend/services/data_graph_service.py`:

1. **Drop the empty-table guard** in `seed_from_legacy_knowledge()`. Replace with per-row `SELECT 1 FROM data_graph WHERE kind=? AND key=? AND value=? LIMIT 1` skip check — idempotent, safe to re-run.
2. **Lazy-migrate probe** at the top of `DataGraphService.recall()`. Single cheap `LEFT JOIN` detects any `knowledge` row lacking a `data_graph` counterpart; if one is present, fire `seed_from_legacy_knowledge(self.db)` before the recall executes.

Covers any external writer (scenarios, raw imports, future migrations) that drops rows into `knowledge` without going through `DataGraphService.store()`.

## Verification (nightly run 251, branch `improve/knowledge-lazy-migrate-20260421-205824`)

Container log: `[DATA GRAPH] Seed complete — 12 rows migrated from knowledge` at 19:10:22, right before the memory tool dispatch.

Scenario trace (`scenarios[0]` of run 251):
- memory tool was invoked: `"tools": {"memory": 1}` (not schedule — routing correct)
- memory.recall returned both seeded facts:
  > `[work crunch stress] Periodic phases where deadlines stack up...`
  > `[evening running habit] Runs 4–5km three to four times a week...`
- Chalie's reply cited them verbatim: *"your evening runs are the only thing that reliably clears your head after a hard day... the 4–5km habit seems to be doing the heavy lifting"*
- Step 3 (`SELECT COUNT(*) FROM scheduled_items ...`) = 0 PASS

## Note on run status

Run 251 finished with `status=ERROR` because the judge LLM hit `Judge timed out after 300s` on all 3 retries. That's harness infrastructure — unrelated to the SUT. Turn-by-turn behavior is unambiguously correct (see trace above). Baseline run 235 judge diagnostic: *"correctly routed to memory skill but failed to retrieve the seeded knowledge about running and stress, resulting in a 'no record' response."*

## Tests

88 unit tests pass. 3 new cases in `backend/tests/test_data_graph_service.py`:
- `test_seed_idempotent_adds_only_new_rows`
- `test_seed_no_longer_empty_guarded`
- `test_recall_triggers_lazy_migration`