### PR TITLE
fix(user-mp): zero tool surface on low thinking_level

### DIFF
--- a/backend/services/user_message_processor.py
+++ b/backend/services/user_message_processor.py
@@ -260,7 +260,11 @@ class UserMessageProcessor(MessageProcessor):
         return f"{voice_line}\n\n{self.getUserDefinition()}\n\n{template}"
 
     def getTools(self) -> list[dict]:
-        """Narrow native tools for voice mode (exclude rich_render).
+        """Narrow native tools based on thinking_level and source.
+
+        Low-thinking turns are conversational-only. Zero tool surface prevents
+        the model from hallucinating tool use (e.g. fake reminders) on pure
+        acknowledgments. Scenario 016 § step 4 enforces this contract.
 
         Voice responses are spoken aloud via TTS — rich_render output is not
         speakable, so it is excluded for voice-source turns. All other native
@@ -269,6 +273,9 @@ class UserMessageProcessor(MessageProcessor):
         Out-of-scope §11 preservation: keeps the voice filter logic that was
         in the old UserMessageProcessor.process() at lines 69-73.
         """
+        if self._thinking_level == 'low':
+            return []
+
         if self._metadata.get('source') == 'voice':
             from services.tool_schema_service import get_skill_schemas
 

--- a/backend/tests/test_user_message_processor.py
+++ b/backend/tests/test_user_message_processor.py
@@ -1,0 +1,94 @@
+"""Feature tests — UserMessageProcessor.getTools() thinking_level gate.
+
+All tests are @pytest.mark.unit — real SQLite via the ``db`` fixture,
+real get_skill_schemas(), zero mocks for service internals.
+
+Contract under test (scenario 016 § step 4):
+  - thinking_level == 'low'    → getTools() returns [] regardless of source
+  - thinking_level == 'medium' → getTools() returns the normal tool list
+  - thinking_level == 'high'   → getTools() returns the normal tool list
+  - source == 'voice' + 'low'  → getTools() returns [] (low gate wins)
+  - source == 'voice' + 'medium' → rich_render excluded (existing voice filter)
+"""
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestGetToolsThinkingLevelGate:
+    """getTools() returns [] for low-thinking turns, non-empty otherwise."""
+
+    def test_low_thinking_level_returns_empty_list(self, db):
+        """thinking_level='low' must produce an empty tool list (zero tool surface)."""
+        from services.user_message_processor import UserMessageProcessor
+
+        proc = UserMessageProcessor(raw_input='thanks', metadata={'source': 'text'})
+        proc._thinking_level = 'low'
+
+        result = proc.getTools()
+
+        assert result == [], (
+            f"Expected [] for thinking_level='low', got {[t.get('name') for t in result]}"
+        )
+
+    def test_medium_thinking_level_returns_tools(self, db):
+        """thinking_level='medium' must produce at least one tool (native skills)."""
+        from services.user_message_processor import UserMessageProcessor as UMP
+
+        proc = UMP(raw_input='what is the weather?', metadata={'source': 'text'})
+        proc._thinking_level = 'medium'
+
+        result = proc.getTools()
+
+        # NATIVE_TOOLS is sorted(ALL_SKILL_NAMES) — always non-empty (11 skills)
+        # so getTools() must return at least one entry for medium.
+        if UMP.NATIVE_TOOLS:
+            assert len(result) >= 1, (
+                "thinking_level='medium' must expose at least one tool "
+                f"(NATIVE_TOOLS={UMP.NATIVE_TOOLS!r})"
+            )
+
+    def test_high_thinking_level_returns_tools(self, db):
+        """thinking_level='high' must produce at least one tool (native skills)."""
+        from services.user_message_processor import UserMessageProcessor as UMP
+
+        proc = UMP(raw_input='explain distributed consensus', metadata={'source': 'text'})
+        proc._thinking_level = 'high'
+
+        result = proc.getTools()
+
+        if UMP.NATIVE_TOOLS:
+            assert len(result) >= 1, (
+                "thinking_level='high' must expose at least one tool "
+                f"(NATIVE_TOOLS={UMP.NATIVE_TOOLS!r})"
+            )
+
+    def test_voice_source_low_thinking_returns_empty(self, db):
+        """Voice source + thinking_level='low' must still return [] (low gate wins)."""
+        from services.user_message_processor import UserMessageProcessor
+
+        proc = UserMessageProcessor(raw_input='got it', metadata={'source': 'voice'})
+        proc._thinking_level = 'low'
+
+        result = proc.getTools()
+
+        assert result == [], (
+            f"Expected [] for voice + thinking_level='low', "
+            f"got {[t.get('name') for t in result]}"
+        )
+
+    def test_voice_source_medium_thinking_excludes_rich_render(self, db):
+        """Voice source + thinking_level='medium' must not expose rich_render."""
+        from services.user_message_processor import UserMessageProcessor
+
+        proc = UserMessageProcessor(raw_input='play music', metadata={'source': 'voice'})
+        proc._thinking_level = 'medium'
+
+        result = proc.getTools()
+        tool_names = [t.get('name') for t in result]
+
+        assert 'rich_render' not in tool_names, (
+            f"rich_render must be excluded for voice-source turns, "
+            f"got tools: {tool_names}"
+        )


### PR DESCRIPTION
## Problem

Scenario `016-no-skill-needed` step 2 ("Got it, makes sense") was hallucinating tool invocations on pure conversational acknowledgments. Baseline judge diagnostic:

> `tool_performance_metrics count = 2 when expected 0` — step 3 FAIL. thinking_level correctly classified as `low` (step 4 PASS), but full tool surface was still exposed to the model, enabling fake reminder / passport fabrications.

Scenario score 0.716 WARN. Step 3 FAIL on a thinking_level=low turn that produced 2 tool calls.

## Fix

`UserMessageProcessor.getTools()`: early-return `[]` when `self._thinking_level == 'low'`. Low-thinking turns are conversational-only by definition — removing the tool surface removes the possibility of hallucinated tool use.

Voice filter (source='voice') branch kept intact for medium/high turns.

## Result

Scenario 016 run 254: **0.716 → 0.981 PASS**. All 4 steps PASS, `tool_performance_metrics count=0`, anomaly cleared.

| step | before | after |
| --- | --- | --- |
| 1 — ack #1 | PASS 0.955 | PASS 0.955 |
| 2 — ack #2 | WARN (hallucinated tools) | PASS 0.97 |
| 3 — no tools | **FAIL** (count=2) | **PASS** (count=0) |
| 4 — thinking=low | PASS | PASS |

## Tests

5 real-stack zero-mock unit tests in `backend/tests/test_user_message_processor.py`:
- low → `[]`
- medium → tools present
- high → tools present
- voice + low → `[]`
- voice + medium → voice filter intact (no rich_render)