### PR TITLE
fix(goal-pursuit): sharpen tool description to fire before inline answer

### DIFF
--- a/backend/services/innate_skills/goal_pursuit_skill.py
+++ b/backend/services/innate_skills/goal_pursuit_skill.py
@@ -17,9 +17,12 @@ LOG_PREFIX = "[GOAL PURSUIT SKILL]"
 TOOL_SCHEMA = {
     "name": "goal_pursuit",
     "description": (
-        "Use this tool to launch a separate instance of yourself with unconstrained limits "
-        "to research or perform long running tasks. Only use this if you expect a request to "
-        "take longer than 2 minutes to complete. If not, use other tools to resolve the request."
+        "Launch a background copy of yourself for deep, long-running research or multi-source investigation. "
+        "Fire this tool FIRST (before answering inline) when the user asks for: deep research, comprehensive analysis, "
+        "multi-source comparison, deep dive, extended investigation, or anything requiring 2+ minutes of work across many sources. "
+        "Signal phrases: 'deep dive', 'research', 'analyze multiple', 'compare X and Y', 'comprehensive study', "
+        "'competitive analysis', 'find out about', 'investigate thoroughly'. "
+        "When unsure if a request is heavy enough, prefer this tool — surface-level answers to deep-research asks waste the user's time."
     ),
     "input_schema": {
         "type": "object",

--- a/backend/tests/test_goal_pursuit_skill.py
+++ b/backend/tests/test_goal_pursuit_skill.py
@@ -11,9 +11,27 @@ from contextlib import contextmanager
 import pytest
 from unittest.mock import MagicMock, patch
 
-from services.innate_skills.goal_pursuit_skill import handle_goal_pursuit
+from services.innate_skills.goal_pursuit_skill import handle_goal_pursuit, TOOL_SCHEMA
 
 pytestmark = pytest.mark.unit
+
+
+# ── TOOL_SCHEMA description contract ──────────────────────────────────────────
+
+class TestToolSchemaDescription:
+    def test_description_contains_deep(self):
+        """Description must mention 'deep' to signal deep-research trigger."""
+        assert 'deep' in TOOL_SCHEMA['description'].lower()
+
+    def test_description_contains_research(self):
+        """Description must mention 'research' to signal research trigger."""
+        assert 'research' in TOOL_SCHEMA['description'].lower()
+
+    def test_description_length_within_bounds(self):
+        """Description must be at least 100 chars and no more than 800 chars."""
+        length = len(TOOL_SCHEMA['description'])
+        assert length > 100, f"Description too short: {length} chars"
+        assert length < 800, f"Description too long: {length} chars"
 
 
 # ── Input validation ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Scenario `077-goal-task-report` baseline (run 235): 0.667 WARN. Step 1 FAIL with:

> Judge diagnostic: \"The /chat endpoint timed out after ~360 seconds and returned an error event. The pipeline must handle the hand-off to background pursuit without blocking the HTTP response for 6 minutes.\"
>
> Anomalies: \"HTTP event stream contains 'type': 'error' with message 'Request timed out'\", \"elapsed_ms is 363748, far exceeding any acceptable baseline\"

Root cause: `goal_pursuit` TOOL_SCHEMA description was weak — descriptive rather than prescriptive:

> \"Use this tool to launch a separate instance of yourself with unconstrained limits to research or perform long running tasks. Only use this if you expect a request to take longer than 2 minutes to complete. If not, use other tools to resolve the request.\"

Model underestimated duration, attempted inline research for ~221s before dispatching goal_pursuit.

## Fix

Rewrote `TOOL_SCHEMA['description']` in `backend/services/innate_skills/goal_pursuit_skill.py`:
- Imperative opening (\"Launch a background copy...\")
- Explicit \"Fire this tool FIRST (before answering inline)\" instruction
- Enumerated trigger signals: \"deep research\", \"comprehensive analysis\", \"multi-source comparison\", \"deep dive\", \"competitive analysis\", \"investigate thoroughly\"
- Preference nudge for borderline cases

## Result

Scenario 077 run 255: **0.667 WARN → 0.948 PASS**. Both steps PASS. Anomalies cleared.

| metric | before | after |
| --- | --- | --- |
| scenario score | 0.667 WARN | **0.948 PASS** |
| duration | 565s | 111s |
| step 1 composite | 0.365 FAIL | 0.895 PASS |
| step 2 composite | 0.97 PASS | 1.0 PASS |

Anomalies cleared: \"Request timed out\", \"elapsed_ms 363748\".

Note: Step 1 latency still 0.3 (68.9s response) — goal_pursuit fires quickly now but initial response still slow. Judge issues one \"medium\" severity note but scenario passes.

## Tests

`backend/tests/test_goal_pursuit_skill.py` TestToolSchemaDescription: 3 assertions (description contains \"deep\", contains \"research\", 100–800 char bounds). 25 unit tests pass.