### PR TITLE
fix(privacy): expand delete-all to wipe every user-data table

### DIFF
--- a/backend/api/privacy.py
+++ b/backend/api/privacy.py
@@ -15,6 +15,42 @@ logger = logging.getLogger(__name__)
 
 privacy_bp = Blueprint('privacy', __name__)
 
+# Ordered list of user-data tables for the nuclear delete operation.
+# Children must appear before parents to satisfy FK constraints.
+# System / auth / config tables are deliberately excluded.
+_DELETE_ALL_TABLES = (
+    # ── FK children first ─────────────────────────────────────────────────
+    "tool_calls",          # FK → transcript(id)
+    "compactions",         # FK → transcript(id)
+    "goal_evidence",       # FK → goals(id) ON DELETE CASCADE
+    "list_items",          # FK → lists(id)
+    "list_events",         # FK → lists(id)
+    "data_graph_edges",    # FK → data_graph(id) ON DELETE CASCADE
+    # ── Parents / independents ────────────────────────────────────────────
+    "transcript",
+    "episodes",
+    "knowledge",
+    "data_graph",
+    "goals",
+    "lists",
+    "scheduled_items",
+    "documents",
+    "watched_folders",
+    "place_fingerprints",
+    "user_tool_preferences",
+    "tool_performance_metrics",
+    "memory_recall_log",
+    "llm_call_log",
+    "concept_lut_misses",
+    "browser_snapshots",
+    "browser_credentials",
+)
+
+# MemoryStore key patterns that belong to the user and must be cleared.
+_DELETE_ALL_STORE_PATTERNS = (
+    "working_memory:*",
+)
+
 
 def _serialize_row(row: dict) -> dict:
     """Convert a database row dict to JSON-serializable form."""
@@ -209,26 +245,48 @@ def export_data():
 @privacy_bp.route('/privacy/delete-all', methods=['DELETE'])
 @require_session
 def delete_all():
-    """Nuclear option — clear all stored user data."""
+    """Nuclear option — clear all stored user data.
+
+    Wipes every user-owned table (episodes, transcript, tool_calls,
+    compactions, goal_evidence, list_items, list_events, data_graph_edges,
+    data_graph, knowledge, goals, lists, scheduled_items, documents,
+    watched_folders, place_fingerprints, user_tool_preferences,
+    tool_performance_metrics, memory_recall_log, llm_call_log,
+    concept_lut_misses, browser_snapshots, browser_credentials)
+    and clears MemoryStore working_memory keys.
+
+    System / auth / config tables are deliberately excluded.
+    """
     confirm = request.headers.get("X-Confirm-Delete", "")
     if confirm != "yes":
         return jsonify({"error": "Requires X-Confirm-Delete: yes header"}), 400
 
     try:
         from services.database_service import get_shared_db_service
+        from services.memory_client import MemoryClientService
 
         db = get_shared_db_service()
         truncate_failures = []
+
         with db.connection() as conn:
             cursor = conn.cursor()
-            # FK order: tool_calls → transcript (tool_calls.transcript_id FK)
-            for table in ["tool_calls", "episodes", "transcript"]:
+            for table in _DELETE_ALL_TABLES:
                 try:
                     cursor.execute(f"DELETE FROM {table}")
                 except Exception as e:
                     logger.warning(f"[REST API] Failed to delete from {table}: {e}")
                     truncate_failures.append(table)
             cursor.close()
+
+        # Clear user-owned MemoryStore keys
+        try:
+            store = MemoryClientService.create_connection()
+            for pattern in _DELETE_ALL_STORE_PATTERNS:
+                matched = store.keys(pattern)
+                if matched:
+                    store.delete(*matched)
+        except Exception as e:
+            logger.warning(f"[REST API] Failed to clear memory store: {e}")
 
         result = {"deleted": True, "timestamp": utc_now().isoformat()}
         if truncate_failures:

--- a/backend/tests/test_api_privacy.py
+++ b/backend/tests/test_api_privacy.py
@@ -143,7 +143,7 @@ class TestPrivacyAPI:
         db.execute(
             "INSERT INTO documents (id, original_name, mime_type, file_path) "
             "VALUES (?, ?, ?, ?)",
-            ("doc-1", "notes.txt", "text/plain", "/tmp/notes.txt"),
+            ("doc-1", "notes.txt", "text/plain", "data/uploads/notes.txt"),
         )
 
         # ── Seed place_fingerprints ───────────────────────────────────────────

--- a/backend/tests/test_api_privacy.py
+++ b/backend/tests/test_api_privacy.py
@@ -100,3 +100,87 @@ class TestPrivacyAPI:
 
         assert db.execute("SELECT COUNT(*) FROM episodes").fetchone()[0] == 0
         assert db.execute("SELECT COUNT(*) FROM transcript").fetchone()[0] == 0
+
+    def test_delete_all_clears_extended_tables(self, client, db):
+        """DELETE /privacy/delete-all wipes data_graph, knowledge, lists, list_items,
+        goals, scheduled_items, documents, and place_fingerprints."""
+        # ── Seed data_graph ───────────────────────────────────────────────────
+        db.execute(
+            "INSERT INTO data_graph (kind, key, value) VALUES (?, ?, ?)",
+            ("fact", "favourite_colour", "blue"),
+        )
+
+        # ── Seed knowledge ────────────────────────────────────────────────────
+        db.execute(
+            "INSERT INTO knowledge (kind, entity, key, value) VALUES (?, ?, ?, ?)",
+            ("trait", "user", "prefers_dark_mode", "true"),
+        )
+
+        # ── Seed lists + list_items (list_items FK → lists) ───────────────────
+        db.execute(
+            "INSERT INTO lists (id, name, list_type) VALUES (?, ?, ?)",
+            ("list-1", "Groceries", "checklist"),
+        )
+        db.execute(
+            "INSERT INTO list_items (id, list_id, content) VALUES (?, ?, ?)",
+            ("item-1", "list-1", "Milk"),
+        )
+
+        # ── Seed goals ────────────────────────────────────────────────────────
+        db.execute(
+            "INSERT INTO goals (id, description, type, status, salience, confidence) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("goal-1", "Learn to cook", "stated", "candidate", 0.5, 0.8),
+        )
+
+        # ── Seed scheduled_items ──────────────────────────────────────────────
+        db.execute(
+            "INSERT INTO scheduled_items (id, message, due_at) VALUES (?, ?, ?)",
+            ("sched-1", "Buy groceries", "2026-05-01T10:00:00+00:00"),
+        )
+
+        # ── Seed documents ────────────────────────────────────────────────────
+        db.execute(
+            "INSERT INTO documents (id, original_name, mime_type, file_path) "
+            "VALUES (?, ?, ?, ?)",
+            ("doc-1", "notes.txt", "text/plain", "/tmp/notes.txt"),
+        )
+
+        # ── Seed place_fingerprints ───────────────────────────────────────────
+        db.execute(
+            "INSERT INTO place_fingerprints "
+            "(fingerprint_hash, device_class, hour_bucket, place_label) "
+            "VALUES (?, ?, ?, ?)",
+            ("abc123hash", "laptop", 9, "home"),
+        )
+
+        db.commit()
+
+        # Pre-conditions: every seeded table has >= 1 row
+        assert db.execute("SELECT COUNT(*) FROM data_graph").fetchone()[0] >= 1
+        assert db.execute("SELECT COUNT(*) FROM knowledge").fetchone()[0] >= 1
+        assert db.execute("SELECT COUNT(*) FROM lists").fetchone()[0] >= 1
+        assert db.execute("SELECT COUNT(*) FROM list_items").fetchone()[0] >= 1
+        assert db.execute("SELECT COUNT(*) FROM goals").fetchone()[0] >= 1
+        assert db.execute("SELECT COUNT(*) FROM scheduled_items").fetchone()[0] >= 1
+        assert db.execute("SELECT COUNT(*) FROM documents").fetchone()[0] >= 1
+        assert db.execute("SELECT COUNT(*) FROM place_fingerprints").fetchone()[0] >= 1
+
+        response = client.delete(
+            '/privacy/delete-all',
+            headers={"X-Confirm-Delete": "yes"},
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["deleted"] is True
+
+        # Post-conditions: every seeded table must be empty
+        assert db.execute("SELECT COUNT(*) FROM data_graph").fetchone()[0] == 0
+        assert db.execute("SELECT COUNT(*) FROM knowledge").fetchone()[0] == 0
+        assert db.execute("SELECT COUNT(*) FROM lists").fetchone()[0] == 0
+        assert db.execute("SELECT COUNT(*) FROM list_items").fetchone()[0] == 0
+        assert db.execute("SELECT COUNT(*) FROM goals").fetchone()[0] == 0
+        assert db.execute("SELECT COUNT(*) FROM scheduled_items").fetchone()[0] == 0
+        assert db.execute("SELECT COUNT(*) FROM documents").fetchone()[0] == 0
+        assert db.execute("SELECT COUNT(*) FROM place_fingerprints").fetchone()[0] == 0


### PR DESCRIPTION
## Summary
`/privacy/delete-all` claimed success but left `data_graph`, `knowledge`, `lists`, `goals`, `scheduled_items`, `documents`, and others intact. It was only truncating `tool_calls` / `episodes` / `transcript`.

Expanded the handler to wipe every user-owned table (FK-safe order) plus `working_memory:*` keys in MemoryStore. System / auth / config tables (`providers`, `settings`, `vault_*`, `master_account`, `auth_sessions`, `interfaces*`, `tool_configs`, `schema_version`, `wrapper_tokens`) remain untouched.

## Nightly scenario 091 — Privacy: nuclear delete requires confirmation and clears data
- **Before (run 263 rc-0.3.3):** WARN **0.495**. Judge: *"Incomplete Nuclear Delete — /privacy/delete-all endpoint returned a success response, but failed to clear records from the data_graph table, leaving 11 traits intact."*
- **After (run 267 this branch):** PASS **0.925**. All 3 steps PASS. Judge step 3: *"Database query confirms all traits, episodes, and lists were purged (count 0)."*

## Test plan
- [x] `pytest -m unit tests/test_api_privacy.py` — 4/4 green (new `test_delete_all_clears_extended_tables` added, seeds 8 tables, asserts empty post-call)
- [x] Full unit suite — 2947 passed / 2 skipped / 0 failed
- [x] `ruff check .` — clean
- [x] Targeted nightly 091 — PASS 0.925

🤖 Generated with [Claude Code](https://claude.com/claude-code)