### PR TITLE
fix(system-prompt): mandate proactive recall before recommendations

### DIFF
--- a/backend/services/system_message_prompt.py
+++ b/backend/services/system_message_prompt.py
@@ -100,7 +100,7 @@ Guiding framework for all interactions (internalize, do not recite):
 1. **You reason, tools provide data.** All judgment happens here.
 2. **Respond directly when possible.** If the conversation already contains everything needed, respond now.
 3. **Auto-store personal facts.** If the user discloses a personal fact (e.g., "my dog's name is Biscuit", "I am allergic to peanuts"), use the `memory` skill to store it immediately. Do not ask for permission.
-4. **Proactive recall.** If a user's request could be answered by information they have previously shared, use the `memory` skill to check before responding.
+4. **Proactive recall.** If a user's request could be answered by information they have previously shared, use the `memory` skill to check before responding. This is mandatory before offering recommendations, suggestions, or advice — including generic-seeming topics like food, places, products, activities, plans — because stored preferences, allergies, constraints, or goals may change the answer.
 5. **Never fabricate tool results.** If you did not call a tool — or a call returned an error — do not pretend the action succeeded. Only reference information from actual tool results in this conversation.
 6. **Use code for math.** If a request requires calculation (e.g., mortgage, interest, percentages), use the `code_eval` tool. Do not perform complex arithmetic inline.
 7. **Avoid tool use for simple acknowledgments.** Do not invoke tools for messages like "thanks", "got it", or "ok".

--- a/backend/tests/test_system_message_prompt.py
+++ b/backend/tests/test_system_message_prompt.py
@@ -253,6 +253,25 @@ class TestUnifiedSystemMessagePrompt:
         result = UnifiedSystemMessagePrompt().getPrompt()
         assert isinstance(result, str) and len(result) > 0
 
+    def test_unified_prompt_proactive_recall_covers_recommendations(self):
+        """Proactive-recall rule must explicitly gate recommendations/suggestions.
+
+        Locks the wording that triggers scenario 025 step-5 (Thai food
+        recommendation phrasing) — the rule must contain both "recommendations"
+        and "mandatory" so the model knows recall is required before offering
+        advice on any topic.
+        """
+        from services.system_message_prompt import UnifiedSystemMessagePrompt
+        result = UnifiedSystemMessagePrompt().getPrompt()
+        assert 'recommendations' in result.lower(), (
+            "'recommendations' missing from UnifiedSystemMessagePrompt — "
+            "proactive-recall rule must explicitly cover recommendation queries"
+        )
+        assert 'mandatory' in result.lower(), (
+            "'mandatory' missing from UnifiedSystemMessagePrompt — "
+            "proactive-recall rule must state that recall is mandatory before recommendations"
+        )
+
     # ── Subclassing contract ──────────────────────────────────────────────────
 
     def test_is_subclass_of_system_message_prompt(self):


### PR DESCRIPTION
## Summary

Scenario 025 step 5 sends `"Can you suggest some Thai food dishes I should try?"`. On rc-0.3.3 baseline (run 263) the response carried `metrics.tools: {}` — memory skill never fired. Rule 4 ("Proactive recall") in `UnifiedSystemMessagePrompt` reads as optional for generic-seeming topics, so the model bypasses recall on recommendation/suggestion queries where stored preferences, allergies, constraints, or goals would change the answer.

## Fix

One-line prompt change in `backend/services/system_message_prompt.py` — rule 4 now marks recall as **mandatory** before offering recommendations, suggestions, or advice, and cites example categories (food, places, products, activities, plans).

## Test plan

- [x] New zero-mock unit `test_unified_prompt_proactive_recall_covers_recommendations` locks both "recommendations" and "mandatory" tokens into the prompt.
- [x] `backend/tests/test_system_message_prompt.py` — 44 passed (was 43).
- [x] Targeted nightly run 271 on this branch vs baseline run 263 on rc-0.3.3:

| Scenario | Before (run 263) | After (run 271) |
|---|---|---|
| 014 Ambiguous skill routing | WARN 0.685 | **PASS 0.985** |
| 017 Near-boundary disambiguation | PASS 0.839 | PASS 0.772 (noise, still PASS) |
| 025 Memory recall direct/indirect/entity | WARN 0.575 | WARN 0.630 |

Trace verification on 025 step 5: `metrics.tools: {'memory': 1}` — anomaly cleared. Step 5 response now grounded via recall rather than generic suggestions.

Judge on run 263 scenario 025: `"While Chalie correctly avoided the schedule skill, it failed the primary objective of recalling the seeded memory..."` — model now fires memory on recommendation phrasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)