### PR TITLE
fix(find_tools): direct invocation of discovered tool in same turn

### DIFF
--- a/backend/services/innate_skills/find_tools_skill.py
+++ b/backend/services/innate_skills/find_tools_skill.py
@@ -24,7 +24,13 @@ LOG_PREFIX = "[FIND_TOOLS]"
 
 TOOL_SCHEMA = {
     "name": "find_tools",
-    "description": "Find tools for tasks your built-in skills can't handle. Returns usable tools.",
+    "description": (
+        "Find tools for tasks your built-in skills can't handle. "
+        "Returns a list of tools that are now available to you. "
+        "IMPORTANT: after this returns, if any listed tool matches the user's request, "
+        "INVOKE it in the same turn to complete the task. Do not respond to the user "
+        "without invoking the matching tool first."
+    ),
     "input_schema": {
         "type": "object",
         "properties": {

--- a/backend/tests/test_find_tools_skill.py
+++ b/backend/tests/test_find_tools_skill.py
@@ -7,6 +7,7 @@ from unittest.mock import patch, MagicMock
 from services.innate_skills.find_tools_skill import (
     handle_find_tools,
     _filter_available,
+    TOOL_SCHEMA,
 )
 
 
@@ -477,3 +478,15 @@ class TestFilterAvailableQueryPassthrough:
         assert isinstance(result, dict)
         # Both tools should appear; weather should rank first (lower score)
         assert 'weather' in result['_discovered_tools']
+
+
+class TestToolSchemaDescription:
+    """Lock the invoke-now directive into TOOL_SCHEMA['description']."""
+
+    def test_tool_schema_description_requires_invocation(self):
+        """TOOL_SCHEMA description must instruct the model to invoke the returned tool
+        in the same turn — prevents the model from treating find_tools as informational
+        and responding without calling the discovered tool."""
+        desc = TOOL_SCHEMA["description"].lower()
+        assert "invoke" in desc, "Description must contain 'invoke' directive"
+        assert "same turn" in desc, "Description must contain 'same turn' directive"


### PR DESCRIPTION
## Summary

Scenario 044-skill-invocation-determinism sends identical `"What is the weather in Berlin right now?"` three times with thread resets. Baseline run 263 trace showed the first attempt fired `find_tools` only — `metrics.tools: {'find_tools': 1}` — no weather call. Response drifted to stale DMN context (`"Cold water swimming primarily benefits..."`). Rows 2 and 3 invoked weather correctly. Step 7 expected weather count=3, got 2 (FAIL).

Root cause: `find_tools` TOOL_SCHEMA description reads as capability discovery. On a fresh turn the model treats the returned `{added_tools: [...]}` list as informational and responds directly instead of invoking the matching tool.

## Fix

One-block change in `backend/services/innate_skills/find_tools_skill.py` — TOOL_SCHEMA["description"] gains an explicit `IMPORTANT: ... INVOKE it in the same turn` directive: after `find_tools` returns, if any listed tool matches the user's request, invoke it in the same turn. Do not respond to the user without invoking the matching tool first.

## Test plan

- [x] New zero-mock unit `test_tool_schema_description_requires_invocation` locks both "invoke" and "same turn" tokens into the description.
- [x] `backend/tests/test_find_tools_skill.py` — 26 passed (was 25).
- [x] `pytest -m unit -q -k "find_tools or dispatcher or tool_registry"` — 58 passed, zero regressions.
- [x] Targeted nightly run 272 on this branch vs baseline run 263 on rc-0.3.3:

| Scenario | Before (run 263) | After (run 272) |
|---|---|---|
| 041 Find tools skill — semantic capability discovery | PASS 0.792 | PASS 0.778 (noise) |
| 044 Same input triggers same skill — determinism canary | PASS 0.777 | **PASS 0.877** |

Trace verification on 044 step 2: `metrics.tools: {'find_tools': 1, 'weather': 1, 'search': 1}` — weather now fires on first attempt. Step 7 `count=3` (was 2) — hard assertion passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)