### PR TITLE
fix(world-state): truncate bg_process content to prevent turn bleed

### DIFF
--- a/backend/services/world_state.py
+++ b/backend/services/world_state.py
@@ -274,6 +274,11 @@ class WorldState:
                 last_update = TimeFormatterService.ago(created_at)
             except Exception:
                 last_update = "unknown"
+            if len(content) > 200:
+                cut = content.rfind(" ", 0, 200)
+                if cut == -1:
+                    cut = 200
+                content = content[:cut] + "…"
             lines.append(f"[bg_process(last_update:{last_update})] {content}")
         return lines
 

--- a/backend/tests/test_world_state.py
+++ b/backend/tests/test_world_state.py
@@ -464,6 +464,40 @@ class TestRenderBgProcess:
         # Should contain 'last_update:2m ago' (125s ≈ 2m)
         assert "last_update:2m ago" in result
 
+    def test_bg_process_truncates_long_content(self, db):
+        long_content = "word " * 120  # 600 chars, well above 200
+        db.execute(
+            "INSERT INTO transcript (channel, role, content, created_at) "
+            "VALUES ('goal_pursuit', 'assistant', ?, ?)",
+            (long_content, _recent_iso(seconds=60)),
+        )
+        db.commit()
+
+        ws = _fresh()
+        result = ws.render()
+        bg_line = next((ln for ln in result.splitlines() if "[bg_process(" in ln), None)
+        assert bg_line is not None
+        # Content is capped at 200 chars + '…'; prefix '[bg_process(last_update:Xs ago)] '
+        # adds ~30-35 chars — use 240 as the safe upper bound.
+        assert len(bg_line) <= 240
+        assert bg_line.endswith("…")
+
+    def test_bg_process_short_content_not_truncated(self, db):
+        short_content = "Researching cheap hotels in Valletta"
+        db.execute(
+            "INSERT INTO transcript (channel, role, content, created_at) "
+            "VALUES ('goal_pursuit', 'assistant', ?, ?)",
+            (short_content, _recent_iso(seconds=60)),
+        )
+        db.commit()
+
+        ws = _fresh()
+        result = ws.render()
+        assert short_content in result
+        bg_line = next((ln for ln in result.splitlines() if "[bg_process(" in ln), None)
+        assert bg_line is not None
+        assert not bg_line.endswith("…")
+
 
 # ---------------------------------------------------------------------------
 # render() — full-mix section ordering


### PR DESCRIPTION
## Problem

`WorldState._render_bg_process()` emits each goal_pursuit transcript row's **full content verbatim** into the user-turn system prompt. Research outputs are often 500+ words. When a subsequent unrelated user turn arrives, the LLM sees the bg_process content at the top of its prompt and echoes it back instead of answering the current query.

### Evidence — nightly run 291

Scenario 050 `050-tool-weather.yaml` — user asks for Paris weather:
- Response was cold-water swimming content (from 037 goal_pursuit bg_process bleed)
- Score **0.981 → 0.43**
- Judge: *"The model replied with a detailed, well-written summary about the benefits of cold water swimming. This is a complete and total failure. The user asked for weather in Paris."*

Scenario 044 `044-skill-invocation-determinism.yaml` — Berlin weather ×3:
- All 3 attempts responded with cold-water content
- Score **0.983 → 0.571**

## Fix

Truncate each rendered bg_process line to first ~200 chars at a word boundary, append `…`. Preserves the telemetry signal (model knows a background pursuit is active + topic headline) without letting 500+ word research outputs dominate the prompt.

Surgical change: `backend/services/world_state.py::_render_bg_process()` only.

## Results — run 297 (targeted)

| Scenario | Before | After | Delta |
|---|---|---|---|
| 044 determinism | 0.571 | **0.884 PASS** | +0.313 |
| 050 weather | 0.43 | **0.917 PASS** | +0.487 |
| 037 goal_pursuit | 0.902 | 0.500 WARN | -0.402 |

Targeted anomalies (044, 050) cleared. 037 regressed on a different step (tool_calls count=0 inside 3-min window) with Berlin-weather bleed — appears to be scenario-ordering artifact unrelated to the truncation. 037 was not a targeted scenario; watch the next full nightly to confirm it recovers when the full 44-scenario sequence runs.

## Tests

Two zero-mock tests in `test_world_state.py`:
- `test_bg_process_truncates_long_content` — 600-char row truncates to ≤240 chars with `…`
- `test_bg_process_short_content_not_truncated` — 36-char row renders verbatim

46/46 test_world_state passes. ruff clean.