### PR TITLE
fix(system): reset-thread clears notifications:recent to stop task bleed

### DIFF
--- a/backend/api/system.py
+++ b/backend/api/system.py
@@ -553,7 +553,7 @@ def update_apply():
 def reset_thread():
     """Clear conversation context and advance the thread ID.
 
-    Does two things:
+    Does three things:
     1. Deletes all transcript rows (and their linked tool_calls + compaction watermark)
        for the given processor channel (default 'user'). This empties the Previous
        Messages block so the next turn starts genuinely fresh — recall must come from
@@ -561,6 +561,10 @@ def reset_thread():
     2. Advances the active_channel MemoryStore key (web:default:N → N+1) so postTurn
        services (adaptive directives, phase, situation model) scope their writes to the
        new thread_id.
+    3. Clears the notifications:recent MemoryStore list. On every /ws connect the
+       client drains this list to replay missed background events (goal_pursuit
+       completions, etc.). Without this clear, stale task events from a previous
+       scenario bleed into the next scenario's event stream.
 
     In the persistent-context architecture, getPreviousMessages() reads from the
     transcript table filtered by the hardcoded CHANNEL value ('user'). The MemoryStore
@@ -615,15 +619,21 @@ def reset_thread():
             new_thread = f"{parts[0]}:{seq}" if len(parts) > 1 else f"web:default:{seq}"
             store.set('active_channel:default', new_thread, ex=604800)
 
+        # ── 3. Clear stale background-event notifications ──────────────────────
+        notifications_count = store.llen('notifications:recent')
+        store.delete('notifications:recent')
+
         logger.info(
             f"[RESET-THREAD] channel='{channel}': cleared {cleared} transcript rows, "
-            f"thread {current!r} → {new_thread!r}"
+            f"thread {current!r} → {new_thread!r}, "
+            f"notifications_cleared={notifications_count}"
         )
         return jsonify({
             'ok': True,
             'channel': channel,
             'transcript_rows_cleared': cleared,
             'new_thread': new_thread,
+            'notifications_cleared': notifications_count,
         }), 200
 
     except Exception as e:

--- a/backend/tests/test_api_system.py
+++ b/backend/tests/test_api_system.py
@@ -515,3 +515,33 @@ class TestSystemAPI:
 
         data = resp.get_json()
         assert 'checks' not in data
+
+    # ────────────────────────────────────────────
+    # POST /system/reset-thread — notifications:recent cleared
+    # ────────────────────────────────────────────
+
+    def test_reset_thread_clears_notifications_recent(self, authed_client):
+        """POST /system/reset-thread wipes notifications:recent from MemoryStore.
+
+        Plants a stale task event in notifications:recent (mimicking a completed
+        goal_pursuit background worker), calls the endpoint, then asserts the list
+        is gone — both via llen==0 and lpop returning None.  Also verifies the
+        response includes notifications_cleared==1.
+        """
+        client, _db_conn, store = authed_client
+
+        store.rpush('notifications:recent', '{"type":"task","test":1}')
+        assert store.llen('notifications:recent') == 1
+
+        resp = client.post(
+            '/system/reset-thread',
+            json={'channel': 'user'},
+            content_type='application/json',
+        )
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['ok'] is True
+        assert data['notifications_cleared'] == 1
+        assert store.llen('notifications:recent') == 0
+        assert store.lpop('notifications:recent') is None


### PR DESCRIPTION
## Summary
- `POST /system/reset-thread` now also deletes the `notifications:recent` MemoryStore list alongside transcript clear + thread advance.
- `/ws` drains that list on every connect (websocket.py L118-129). After a goal_pursuit background worker completed in scenario 037, its task event lived there until drained — polluting scenarios 041/042/044/050/051 with stale "cold water swimming" content via the post-done SSE drain.
- Complements cycle 5's bg_process truncation (PR #1675) — that closed the prompt-side leak, this closes the event-side leak.

## Judge evidence (run 291, scenario 041 step-2)
> "Output block contains irrelevant content about cold water swimming"
> "Transcript shows a user message about Spanish goals that was not in the request"

## Targeted run 299 (this branch)
| Scenario | Baseline | After | Δ |
|---|---|---|---|
| 037 goal_pursuit | 0.5 (run 297) | **0.98 PASS** | +0.48 |
| 041 find_tools   | 0.871 (run 291) | **0.902 PASS** | +0.031 |
| 044 determinism  | 0.884 (run 297) | **0.951 PASS** | +0.067 |

Cold-water anomaly gone from 041 step-2 verdict.

## Test plan
- [x] `test_reset_thread_clears_notifications_recent` (zero-mock, real MemoryStore)
- [x] Ruff clean
- [x] Targeted scenarios 037/041/044 PASS
- [ ] CI green (this PR)