### PR TITLE
fix(transcript): per-turn snapshot isolates concurrent channel turns

### DIFF
--- a/backend/services/message_processor.py
+++ b/backend/services/message_processor.py
@@ -330,8 +330,15 @@ class MessageProcessor:
         compaction = compaction_service.get_compaction(self.CHANNEL)
         watermark = compaction['compacted_up_to_id'] if compaction else 0
 
+        # Pass self._uid as until_id so this turn only sees rows written at or
+        # before its own input row. Concurrent turns (id > self._uid) are
+        # invisible, preventing context drift in parallel-scenario harness runs
+        # and rapid-fire UI messages on the same channel.
         entries = transcript_service.get_recent(
-            self.CHANNEL, limit=self._TRANSCRIPT_FETCH_LIMIT, since_id=watermark
+            self.CHANNEL,
+            limit=self._TRANSCRIPT_FETCH_LIMIT,
+            since_id=watermark,
+            until_id=self._uid if self._uid else None,
         )
 
         if not entries and not (compaction and compaction.get('compacted_text')):

--- a/backend/services/transcript_service.py
+++ b/backend/services/transcript_service.py
@@ -184,13 +184,14 @@ def search(
         return _keyword_search(channel, query, limit, date_from, date_to)
 
 
-def get_recent(channel: str, limit: int = 20, since_id: int = None, _context=None) -> List[Dict]:
+def get_recent(channel: str, limit: int = 20, since_id: int = None, *, until_id: int | None = None, _context=None) -> List[Dict]:
     """Get the most recent transcript entries for a channel.
 
     Args:
         channel: Channel key to retrieve entries for.
         limit: Maximum entries to return (default 20).
         since_id: If provided, only return entries with id > since_id.
+        until_id: If provided, only return entries with id <= until_id (per-turn snapshot cap).
 
     Returns list of dicts with: id, role, content, tool_call_id, tool_name, internal, created_at.
     """
@@ -201,27 +202,51 @@ def get_recent(channel: str, limit: int = 20, since_id: int = None, _context=Non
         with db.connection() as conn:
             cursor = conn.cursor()
             if since_id is not None:
-                cursor.execute(
-                    """
-                    SELECT id, role, content, tool_call_id, tool_name, internal, created_at
-                    FROM transcript
-                    WHERE channel = ? AND id > ?
-                    ORDER BY id ASC
-                    LIMIT ?
-                    """,
-                    (channel, since_id, limit),
-                )
+                if until_id is not None:
+                    cursor.execute(
+                        """
+                        SELECT id, role, content, tool_call_id, tool_name, internal, created_at
+                        FROM transcript
+                        WHERE channel = ? AND id > ? AND id <= ?
+                        ORDER BY id ASC
+                        LIMIT ?
+                        """,
+                        (channel, since_id, until_id, limit),
+                    )
+                else:
+                    cursor.execute(
+                        """
+                        SELECT id, role, content, tool_call_id, tool_name, internal, created_at
+                        FROM transcript
+                        WHERE channel = ? AND id > ?
+                        ORDER BY id ASC
+                        LIMIT ?
+                        """,
+                        (channel, since_id, limit),
+                    )
             else:
-                cursor.execute(
-                    """
-                    SELECT id, role, content, tool_call_id, tool_name, internal, created_at
-                    FROM transcript
-                    WHERE channel = ?
-                    ORDER BY id DESC
-                    LIMIT ?
-                    """,
-                    (channel, limit),
-                )
+                if until_id is not None:
+                    cursor.execute(
+                        """
+                        SELECT id, role, content, tool_call_id, tool_name, internal, created_at
+                        FROM transcript
+                        WHERE channel = ? AND id <= ?
+                        ORDER BY id DESC
+                        LIMIT ?
+                        """,
+                        (channel, until_id, limit),
+                    )
+                else:
+                    cursor.execute(
+                        """
+                        SELECT id, role, content, tool_call_id, tool_name, internal, created_at
+                        FROM transcript
+                        WHERE channel = ?
+                        ORDER BY id DESC
+                        LIMIT ?
+                        """,
+                        (channel, limit),
+                    )
             rows = cursor.fetchall()
             cursor.close()
 

--- a/backend/tests/test_message_processor_v2_store.py
+++ b/backend/tests/test_message_processor_v2_store.py
@@ -1262,3 +1262,35 @@ class TestRunFullCompaction:
             p._run_full_compaction()
 
         assert 'custom-job-name' in captured_jobs
+
+
+# =============================================================================
+# getPreviousMessages() — per-turn snapshot isolation
+# =============================================================================
+
+
+class TestGetPreviousMessagesSnapshotIsolation:
+    """Each turn must only see transcript rows with id <= its own self._uid.
+
+    Concurrent turns (id > self._uid) must be invisible to getPreviousMessages
+    regardless of channel filtering.
+    """
+
+    def test_getPreviousMessages_per_turn_snapshot_isolation(self, db):
+        """uid_a sees only its own row; uid_b's concurrent row is invisible."""
+        from services.transcript_service import write_input_row
+
+        channel = 'test_channel'
+
+        uid_a = write_input_row(channel, 'user', 'What is EUR vs USD?')
+        uid_b = write_input_row(channel, 'user', 'Calculate monthly mortgage payment')
+
+        assert uid_b > uid_a, "uid_b must be a later (higher) rowid than uid_a"
+
+        p = _GPMFakeProcessor.make()
+        p._uid = uid_a
+
+        result = p.getPreviousMessages()
+
+        assert 'EUR vs USD' in result
+        assert 'mortgage' not in result

--- a/backend/tests/test_transcript_service.py
+++ b/backend/tests/test_transcript_service.py
@@ -69,6 +69,50 @@ class TestAppend:
         assert append('', 'user', 'content') is None
 
 
+class TestGetRecentUntilId:
+    def test_get_recent_until_id_caps_results(self, db):
+        from services.transcript_service import append, get_recent
+
+        id1 = append('ch', 'user', 'Msg1')
+        id2 = append('ch', 'user', 'Msg2')
+        id3 = append('ch', 'user', 'Msg3')
+        append('ch', 'user', 'Msg4')
+        append('ch', 'user', 'Msg5')
+
+        results = get_recent('ch', until_id=id3)
+        assert len(results) == 3
+        returned_ids = [r['id'] for r in results]
+        assert id1 in returned_ids
+        assert id2 in returned_ids
+        assert id3 in returned_ids
+
+    def test_get_recent_until_id_combined_with_since_id(self, db):
+        from services.transcript_service import append, get_recent
+
+        id1 = append('ch2', 'user', 'Msg1')
+        id2 = append('ch2', 'user', 'Msg2')
+        id3 = append('ch2', 'user', 'Msg3')
+        append('ch2', 'user', 'Msg4')
+
+        results = get_recent('ch2', since_id=id1, until_id=id3)
+        assert len(results) == 2
+        returned_ids = [r['id'] for r in results]
+        assert id2 in returned_ids
+        assert id3 in returned_ids
+        assert id1 not in returned_ids
+
+    def test_get_recent_until_id_none_is_noop(self, db):
+        from services.transcript_service import append, get_recent
+
+        append('ch3', 'user', 'A')
+        append('ch3', 'user', 'B')
+        append('ch3', 'user', 'C')
+
+        without_filter = get_recent('ch3')
+        with_none = get_recent('ch3', until_id=None)
+        assert [r['id'] for r in without_filter] == [r['id'] for r in with_none]
+
+
 class TestGetRecent:
     def test_get_recent_returns_ordered(self, db):
         from services.transcript_service import append, get_recent


### PR DESCRIPTION
## Summary

`getPreviousMessages()` read the latest channel transcript via `transcript_service.get_recent(channel, since_id=watermark)`. Under concurrency on a single channel — rapid-fire UI messages, or the nightly harness running scenarios in parallel as the same user on one container — one turn's `_uid` would be overtaken by another turn's in-flight `write_input_row` call, and the first turn's prompt would surface the second turn's user content.

Concrete failure: scenario 051 (Search tool — live web lookup and reasoning), run 291. Judge diagnostic:

> The model hallucinated a combined response including a mortgage calculation that was not requested in the current turn.

The mortgage text was in-flight from scenario 052 writing its user row while 051 was assembling its prompt.

## Fix

- `transcript_service.get_recent` gains `until_id: int | None = None`. When set, appends `AND id <= ?` to both SQL branches.
- `MessageProcessor.getPreviousMessages` passes `until_id=self._uid` when it is truthy. Each turn now sees a history snapshot as of its own input write — concurrent rows (`id > self._uid`) are invisible.
- Internal processors (`SKIP_TRANSCRIPT_WRITE=True`) leave `_uid` as `None` and pass no filter — behavior unchanged.

## Results

Targeted run (improve/transcript-turn-snapshot, scenarios=[051]):
- 051 composite **0.751 → 0.804** (+0.053, PASS holds)
- Step 1 targeted anomaly **"Response contains unsolicited mortgage calculation" cleared** — no mortgage text in response or transcript
- Remaining warnings (future-date hallucination in search query) are pre-existing model behavior, unrelated to this fix

## Test plan

- [x] `pytest backend/tests/test_transcript_service.py` — 24/24 PASS (3 new `until_id` tests)
- [x] `pytest backend/tests/test_message_processor_v2_store.py` — 60/60 PASS (1 new per-turn-snapshot isolation test)
- [x] Targeted nightly scenario 051 run on branch — composite rose, mortgage bleed gone
- [ ] CI: ruff, vulture, sonarcloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)