### PR TITLE
fix(world-state): gate bg_process on active goal + 5m window

### DIFF
--- a/backend/services/world_state.py
+++ b/backend/services/world_state.py
@@ -56,9 +56,15 @@ _BG_PROCESS_SQL = """
 SELECT content, created_at
 FROM transcript
 WHERE channel = 'goal_pursuit'
-  AND created_at >= datetime('now', '-24 hours')
+  AND created_at >= datetime('now', '-5 minutes')
 ORDER BY created_at DESC
 LIMIT 10
+"""
+
+_ACTIVE_GOAL_SQL = """
+SELECT COUNT(*) FROM goals
+WHERE status IN ('actionable', 'active')
+  AND is_muted = 0
 """
 
 
@@ -262,7 +268,14 @@ class WorldState:
         return lines
 
     def _render_bg_process(self) -> list[str]:
-        """Produce [bg_process(...)] lines from goal_pursuit transcript rows."""
+        """Produce [bg_process(...)] lines from goal_pursuit transcript rows.
+
+        Returns an empty list immediately when no unmuted goal is in
+        ('actionable', 'active') status — pursuit output does not belong
+        in the user prompt if no pursuit is running.
+        """
+        if not _has_active_goal():
+            return []
         rows = _fetch_bg_process_rows()
         lines = []
         for row in rows:
@@ -339,6 +352,19 @@ def _fetch_bg_process_rows() -> list[dict]:
             cursor.execute(_BG_PROCESS_SQL)
             cols = [d[0] for d in cursor.description]
             return [dict(zip(cols, row)) for row in cursor.fetchall()]
+        finally:
+            cursor.close()
+
+
+def _has_active_goal() -> bool:
+    """Return True when at least one unmuted goal is in ('actionable', 'active') status."""
+    db = _get_db()
+    with db.connection() as conn:
+        cursor = conn.cursor()
+        try:
+            cursor.execute(_ACTIVE_GOAL_SQL)
+            count = cursor.fetchone()[0]
+            return count > 0
         finally:
             cursor.close()
 

--- a/backend/tests/test_world_state.py
+++ b/backend/tests/test_world_state.py
@@ -394,9 +394,19 @@ class TestRenderSchedule:
 # render() — bg_process section (requires real DB)
 # ---------------------------------------------------------------------------
 
+def _seed_active_goal(db, goal_id: str = "g-active-001") -> None:
+    """Insert a minimal unmuted active goal row so _render_bg_process passes the gate."""
+    db.execute(
+        "INSERT INTO goals (id, description, status, is_muted) "
+        "VALUES (?, 'Test active goal', 'active', 0)",
+        (goal_id,),
+    )
+
+
 @pytest.mark.unit
 class TestRenderBgProcess:
     def test_recent_goal_pursuit_row_appears(self, db):
+        _seed_active_goal(db)
         db.execute(
             "INSERT INTO transcript (channel, role, content, created_at) "
             "VALUES ('goal_pursuit', 'assistant', 'Researching hotels in Valletta', ?)",
@@ -411,6 +421,7 @@ class TestRenderBgProcess:
         assert "Researching hotels in Valletta" in result
 
     def test_bg_process_format_no_bullet(self, db):
+        _seed_active_goal(db)
         db.execute(
             "INSERT INTO transcript (channel, role, content, created_at) "
             "VALUES ('goal_pursuit', 'assistant', 'Active pursuit', ?)",
@@ -451,6 +462,7 @@ class TestRenderBgProcess:
         assert "regular chat content" not in result
 
     def test_last_update_field_uses_time_formatter(self, db):
+        _seed_active_goal(db)
         # Seed a row from exactly ~2 minutes ago (should render as '2m ago')
         db.execute(
             "INSERT INTO transcript (channel, role, content, created_at) "
@@ -465,6 +477,7 @@ class TestRenderBgProcess:
         assert "last_update:2m ago" in result
 
     def test_bg_process_truncates_long_content(self, db):
+        _seed_active_goal(db)
         long_content = "word " * 120  # 600 chars, well above 200
         db.execute(
             "INSERT INTO transcript (channel, role, content, created_at) "
@@ -483,6 +496,7 @@ class TestRenderBgProcess:
         assert bg_line.endswith("…")
 
     def test_bg_process_short_content_not_truncated(self, db):
+        _seed_active_goal(db)
         short_content = "Researching cheap hotels in Valletta"
         db.execute(
             "INSERT INTO transcript (channel, role, content, created_at) "
@@ -497,6 +511,50 @@ class TestRenderBgProcess:
         bg_line = next((ln for ln in result.splitlines() if "[bg_process(" in ln), None)
         assert bg_line is not None
         assert not bg_line.endswith("…")
+
+    def test_bg_process_empty_when_no_active_goals(self, db):
+        # Transcript row is fresh (1 minute ago) but no goal is active/actionable
+        db.execute(
+            "INSERT INTO transcript (channel, role, content, created_at) "
+            "VALUES ('goal_pursuit', 'assistant', 'Swimming research', ?)",
+            (_recent_iso(seconds=60),),
+        )
+        db.commit()
+
+        ws = _fresh()
+        result = ws.render()
+        assert "[bg_process(" not in result
+        assert "Swimming research" not in result
+
+    def test_bg_process_empty_when_rows_stale(self, db):
+        # Active goal present, but transcript row is 10 minutes old (>5m window)
+        _seed_active_goal(db, goal_id="g-stale-001")
+        db.execute(
+            "INSERT INTO transcript (channel, role, content, created_at) "
+            "VALUES ('goal_pursuit', 'assistant', 'Stale pursuit content', ?)",
+            (_past_iso(minutes=10),),
+        )
+        db.commit()
+
+        ws = _fresh()
+        result = ws.render()
+        assert "[bg_process(" not in result
+        assert "Stale pursuit content" not in result
+
+    def test_bg_process_renders_when_active_goal_and_fresh_rows(self, db):
+        # Active goal + transcript row from 30 seconds ago — must render
+        _seed_active_goal(db, goal_id="g-fresh-001")
+        db.execute(
+            "INSERT INTO transcript (channel, role, content, created_at) "
+            "VALUES ('goal_pursuit', 'assistant', 'Booking hotel in Valletta', ?)",
+            (_recent_iso(seconds=30),),
+        )
+        db.commit()
+
+        ws = _fresh()
+        result = ws.render()
+        assert "[bg_process(" in result
+        assert "Booking hotel in Valletta" in result
 
 
 # ---------------------------------------------------------------------------
@@ -518,6 +576,7 @@ class TestRenderFullMix:
             "VALUES (?, ?, ?, 'pending', 0)",
             (item_id, "Team meeting", _future_iso(60)),
         )
+        _seed_active_goal(db, goal_id="g-order-001")
         db.execute(
             "INSERT INTO transcript (channel, role, content, created_at) "
             "VALUES ('goal_pursuit', 'assistant', 'Active goal', ?)",

--- a/backend/tests/test_world_state_api.py
+++ b/backend/tests/test_world_state_api.py
@@ -189,6 +189,12 @@ class TestWorldStateBgProcessRendering:
         client, db_conn, _ = authed_client
         _reset_world_state()
 
+        # Rendered bg_process is gated on an active goal — seed one.
+        db_conn.execute(
+            "INSERT INTO goals (id, description, type, status) "
+            "VALUES (?, 'test goal', 'stated', 'active')",
+            (str(uuid.uuid4()),),
+        )
         db_conn.execute(
             "INSERT INTO transcript (channel, role, content, created_at) "
             "VALUES ('goal_pursuit', 'assistant', 'Booking holiday flights', ?)",
@@ -255,7 +261,12 @@ class TestWorldStateFullLifecycle:
             (item_id, "Call Mum", _future_iso(120)),
         )
 
-        # bg_process
+        # bg_process — gated on active goal, seed one first
+        db_conn.execute(
+            "INSERT INTO goals (id, description, type, status) "
+            "VALUES (?, 'test goal', 'stated', 'active')",
+            (str(uuid.uuid4()),),
+        )
         db_conn.execute(
             "INSERT INTO transcript (channel, role, content, created_at) "
             "VALUES ('goal_pursuit', 'assistant', 'Booking holiday flights', ?)",


### PR DESCRIPTION
## Summary

Scenario 041 (find_tools skill) nightly run 291 showed severe bleed — a `/chat` response for an *Apple Q2 earnings* query contained detailed cold-water-swimming research blocks. Root cause: `world_state._fetch_bg_process_rows()` pulled ALL `goal_pursuit` channel transcript rows from the last 24 hours without any active-goal gate, so stale or unrelated goal pursuit output polluted the user prompt and the model wove it into its response.

Judge diagnostic (run 291):
> The model provided the correct answer, but the execution evidence shows a severe hallucination/leak in the 'task' output block (discussing cold water swimming) and a transcript mismatch (mentioning Spanish goals).

## Changes

`backend/services/world_state.py`:
- `_BG_PROCESS_SQL` window tightened from `-24 hours` to `-5 minutes` — stale noise filter.
- `_render_bg_process()` returns `[]` immediately when no goals are in `('actionable','active')` (unmuted). Real fix: if no goal is running, no pursuit output belongs in the user prompt.

`backend/tests/test_world_state.py`:
- 3 new gate-specific tests + 7 existing tests updated to seed an active goal so the render path is still exercised.
- 49/49 world_state unit tests pass. Ruff + vulture clean.

## Result

Run 306 (targeted 041 on this branch):
- **041 score: 0.871 → 0.886 PASS** (+0.015)
- Step 2 composite **0.485 → 0.770** (+0.285)
- Cold-water-swimming bleed: **cleared**
- Spanish-goal transcript mismatch: **cleared**

## Test plan
- [x] Targeted 041 run (id 306) passes
- [x] Unit suite passes
- [x] ruff + vulture clean
- [ ] CI checks green (waiting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)