### PR TITLE
fix(mode-gate): lower plan threshold 0.8 → 0.5

### DIFF
--- a/backend/configs/mode_gate.yaml
+++ b/backend/configs/mode_gate.yaml
@@ -13,7 +13,7 @@ fire_threshold_overrides:      # null = use classifier_meta.json value
   coding:     null
   brainstorm: null
   analyze:    null
-  plan:       null
+  plan:       0.5      # baked 0.8 too high — schedule/goal_pursuit gated out of natural prompts (run 314 scenario 033)
   write:      null
   math:       null
   converse:   null


### PR DESCRIPTION
## Why

After shadow_mode rip (c3b12e7), ModeGateService now actively gates non-primitive innate skills. `UserMessageProcessor.NATIVE_TOOLS` was narrowed to 3 cognitive primitives in 815d329; everything else (schedule, goal_pursuit, list, rich_render, document, read, introspect) requires mode-gate promotion.

`SKILL_MODES['schedule'] = ['plan', 'brainstorm']` and `SKILL_MODES['goal_pursuit'] = ['plan', 'research']`. Plan-head fire threshold baked at **0.8** in `classifier_meta.json` — too high for natural-language productivity prompts.

## Evidence

Nightly run 314 — scenario `033-skill-schedule.yaml`, score 0.393 FAIL.

User: *"Remind me to call the dentist tomorrow at 3pm"*

Model response (step 1): *"I'm afraid I have to be the bearer of a recurring limitation: I don't have the ability to send you notifications or trigger alerts at a specific time."* TOOLS: `{}`.

Judge diagnostic:
> Schedule skill was never invoked; the model incorrectly claimed it cannot set reminders. Verify the schedule skill is registered and described in the system prompt so the model knows to use it.

Same root cause for `037-skill-goal-pursuit.yaml` — score 0.241 FAIL, goal_pursuit never invoked despite explicit "background task" phrasing.

## Fix

`backend/configs/mode_gate.yaml`:

```diff
-  plan:       null
+  plan:       0.5      # baked 0.8 too high — schedule/goal_pursuit gated out of natural prompts (run 314 scenario 033)
```

## Result (run 318)

| Scenario | Before | After | Δ | Anomaly cleared |
| --- | --- | --- | --- | --- |
| 037 goal_pursuit | 0.241 FAIL | **0.725 PASS** | +0.484 | ✅ goal_pursuit now invoked |
| 033 schedule | 0.393 FAIL | **0.557 WARN** | +0.164 | ✅ schedule now invoked on create |

Step 1 of 033 now PASSes the targeted "schedule skill never invoked" anomaly. Step 4 (cancel) still mis-fires — separate, narrower issue (cancel utterance phrasing) tracked for next cycle.

35/35 mode-gate unit tests pass.