### PR TITLE
fix(mode-gate): add converse mode to read skill

### DIFF
--- a/backend/services/innate_skills/registry.py
+++ b/backend/services/innate_skills/registry.py
@@ -94,7 +94,7 @@ SKILL_MODES: dict[str, list[str]] = {
     'schedule':     ['plan', 'brainstorm'],
     'goal_pursuit': ['plan', 'research'],
     'document':     ['research', 'analyze', 'write', 'brainstorm'],
-    'read':         ['research', 'analyze', 'write'],
+    'read':         ['research', 'analyze', 'write', 'converse'],
     'rich_render':  ['analyze', 'plan', 'write', 'brainstorm'],
 }
 


### PR DESCRIPTION
## Why

Same root cause family as #1681. After shadow_mode rip (c3b12e7) and `NATIVE_TOOLS` narrowing (815d329), `read` is gated by ModeGateService. `SKILL_MODES['read'] = ['research', 'analyze', 'write']` — none reliably fires on casual URL prompts.

## Evidence

Nightly run 312 — scenario `039-skill-read.yaml`, score 0.475 WARN.

User: *"Can you read this page and tell me what it says? https://example.com"*

Tools invoked: `find_tools=1, browser=1`. Read skill never fired.

Judge step 1 diagnostic:
> Assistant accurately summarized the page content but invoked the 'browser' tool instead of the expected 'read' skill; skill routing or registry naming needs alignment.

Step 2 anomaly: tool_calls count for tool_name='read' = 0 → FAIL.

The find_tools query was `"browser"` rather than `"read"` — model only saw external browser tool because read wasn't in the promoted tool list.

## Fix

`backend/services/innate_skills/registry.py`:

```diff
-    'read':         ['research', 'analyze', 'write'],
+    'read':         ['research', 'analyze', 'write', 'converse'],
```

Mirrors the existing pattern in `'introspect': ['converse', 'analyze']`. Read is a fundamental URL/file capability whose alternative path (find_tools → browser) routes to the wrong tool.

## Result (run 319)

| Scenario | Before | After | Δ |
| --- | --- | --- | --- |
| 039 read | 0.475 WARN | **0.932 PASS** | +0.457 |

Both steps PASS. Read skill invoked exactly once. Anomaly cleared.

89/89 mode-gate + registry + read-skill unit tests pass.