### PR TITLE
fix(introspect): expand description with colloquial trigger phrases

### DIFF
--- a/backend/services/innate_skills/introspect_skill.py
+++ b/backend/services/innate_skills/introspect_skill.py
@@ -21,8 +21,10 @@ TOOL_SCHEMA = {
         "consolidation recency), reasoning state (active focus, upcoming reminders, "
         "recent autonomous actions), and identity (relationship depth, communication style, "
         "personality). All deterministic — no LLM calls. "
-        "Use when the user asks about system state, capabilities, or what you have been doing, "
-        "or when you need to gauge how much context you have before deciding what to do."
+        "Use when the user asks how you are doing, requests a status report, asks what you "
+        "have been up to, asks about your wellbeing, your capabilities, or your current "
+        "internal state — any self-referential or 'how are you' style question. Also fire "
+        "when you need to gauge how much context you have before deciding what to do."
     ),
     "input_schema": {
         "type": "object",


### PR DESCRIPTION
## Why

Scenario 031 baseline (run 312, 0.575 WARN). User: *\"How are you doing? Give me a status report on yourself\"*. Model produced a generic anthropomorphic response without invoking introspect.

Judge step 1:
> Chalie produced a generic anthropomorphic response instead of invoking the introspect skill to retrieve concrete memory counts, skill usage, or identity metrics. Fix skill routing or prompt triggers.

Step 2 (deterministic DB count of `introspect` tool_calls): zero. FAIL.

introspect was likely promoted by mode-gate (`SKILL_MODES['introspect'] = ['converse', 'analyze']`, converse threshold 0.55 fires for casual asks). The missing piece is the description: it used developer-ish phrasings (\"system state, capabilities, what you have been doing\") that don't match natural user prompts.

## Fix

`backend/services/innate_skills/introspect_skill.py` — replace the trigger sentence with explicit colloquial phrasings: \"how you are doing\", \"status report\", \"what you have been up to\", \"wellbeing\", \"current internal state\", \"any self-referential or 'how are you' style question\".

## Result (run 320)

| Scenario | Before | After | Δ |
| --- | --- | --- | --- |
| 031 introspect | 0.575 WARN | **0.899 PASS** | +0.324 |

All 4 steps PASS. introspect invoked, tool_call logged, anomaly cleared. Step 1 residual (rendered output uses metaphors instead of metrics) is a separate output-quality issue, not the routing miss this PR targets.

31/31 introspect-skill unit tests pass.

## Distinct from cycle 10

Cycle 10's failed goal_pursuit description angle was blocked by mode-gate (plan threshold 0.8). Here introspect's converse mode (0.55) fires for these prompts, so the skill IS in the model's tool list — only the description matching needed updating.