### PR TITLE
fix(find-tools): surface innate skills when mode-gate fails to promote

### DIFF
--- a/backend/services/innate_skills/find_tools_skill.py
+++ b/backend/services/innate_skills/find_tools_skill.py
@@ -17,6 +17,7 @@ import logging
 from typing import List, Dict
 
 from services.embedding_utils import pack_embedding
+from services.innate_skills.registry import COGNITIVE_PRIMITIVES
 
 logger = logging.getLogger(__name__)
 
@@ -163,8 +164,29 @@ def _filter_available(rows: list, query: str = "") -> List[Dict]:
         distance = row[6] if not isinstance(row, dict) else row['distance']
         keywords = row[7] if not isinstance(row, dict) else row.get('keywords', '')
 
-        # Skip innate skills — they're already injected
+        # Skip cognitive primitives — they're always present in every ACT turn
+        if tool_type == 'skill' and tool_name in COGNITIVE_PRIMITIVES:
+            continue
+
+        # For non-primitive innate skills, include directly without registry check
+        # (innate skills have no manifest in ToolRegistryService — external-only).
         if tool_type == 'skill':
+            kw_list = [k.strip().lower() for k in (keywords or '').split(',') if k.strip()]
+            query_words = set(query_lower.split())
+            kw_match_count = sum(
+                1 for kw in kw_list
+                if (' ' not in kw and kw in query_words) or (' ' in kw and kw in query_lower)
+            )
+            score = (distance * 10) - kw_match_count
+            results.append({
+                'tool_name': tool_name,
+                'short_summary': short_summary,
+                'full_profile': full_profile,
+                'domain': domain,
+                'effort': effort,
+                'score': score,
+                'distance': distance,
+            })
             continue
 
         # Check tool is registered and ready

--- a/backend/services/innate_skills/find_tools_skill.py
+++ b/backend/services/innate_skills/find_tools_skill.py
@@ -144,6 +144,35 @@ def handle_find_tools(channel: str, params: dict) -> dict:
 # -- Search helpers --------------------------------------------------------
 
 
+def _score_and_pack(
+    tool_name: str,
+    short_summary,
+    full_profile,
+    domain,
+    effort,
+    distance: float,
+    keywords: str,
+    query_words: set,
+    query_lower: str,
+) -> Dict:
+    """Build a scored result dict for a single tool candidate."""
+    kw_list = [k.strip().lower() for k in (keywords or '').split(',') if k.strip()]
+    kw_match_count = sum(
+        1 for kw in kw_list
+        if (' ' not in kw and kw in query_words) or (' ' in kw and kw in query_lower)
+    )
+    score = (distance * 10) - kw_match_count
+    return {
+        'tool_name': tool_name,
+        'short_summary': short_summary,
+        'full_profile': full_profile,
+        'domain': domain,
+        'effort': effort,
+        'score': score,
+        'distance': distance,
+    }
+
+
 def _filter_available(rows: list, query: str = "") -> List[Dict]:
     """Filter vec search results to available, ready tools. Score by distance + keyword match."""
     try:
@@ -153,6 +182,7 @@ def _filter_available(rows: list, query: str = "") -> List[Dict]:
         registry = None
 
     query_lower = query.lower()
+    query_words = set(query_lower.split())
     results = []
     for row in rows:
         tool_name = row[0] if not isinstance(row, dict) else row['tool_name']
@@ -171,22 +201,10 @@ def _filter_available(rows: list, query: str = "") -> List[Dict]:
         # For non-primitive innate skills, include directly without registry check
         # (innate skills have no manifest in ToolRegistryService — external-only).
         if tool_type == 'skill':
-            kw_list = [k.strip().lower() for k in (keywords or '').split(',') if k.strip()]
-            query_words = set(query_lower.split())
-            kw_match_count = sum(
-                1 for kw in kw_list
-                if (' ' not in kw and kw in query_words) or (' ' in kw and kw in query_lower)
-            )
-            score = (distance * 10) - kw_match_count
-            results.append({
-                'tool_name': tool_name,
-                'short_summary': short_summary,
-                'full_profile': full_profile,
-                'domain': domain,
-                'effort': effort,
-                'score': score,
-                'distance': distance,
-            })
+            results.append(_score_and_pack(
+                tool_name, short_summary, full_profile, domain, effort,
+                distance, keywords, query_words, query_lower,
+            ))
             continue
 
         # Check tool is registered and ready
@@ -200,23 +218,10 @@ def _filter_available(rows: list, query: str = "") -> List[Dict]:
                 continue
 
         # 2-axis scoring: semantic distance + keyword match bonus
-        kw_list = [k.strip().lower() for k in (keywords or '').split(',') if k.strip()]
-        query_words = set(query_lower.split())
-        kw_match_count = sum(
-            1 for kw in kw_list
-            if (' ' not in kw and kw in query_words) or (' ' in kw and kw in query_lower)
-        )
-        score = (distance * 10) - kw_match_count
-
-        results.append({
-            'tool_name': tool_name,
-            'short_summary': short_summary,
-            'full_profile': full_profile,
-            'domain': domain,
-            'effort': effort,
-            'score': score,
-            'distance': distance,
-        })
+        results.append(_score_and_pack(
+            tool_name, short_summary, full_profile, domain, effort,
+            distance, keywords, query_words, query_lower,
+        ))
 
     # Lower score = better (closer semantically + more keyword matches)
     results.sort(key=lambda t: t['score'])

--- a/backend/services/message_processor.py
+++ b/backend/services/message_processor.py
@@ -409,7 +409,7 @@ class MessageProcessor:
         Never re-raises — errors become strings the LLM sees next iteration.
         """
         from services.tool_render_and_record_service import ToolRenderAndRecordService
-        from services.tool_schema_service import get_external_tool_schemas
+        from services.tool_schema_service import get_external_tool_schemas, get_skill_schemas
 
         tool_name = (tc.get('name') if isinstance(tc, dict) else None) or 'unknown'
         tc_input = tc.get('input', {}) if isinstance(tc, dict) else {}
@@ -435,7 +435,22 @@ class MessageProcessor:
             ):
                 discovered = dispatch.get('_discovered_tools', [])
                 if discovered:
-                    new_schemas = get_external_tool_schemas(discovered)
+                    from services.innate_skills.registry import (
+                        ALL_SKILL_NAMES, COGNITIVE_PRIMITIVES,
+                    )
+                    innate_discovered = [
+                        n for n in discovered
+                        if n in ALL_SKILL_NAMES and n not in COGNITIVE_PRIMITIVES
+                    ]
+                    external_discovered = [
+                        n for n in discovered
+                        if n not in ALL_SKILL_NAMES
+                    ]
+
+                    new_schemas = (
+                        get_skill_schemas(innate_discovered)
+                        + get_external_tool_schemas(external_discovered)
+                    )
                     existing_names = {
                         t.get('name') for t in self._discovered_tools
                     }
@@ -445,9 +460,10 @@ class MessageProcessor:
                             self._discovered_tools.append(s)
                             existing_names.add(name)
 
-                    # Register as dispatcher handlers so they dispatch
-                    # through the standard handler path (no fallback needed).
-                    self._register_discovered_tools(discovered)
+                    # Register external tools as dispatcher handlers so they
+                    # dispatch through the standard handler path.
+                    # Innate skills are already registered at boot — skip.
+                    self._register_discovered_tools(external_discovered)
 
         except Exception as exc:
             result_text = f"ERROR: {tool_name} failed: {exc}"

--- a/backend/tests/test_find_tools_skill.py
+++ b/backend/tests/test_find_tools_skill.py
@@ -89,18 +89,38 @@ class TestFilterAvailable:
         return (name, tool_type, summary, profile, domain, effort, distance, keywords)
 
     @patch(_REGISTRY)
-    def test_filters_out_skills(self, mock_registry_cls):
-        """Innate skills should be excluded from results."""
+    def test_filters_out_cognitive_primitives(self, mock_registry_cls):
+        """Cognitive primitives are always present and must be excluded from results."""
         mock_reg = _mock_registry(tools={'weather': {'manifest': {}}})
         mock_registry_cls.return_value = mock_reg
 
         rows = [
-            self._make_row('recall', 'skill'),
+            self._make_row('memory', 'skill'),
             self._make_row('weather', 'tool'),
         ]
         result = _filter_available(rows, query='weather')
         assert len(result) == 1
         assert result[0]['tool_name'] == 'weather'
+
+    @patch(_REGISTRY)
+    def test_passes_through_non_primitive_skills(self, mock_registry_cls):
+        """Non-primitive innate skills surface without a registry readiness check."""
+        # Only 'weather' is in the registry — 'schedule' is NOT.
+        mock_reg = _mock_registry(tools={'weather': {'manifest': {}}})
+        mock_registry_cls.return_value = mock_reg
+
+        rows = [
+            self._make_row('schedule', 'skill'),
+            self._make_row('weather', 'tool'),
+        ]
+        result = _filter_available(rows, query='remind me')
+        assert len(result) == 2
+        names = {t['tool_name'] for t in result}
+        assert 'schedule' in names
+        assert 'weather' in names
+        # schedule must appear even though it is absent from mock_reg.tools
+        schedule_entry = next(t for t in result if t['tool_name'] == 'schedule')
+        assert 'score' in schedule_entry
 
     @patch(_REGISTRY)
     def test_filters_unready_tools(self, mock_registry_cls):
@@ -278,13 +298,13 @@ class TestEdgeCases:
 
     @patch(_REGISTRY)
     @patch(_EMB)
-    def test_only_skills_match(self, mock_emb_cls, mock_registry_cls, db):
-        """When only innate skills match, should inform the user."""
+    def test_only_primitive_match(self, mock_emb_cls, mock_registry_cls, db):
+        """When only a cognitive primitive matches, it is filtered → INFO message."""
         embedding = [0.1] * 256
         mock_emb_cls.return_value.generate_embedding.return_value = embedding
 
         _seed_tool_profile(
-            db, 'recall', tool_type='skill', summary='Memory retrieval',
+            db, 'memory', tool_type='skill', summary='Memory retrieval',
             profile='Full profile', domain='Memory', effort='trivial',
             embedding=embedding,
         )
@@ -293,9 +313,32 @@ class TestEdgeCases:
 
         result = handle_find_tools("topic", {"query": "remember something"})
         assert isinstance(result, dict)
-        # Skills are filtered out → no tools added → INFO message
+        # Cognitive primitive is filtered out → no tools added → INFO message
         assert 'already available' in result['text']
         assert result['_discovered_tools'] == []
+
+    @patch(_REGISTRY)
+    @patch(_EMB)
+    def test_skill_match_surfaces_skill(self, mock_emb_cls, mock_registry_cls, db):
+        """When a non-primitive innate skill matches, it surfaces in the result."""
+        import json
+        embedding = [0.1] * 256
+        mock_emb_cls.return_value.generate_embedding.return_value = embedding
+
+        _seed_tool_profile(
+            db, 'schedule', tool_type='skill', summary='Set reminders and schedule tasks',
+            profile='Full profile', domain='Productivity', effort='light',
+            embedding=embedding,
+        )
+
+        # schedule is NOT in the registry — should still surface
+        mock_registry_cls.return_value = _mock_registry()
+
+        result = handle_find_tools("topic", {"query": "remind me about something"})
+        assert isinstance(result, dict)
+        parsed = json.loads(result['text'])
+        assert any(t['name'] == 'schedule' for t in parsed['added_tools'])
+        assert 'schedule' in result['_discovered_tools']
 
 
 class TestKeywordScoring:


### PR DESCRIPTION
## Summary

`find_tools` now surfaces non-primitive innate skills (schedule, goal_pursuit, list, document, read, rich_render) when they are the best semantic match for the user's query but mode_gate failed to promote them into the active tool list.

Previously `_filter_available()` hard-skipped all `tool_type == 'skill'` rows on the assumption "they're already injected." That assumption breaks when the mode-gate logit for the relevant cognitive mode falls below threshold — the skill is registered with the dispatcher but invisible to the LLM. The model then either claims it lacks the capability or routes inline tools instead of the correct skill.

Now: cognitive primitives (memory, find_tools, review_tool_calls — always present in tool list) stay filtered. Other innate skills pass through, get scored, and are returned in `_discovered_tools`. `MessageProcessor.handleTool()` partitions discovered names and fetches innate schemas via the existing `get_skill_schemas()` helper, alongside external schemas from `get_external_tool_schemas()`.

## Evidence — judge diagnostics from baseline

**Scenario 015** (multi-cap memory + schedule, run 322):
> "Schedule skill was not invoked despite explicit user request; model incorrectly claimed no calendar capability instead of routing to the schedule tool."

**Scenario 037** (goal_pursuit background research, run 314):
> "The ACT loop dispatched inline search and weather tools instead of the goal_pursuit skill, and the response omitted any background-task acknowledgment."

## Results — run 323

| Scenario | Before | After | Targeted anomaly |
|---|---|---|---|
| 037 goal_pursuit | 0.205 FAIL | **0.846 PASS** | CLEARED (all steps PASS, world-state bg_process visible) |
| 033 schedule | 0.37 FAIL | **0.505 WARN** | CREATE works (steps 2/3 PASS); cancel still misroutes (separate issue) |
| 015 multi-cap | 0.563 WARN | 0.500 WARN | Schedule step (4) **PASSES**; score dropped due to unrelated trait-extraction race in steps 2/3 |

## Test plan
- [x] `pytest -m unit -q` — 2423 passed, 2 skipped
- [x] `ruff check` — clean on touched files
- [x] Live nightly run 323 — 1 PASS / 2 WARN / 0 FAIL
- [ ] CI green (will fix any sonar/vulture flags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)