### PR TITLE
fix(scheduler): atomic dedup eliminates duplicate scheduled_items

### DIFF
--- a/backend/services/innate_skills/scheduler_skill.py
+++ b/backend/services/innate_skills/scheduler_skill.py
@@ -221,18 +221,42 @@ def _create(channel: str, params: dict) -> dict:
         with db.connection() as conn:
             cursor = conn.cursor()
 
-            # Dedup: reject if same message was scheduled within the last 60s
+            # Atomic dedup: INSERT only when no pending row with the same message
+            # was created in the last 60 seconds.  A single statement eliminates
+            # the SELECT-then-INSERT race window that caused duplicate rows when
+            # the model invoked schedule(...) twice in the same turn.
             cursor.execute("""
-                SELECT id FROM scheduled_items
-                WHERE status = 'pending'
-                  AND message = ?
-                  AND created_at > datetime('now', '-60 seconds')
-                LIMIT 1
-            """, (message,))
-            existing = cursor.fetchone()
-            if existing:
-                conn.commit()
-                existing_id = existing[0]
+                INSERT INTO scheduled_items
+                  (id, item_type, message, due_at, recurrence, window_start, window_end,
+                   status, channel, created_by_session, created_at, group_id, is_prompt)
+                SELECT ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, datetime('now'), ?, ?
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM scheduled_items
+                    WHERE status = 'pending'
+                      AND message = ?
+                      AND created_at > datetime('now', '-60 seconds')
+                )
+            """, (
+                item_id, item_type, message, due_at,
+                recurrence, window_start, window_end,
+                channel, None,
+                item_id,  # group_id = own id (root of new series)
+                is_prompt,
+                message,  # WHERE NOT EXISTS param
+            ))
+            conn.commit()
+
+            if cursor.rowcount == 0:
+                # Duplicate detected — fetch the existing row's id
+                cursor.execute("""
+                    SELECT id FROM scheduled_items
+                    WHERE status = 'pending'
+                      AND message = ?
+                      AND created_at > datetime('now', '-60 seconds')
+                    LIMIT 1
+                """, (message,))
+                existing_row = cursor.fetchone()
+                existing_id = existing_row[0] if existing_row else item_id
                 logger.info(f"{LOG_PREFIX} Dedup: '{message[:60]}' already exists as {existing_id}")
                 from services.time_formatter_service import TimeFormatterService
                 local_due = TimeFormatterService.local(due_at, fmt='%Y-%m-%dT%H:%M:%S%z') or due_at.isoformat()
@@ -242,20 +266,6 @@ def _create(channel: str, params: dict) -> dict:
                     "record": {"id": existing_id, "message": message, "due_at": local_due},
                     "note": "already_existed",
                 }
-
-            cursor.execute("""
-                INSERT INTO scheduled_items
-                  (id, item_type, message, due_at, recurrence, window_start, window_end,
-                   status, channel, created_by_session, created_at, group_id, is_prompt)
-                VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, datetime('now'), ?, ?)
-            """, (
-                item_id, item_type, message, due_at,
-                recurrence, window_start, window_end,
-                channel, None,
-                item_id,  # group_id = own id (root of new series)
-                is_prompt,
-            ))
-            conn.commit()
 
         # Embed the scheduled item message for semantic world state retrieval (non-fatal)
         try:

--- a/backend/tests/test_scheduler_skill.py
+++ b/backend/tests/test_scheduler_skill.py
@@ -4,10 +4,14 @@ Tests for backend/services/innate_skills/scheduler_skill.py
 Covers the _create() grace-window behaviour: past-due timestamps within
 _PAST_DUE_GRACE_SECONDS are bumped forward to now+5s; timestamps older
 than the grace window are still hard-rejected.
+
+Also covers the atomic dedup guarantee: back-to-back _create() calls with
+the same message must result in exactly one row in scheduled_items.
 """
 
 import json
 import pytest
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
@@ -73,3 +77,86 @@ class TestCreatePastDueGrace:
         result = json.loads(raw)
         assert result["status"] == "error", f"Expected error, got: {result}"
         assert "due_at must be in the future" in result["error"]
+
+
+# ── Atomic dedup guarantee ────────────────────────────────────────────────────
+
+class TestCreateDedup:
+    """Rapid back-to-back _create() calls with identical message → one row only."""
+
+    def test_sequential_same_message_produces_one_row(self, db):
+        """Two sequential calls with identical message produce exactly one DB row.
+
+        Both calls must return status=success.  The second call returns
+        note='already_existed' and the same record id as the first.
+        """
+        due_at = (utc_now() + timedelta(hours=1)).isoformat()
+        params = {
+            "action": "create",
+            "message": "Call the dentist",
+            "due_at": due_at,
+        }
+
+        with patch("services.scheduler_service.embed_scheduled_item", return_value=None):
+            raw1 = handle_scheduler("user", params)
+            raw2 = handle_scheduler("user", params)
+
+        r1 = json.loads(raw1)
+        r2 = json.loads(raw2)
+
+        assert r1["status"] == "success", f"First call failed: {r1}"
+        assert r2["status"] == "success", f"Second call failed: {r2}"
+
+        # Second call must be identified as a dedup hit
+        assert r2.get("note") == "already_existed", (
+            f"Expected note='already_existed' on second call, got: {r2}"
+        )
+
+        # Both calls must return the same record id
+        assert r1["record"]["id"] == r2["record"]["id"], (
+            f"Different ids returned: {r1['record']['id']} vs {r2['record']['id']}"
+        )
+
+        # Exactly one row must exist in the database
+        row_count = db.execute(
+            "SELECT COUNT(*) FROM scheduled_items WHERE message = 'Call the dentist' AND status = 'pending'"
+        ).fetchone()[0]
+        assert row_count == 1, f"Expected 1 row, found {row_count}"
+
+    def test_concurrent_same_message_produces_one_row(self, db):
+        """Two threads calling _create() simultaneously produce exactly one DB row.
+
+        Uses a ThreadPoolExecutor to maximise the chance of hitting the race
+        window.  Both futures must succeed; exactly one must have no 'note' key
+        (the winner) and exactly one must carry note='already_existed' (the loser).
+        """
+        due_at = (utc_now() + timedelta(hours=2)).isoformat()
+        params = {
+            "action": "create",
+            "message": "Call the dentist concurrent",
+            "due_at": due_at,
+        }
+
+        results = []
+        with patch("services.scheduler_service.embed_scheduled_item", return_value=None):
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                futures = [pool.submit(handle_scheduler, "user", params) for _ in range(2)]
+                for f in as_completed(futures):
+                    results.append(json.loads(f.result()))
+
+        assert all(r["status"] == "success" for r in results), (
+            f"One or more calls failed: {results}"
+        )
+
+        dedup_hits = [r for r in results if r.get("note") == "already_existed"]
+        assert len(dedup_hits) >= 1, (
+            "Expected at least one dedup hit across concurrent calls, "
+            f"but got: {[r.get('note') for r in results]}"
+        )
+
+        # Exactly one row must exist in the database
+        row_count = db.execute(
+            "SELECT COUNT(*) FROM scheduled_items "
+            "WHERE message = 'Call the dentist concurrent' AND status = 'pending'"
+        ).fetchone()[0]
+        assert row_count == 1, f"Expected 1 row, found {row_count}"


### PR DESCRIPTION
## Summary

Replace `_create()` SELECT-then-INSERT dedup with a single atomic `INSERT...SELECT...WHERE NOT EXISTS`. SQLite serializes the existence check with the row insert, eliminating the race window where two concurrent same-turn `schedule(create)` calls both saw SELECT empty and both INSERTed.

## Why

Nightly scenario 033-skill-schedule run 323 step 1:
- \`tools: {schedule: 2}\` — model invoked schedule(create) twice
- World-state showed two identical \`Call the dentist\` rows
- DB \`COUNT(*)\` returned 2 after step-5 cancel

Existing 60s-window dedup ran SELECT then INSERT in two separate statements on the same connection. With concurrent dispatch, both calls' SELECTs ran before either commit.

## Result

Run 333 vs run 332 baseline (rc-0.4.0):

> 033-skill-schedule: 0.763 → **0.848** PASS held
> Step 1: \`schedule:2\` → \`schedule:1\` — duplicate anomaly cleared
> Step 5: count=0 — cancellation persists correctly

Judge diagnostic step 1: *Schedule skill invoked correctly and response accurately confirmed the reminder time*

Step 6 still WARNs on deliberation calibration (0.562 > 0.5 threshold) — orthogonal to this fix.

## Test plan
- [x] \`pytest backend/tests/test_scheduler_skill.py -q\` passes
- [x] Full unit suite: 2400 passed, 2 skipped — no new failures
- [x] New \`TestCreateDedup\` adds sequential + concurrent (ThreadPoolExecutor) feature tests asserting one row in DB and \`already_existed\` note on duplicate
- [x] Nightly run 333 confirms 033 PASS with single-row creation and successful cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)