### PR TITLE
fix(dispatcher): wrap untagged result paths via _tag()

### DIFF
--- a/backend/services/act_dispatcher_service.py
+++ b/backend/services/act_dispatcher_service.py
@@ -14,6 +14,7 @@ from threading import Thread
 import logging
 
 from services.act_action_categories import DETERMINISTIC_ACTIONS as _DETERMINISTIC_ACTIONS, READ_ACTIONS as _READ_ACTIONS
+from services.innate_skills._tag import tag as _tag
 
 
 def _estimate_confidence(action_type: str, raw_result: Any) -> float:
@@ -115,7 +116,7 @@ class ActDispatcherService:
             return {
                 'action_type': action_type,
                 'status': 'error',
-                'result': f"Unknown action type: {action_type}",
+                'result': _tag(action_type, error=f"unknown-action-type:{action_type}"),
                 'execution_time': 0.0,
                 'confidence': 0.0,
                 'notes': '',
@@ -155,7 +156,7 @@ class ActDispatcherService:
                 return {
                     'action_type': action_type,
                     'status': 'timeout',
-                    'result': f"Action exceeded {effective_timeout}s timeout",
+                    'result': _tag(action_type, error=f"timeout:{effective_timeout}s"),
                     'execution_time': execution_time,
                     'confidence': 0.0,
                     'notes': '',
@@ -165,7 +166,7 @@ class ActDispatcherService:
                 return {
                     'action_type': action_type,
                     'status': 'error',
-                    'result': f"Error: {result_container['error']}",
+                    'result': _tag(action_type, error=f"handler-exception:{str(result_container['error'])[:200]}"),
                     'execution_time': execution_time,
                     'confidence': 0.0,
                     'notes': '',
@@ -204,7 +205,7 @@ class ActDispatcherService:
             return {
                 'action_type': action_type,
                 'status': 'error',
-                'result': f"Unexpected error: {str(e)}",
+                'result': _tag(action_type, error=f"dispatcher-exception:{str(e)[:200]}"),
                 'execution_time': execution_time,
                 'confidence': 0.0,
                 'notes': '',

--- a/backend/services/message_processor.py
+++ b/backend/services/message_processor.py
@@ -28,6 +28,7 @@ import logging
 import time
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 
+from services.innate_skills._tag import tag as _tag
 from services.metrics_accumulator import MetricsAccumulator
 from services.system_message_prompt import SystemMessagePrompt
 from services.time_utils import utc_now
@@ -440,7 +441,7 @@ class MessageProcessor:
                     self._register_discovered_tools(discovered)
 
         except Exception as exc:
-            result_text = f"ERROR: {tool_name} failed: {exc}"
+            result_text = _tag(tool_name, error=f"dispatch-failed:{str(exc)[:200]}")
             logger.error(
                 "[MessageProcessor.handleTool] tool=%s raised: %s",
                 tool_name, exc, exc_info=True,
@@ -456,7 +457,7 @@ class MessageProcessor:
                 transcript_id=self._uid,
             ).renderAndRecord()
         except Exception as exc:
-            rendered = f"[{tool_name}()] {result_text}"
+            rendered = result_text
             logger.error(
                 "[MessageProcessor.handleTool] renderAndRecord failed tool=%s: %s",
                 tool_name, exc, exc_info=True,

--- a/backend/tests/test_act_dispatcher_intents.py
+++ b/backend/tests/test_act_dispatcher_intents.py
@@ -145,7 +145,9 @@ class TestNoCapableWrapper:
             result = service.dispatch_action("topic", {"type": "no_such_action"})
 
         assert result["status"] == "error"
-        assert "Unknown action type" in result["result"]
+        assert "unknown-action-type" in result["result"]
+        assert result["result"].startswith("[no_such_action(")
+        assert result["result"].endswith("[end:no_such_action]")
 
     def test_wrapper_without_matching_capability_falls_through(self, service, db):
         """A wrapper with different capabilities doesn't intercept unrelated actions."""

--- a/backend/tests/test_act_dispatcher_service.py
+++ b/backend/tests/test_act_dispatcher_service.py
@@ -4,6 +4,7 @@ import time
 import pytest
 
 from services.act_dispatcher_service import ActDispatcherService, _estimate_confidence
+from services.innate_skills._tag import tag as _tag
 
 
 pytestmark = pytest.mark.unit
@@ -33,7 +34,7 @@ class TestUnknownHandler:
 
         assert result['status'] == 'error'
         assert result['confidence'] == 0.0
-        assert 'Unknown action type' in result['result']
+        assert 'unknown-action-type' in result['result']
         assert result['action_type'] == 'nonexistent_action'
 
     def test_missing_type_defaults_to_unknown(self, service):
@@ -173,3 +174,43 @@ class TestEstimateConfidenceDirectly:
         """Read action with None result gets the lowest read confidence."""
         assert _estimate_confidence('recall', None) == pytest.approx(0.40)
 
+
+# ── Untagged result paths are now canonical blocks ─────────────
+
+
+class TestUntaggedPathsAreTagged:
+
+    def test_unknown_action_returns_tagged_error(self, service):
+        """Unknown action type result is wrapped in canonical [<name>(...)] block."""
+        result = service.dispatch_action('user', {'type': 'no_such_action'})
+
+        assert result['result'].startswith('[no_such_action(')
+        assert result['result'].endswith('[end:no_such_action]')
+        assert 'unknown-action-type' in result['result']
+
+    def test_handler_exception_returns_tagged_error(self, service):
+        """Handler that raises is wrapped in canonical [<name>(...)] block."""
+        service.handlers['boom'] = lambda c, a: (_ for _ in ()).throw(RuntimeError('kaboom'))
+
+        result = service.dispatch_action('user', {'type': 'boom'})
+
+        assert result['result'].startswith('[boom(')
+        assert result['result'].endswith('[end:boom]')
+        assert 'handler-exception' in result['result']
+        assert 'kaboom' in result['result']
+
+    def test_timeout_returns_tagged_error(self):
+        """Handler that exceeds timeout is wrapped in canonical [<name>(...)] block."""
+        svc = ActDispatcherService(timeout=0.05)
+
+        def slow_handler(c, a):
+            time.sleep(0.5)
+            return 'too late'
+
+        svc.handlers['recall'] = slow_handler
+
+        result = svc.dispatch_action('user', {'type': 'recall'})
+
+        assert result['result'].startswith('[recall(')
+        assert result['result'].endswith('[end:recall]')
+        assert 'timeout' in result['result']

--- a/backend/tests/test_act_dispatcher_service.py
+++ b/backend/tests/test_act_dispatcher_service.py
@@ -4,7 +4,6 @@ import time
 import pytest
 
 from services.act_dispatcher_service import ActDispatcherService, _estimate_confidence
-from services.innate_skills._tag import tag as _tag
 
 
 pytestmark = pytest.mark.unit


### PR DESCRIPTION
## Summary
- All four untagged dispatcher result paths (unknown action, timeout, handler exception, dispatcher exception) and `MessageProcessor.handleTool` dispatch-failure fallback now emit canonical `[<name>(error=...)]\n[end:<name>]` blocks via `_tag()`.
- `renderAndRecord` failure fallback collapsed to `rendered = result_text` to avoid double-wrapping the already-tagged content.

## Why
Nightly scenario 110 (Universal skill tag block) WARN 0.42 — steps 9 + 10 found 3 violating innate-skill rows missing opener / closer in `tool_calls.result`. Skills wrap via `_tag()`, but dispatcher error paths emitted plain text that bypassed the contract.

## Before/After (run 333 → run 334)
- 110 Universal skill tag block: **0.42 WARN → 0.75 PASS** (+0.33)
- step 9 (`result NOT LIKE '[<tool>(%'`): 3 → 0 (PASS)
- step 10 (`result NOT LIKE '%[end:<tool>]%'`): 3 → 0 (PASS)
- step 12 (memory recall row with [id:] markers): still 0 — orthogonal issue (model answers from memory_seed-injected context, doesn't dispatch a fresh recall)
- 033 Schedule skill: 0.848 → 0.849 (flat)
- 111 Memory pre-act seed: 0.483 → 0.934 (+0.451 bonus)

## Test plan
- [x] 16 unit tests in `test_act_dispatcher_service.py` (3 new in `TestUntaggedPathsAreTagged`)
- [x] 59 message_processor v2 store tests pass
- [x] Ruff clean on both edited files
- [x] Nightly scenario 110 PASS