### PR TITLE
fix(privacy): include data_graph in summary + export endpoints

### DIFF
--- a/backend/api/privacy.py
+++ b/backend/api/privacy.py
@@ -101,6 +101,7 @@ def data_summary():
                 "scheduled_items",
                 "lists", "list_items",
                 "documents",
+                "data_graph",
             ]:
                 try:
                     cursor = conn.cursor()
@@ -140,6 +141,7 @@ def export_data():
         "list_events",
         "user_tool_preferences",
         "documents", "watched_folders",
+        "data_graph",
     ]
 
     store_patterns = [


### PR DESCRIPTION
## Summary

Adds `data_graph` to the iteration lists in `/privacy/data-summary` and `/privacy/export` so the user-knowledge table is reflected in both responses. `data_graph` is already in `_DELETE_ALL_TABLES` (line 38) — a known user-data table that just got missed in the summary + export listings.

## Trace evidence (run 332, scenario 090-privacy-data-export.yaml, score 0.643 WARN)

> **Step 1 diagnostic:** "The /privacy/data-summary endpoint returns HTTP 200 and integer counts for episodes, transcript, and other categories, but omits the required data_graph count entirely. The summary aggregation logic must be updated to include a data_graph row count."
>
> **Step 4 anomaly:** "Missing 'data_graph' table in /privacy/export response despite database containing 36 undeleted data_graph rows"
>
> **Step 5 anomaly:** "The export JSON from Step 4 does not contain a tables.data_graph key, so it cannot possibly have a non-empty array of trait rows."

## Result (run 337)

- **090 Privacy data summary: 0.643 WARN → 0.925 PASS** (+0.282)
- All 5 steps PASS, both targeted anomalies cleared. Judge: *"complete full export with populated tables"*. data_graph count returned (15 rows).
- Remaining trace lines are test-framework json_path-extraction noise, not Chalie behavior.

## Test plan
- [x] Backend unit tests touching privacy: 18 pass
- [x] Targeted nightly scenario 090 PASS (0.925)
- [x] Diff is +2 lines, surgical

🤖 Generated with [Claude Code](https://claude.com/claude-code)