### PR TITLE
fix(search): directive empty-result message blocks confabulation

### DIFF
--- a/backend/tests/test_search_embedding_cache.py
+++ b/backend/tests/test_search_embedding_cache.py
@@ -161,19 +161,19 @@ class TestSearchExecute:
     def test_empty_query(self):
         from tools.search.search import execute
         r = execute("topic", {})
-        assert r == {'text': 'No results found'}
+        assert r['text'].startswith('EMPTY: no query supplied')
 
     def test_whitespace_query(self):
         from tools.search.search import execute
         r = execute("topic", {"query": "   "})
-        assert r == {'text': 'No results found'}
+        assert r['text'].startswith('EMPTY: no query supplied')
 
     def test_forced_ddg(self):
         with patch('tools.search.search.fetch_ddg_fallback', return_value=[{"title": "r", "url": "http://x.com", "snippet": ""}]) as m:
             from tools.search.search import execute
             r = execute("t", {"query": "test", "provider": "ddg"})
         assert 'text' in r
-        assert r['text'] != 'No results found'
+        assert not r['text'].startswith('EMPTY:')
         m.assert_called_once()
 
     def test_forced_known_provider(self, tmp_path):
@@ -185,7 +185,7 @@ class TestSearchExecute:
              patch('tools.search.search.fetch_ddg_fallback'):
             r = s.execute("t", {"query": "test", "provider": "brave"})
         assert 'text' in r
-        assert r['text'] != 'No results found'
+        assert not r['text'].startswith('EMPTY:')
         m.assert_called_once()
 
     def test_forced_unknown_provider(self):
@@ -194,7 +194,8 @@ class TestSearchExecute:
         s._providers = {'brave': {'name': 'brave'}}
         with patch('tools.search.search.fetch_ddg_fallback', return_value=[]):
             r = s.execute("t", {"query": "test", "provider": "nonexistent"})
-        assert r == {'text': 'No results found'}
+        assert r['text'].startswith('EMPTY: zero results')
+        assert 'Do NOT fabricate' in r['text']
 
     def test_router_failure_falls_back_to_ddg(self):
         self._reset()
@@ -204,7 +205,7 @@ class TestSearchExecute:
              patch('tools.search.router.route_query', side_effect=Exception("boom")):
             r = s.execute("t", {"query": "test"})
         assert 'text' in r
-        assert r['text'] != 'No results found'
+        assert not r['text'].startswith('EMPTY:')
 
     def test_limit_clamped_high(self):
         self._reset()

--- a/backend/tools/search/search.py
+++ b/backend/tools/search/search.py
@@ -49,7 +49,7 @@ def execute(topic: str, params: dict, config: dict = None, telemetry: dict = Non
     """
     query = (params.get('query') or '').strip()
     if not query:
-        return {'text': 'No results found'}
+        return {'text': 'EMPTY: no query supplied. Tell the user no search was performed.'}
 
     limit = max(1, min(10, int(params['limit']) if params.get('limit') is not None else 5))
     forced = (params.get('provider') or '').strip().lower()
@@ -73,7 +73,11 @@ def execute(topic: str, params: dict, config: dict = None, telemetry: dict = Non
     logger.info('[SEARCH] query="%s" providers=%s count=%d', query, used, len(results))
 
     if not results:
-        return {'text': 'No results found'}
+        return {'text': (
+            f'EMPTY: zero results for query "{query}". '
+            'Do NOT fabricate results, URLs, titles, or categories. '
+            'Tell the user honestly that nothing was found and offer to refine the query.'
+        )}
 
     return {'text': json.dumps({'results': [
         {'title': r.get('title', ''), 'desc': r.get('snippet', ''), 'url': r.get('url', '')}


### PR DESCRIPTION
## Summary

Tool-side feedback strengthening for nightly scenario `055-tool-no-results-handling.yaml`. The empty-result return changed from terse `'No results found'` to a directive that primes graceful degradation.

**Before:** `{'text': 'No results found'}`
**After:** `{'text': 'EMPTY: zero results for query \"...\". Do NOT fabricate results, URLs, titles, or categories. Tell the user honestly that nothing was found and offer to refine the query.'}`

## Why

Run 337 / scenario 055 step 1 verdict (improve/privacy-data-graph-export):

> The model hallucinated package tracking services and suggested tracking sites for a gibberish query instead of simply acknowledging no results. Strengthen post-tool reasoning instructions to prevent confabulation when search results are empty.

Anomaly: *Response fabricated specific service categories (package tracking) and actionable suggestions despite a nonsensical query expected to yield no results.*

The model received an ambiguous tool result and confabulated. A directive in-band tells the LLM what happened — aligning with `feedback_always_explain_to_llm`: never silently drop context.

## Result

Run 339 (this branch), scenario 055:

- **Score:** 0.613 WARN → **0.887 PASS** (+0.274)
- **Step 1:** FAIL 0.3 → PASS 0.848 — *Response correctly avoids fabricating URLs or article titles*
- Hard-fail anomaly cleared. Remaining anomaly is mild (model added a soft "generic package tracking sites" gloss, no fabricated URLs/titles).

## Test plan

- [x] `pytest backend/tests/test_search_embedding_cache.py` — 23 pass
- [x] Targeted nightly run 339 — scenario 055 PASS 0.887

🤖 Generated with [Claude Code](https://claude.com/claude-code)