### PR TITLE
fix(message_processor): strip Qwen-style <|...|> sentinels from LLM tool args

### DIFF
--- a/backend/services/message_processor.py
+++ b/backend/services/message_processor.py
@@ -25,6 +25,7 @@ compaction primitives.
 import contextlib
 import contextvars
 import logging
+import re
 import time
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 
@@ -34,6 +35,23 @@ from services.time_utils import utc_now
 from services.time_formatter_service import TimeFormatterService
 
 logger = logging.getLogger(__name__)
+
+_LLM_SENTINEL_PATTERNS = (
+    re.compile(r'<\|[^|<>]*\|>'),
+    re.compile(r'<\|[^|<>]*\|'),
+)
+
+
+def _sanitize_llm_args(value):
+    if isinstance(value, str):
+        for p in _LLM_SENTINEL_PATTERNS:
+            value = p.sub('', value)
+        return value.strip()
+    if isinstance(value, list):
+        return [_sanitize_llm_args(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _sanitize_llm_args(v) for k, v in value.items()}
+    return value
 
 
 # ── Current-processor context ─────────────────────────────────────────────────
@@ -396,6 +414,7 @@ class MessageProcessor:
         tc_input = tc.get('input', {}) if isinstance(tc, dict) else {}
         if not isinstance(tc_input, dict):
             tc_input = {}
+        tc_input = _sanitize_llm_args(tc_input)
 
         self._metrics.record_tool(tool_name)
 

--- a/backend/tests/test_message_processor.py
+++ b/backend/tests/test_message_processor.py
@@ -1,0 +1,28 @@
+import pytest
+
+from services.message_processor import _sanitize_llm_args
+
+
+@pytest.mark.unit
+class TestSanitizeLLMArgs:
+    def test_observed_qwen_list_items(self):
+        assert _sanitize_llm_args('<|"|milk<|"|') == 'milk'
+
+    def test_well_formed_qwen_sentinels(self):
+        assert _sanitize_llm_args('<|im_start|>foo<|im_end|>') == 'foo'
+
+    def test_nested_dict_with_sentinel_items(self):
+        result = _sanitize_llm_args({'items': ['<|"|milk<|"|', 'eggs']})
+        assert result == {'items': ['milk', 'eggs']}
+
+    def test_clean_inputs_untouched(self):
+        value = {'action': 'add', 'items': ['milk']}
+        assert _sanitize_llm_args(value) == {'action': 'add', 'items': ['milk']}
+
+    def test_non_string_scalars_untouched(self):
+        value = {'limit': 10, 'active': True, 'ratio': 0.5}
+        assert _sanitize_llm_args(value) == {'limit': 10, 'active': True, 'ratio': 0.5}
+
+    def test_empty_string_after_strip(self):
+        result = _sanitize_llm_args({'x': '<|"|<|"|'})
+        assert result == {'x': ''}


### PR DESCRIPTION
## Bug

Qwen-style chat-template sentinels (`<|...|>`) leak into LLM-emitted tool arguments, get persisted into application state via the dispatcher, then break downstream queries.

### Concrete evidence — nightly scenario `036-skill-list.yaml`

User prompt: *"Create a grocery list and add milk, eggs, and bread"*

What the LLM emitted as `list.add` items (run 356 baseline):
```json
[{"content": "<|\"|milk<|\"|"}, {"content": "<|\"|eggs<|\"|"}, {"content": "<|\"|bread<|\"|"}]
```

What got persisted into `list_items.content`: literal `<|"|milk<|"|`.

Subsequent turn *"Check off milk from my grocery list"* failed because:
```sql
SELECT li.checked FROM list_items WHERE LOWER(TRIM(li.content)) = 'milk'
```
returned `[]` — content is `<|"|milk<|"|`, not `milk`.

### Reproducibility (last 6 nightly runs of 036 on rc-0.4.0)

| run | content | status | score |
|-----|---------|--------|-------|
| 356 | `<\|"\|milk<\|"\|` | WARN | 0.615 |
| 353 | `milk` | PASS | 0.828 |
| 352 | `<\|"\|milk<\|"\|` | WARN | 0.492 |
| 347 | `milk` | PASS | 0.733 |
| 346 | `<\|"\|milk<\|"\|` | WARN | 0.440 |
| 345 | `<\|"\|milk<\|"\|` | WARN | 0.472 |

WARN/PASS correlates exactly with sentinel presence — 4 of 6 runs corrupted.

## Fix

Generic sanitizer applied at the dispatcher chokepoint (`MessageProcessor.handleTool`), recursive over dict / list / str. Two regex patterns strip both well-formed `<\|...\|>` and the half-open `<\|...\|` form (Qwen's tokenizer sometimes emits the latter as a degenerate quote escape).

The dispatcher is the right place — every tool gets clean args without per-ability sanitization. No tool code touched.

## Verification

Targeted run 358 (commit 4b607b8):

| scenario | baseline (356) | improve (358) | Δ | sentinel? |
|---|---|---|---|---|
| 036 list | WARN 0.615 | **PASS 0.728** | +0.113 | gone — `"content": "milk"` |
| 106 fitness | WARN 0.477 | WARN 0.583 | +0.106 | n/a |
| 105 recipe | PASS 0.85 | WARN 0.428 | within variance¹ | n/a |

¹ 105 history on rc-0.4.0 oscillates PASS 0.85 / FAIL 0.067 / FAIL 0.293 / PASS 0.837 / FAIL 0.227 / PASS 0.825 across recent runs — high variance unrelated to this change.

**Targeted anomaly gone, targeted score rose.** Both criteria met.

## Tests

`backend/tests/test_message_processor.py::TestSanitizeLLMArgs` — 6 unit tests:
- exact observed pattern (`<\|"\|milk<\|"\|` → `milk`)
- well-formed Qwen sentinels (`<\|im_start\|>foo<\|im_end\|>` → `foo`)
- nested dict with mixed clean/dirty items
- clean inputs untouched
- non-string scalars (int/bool/float) untouched
- empty-after-strip

`pytest -m unit -q`: 2084 passed, 32 skipped. Ruff clean.