### PR TITLE
fix(ollama): extract inline <tool_call> markup when structured channel is empty

### DIFF
--- a/backend/services/ollama_service.py
+++ b/backend/services/ollama_service.py
@@ -381,7 +381,7 @@ def _raise_rate_limit(e: requests.exceptions.HTTPError) -> None:
     raise RateLimitError(str(e), retry_after=retry_after, provider='ollama') from e
 
 
-_INLINE_TOOL_CALL_RE = re.compile(r'<tool_call>\s*(.*?)\s*</tool_call>', re.DOTALL)
+_INLINE_TOOL_CALL_RE = re.compile(r'<tool_call>(.*?)</tool_call>', re.DOTALL)
 
 
 def _extract_inline_tool_calls(text: str) -> tuple[str, list]:
@@ -394,7 +394,7 @@ def _extract_inline_tool_calls(text: str) -> tuple[str, list]:
     """
     entries = []
     for idx, match in enumerate(_INLINE_TOOL_CALL_RE.finditer(text)):
-        raw = match.group(1)
+        raw = match.group(1).strip()
         try:
             payload = json.loads(raw)
         except (json.JSONDecodeError, ValueError):

--- a/backend/services/ollama_service.py
+++ b/backend/services/ollama_service.py
@@ -15,6 +15,7 @@ from urllib.parse import urlparse
 
 import requests
 import json
+from abilities._registry import AbilityRegistry
 from services.llm_service import LLMResponse, PayloadTooLargeError, RateLimitError
 
 # Model identifier accepts alphanumeric, dot, underscore, dash, slash, and the
@@ -380,6 +381,62 @@ def _raise_rate_limit(e: requests.exceptions.HTTPError) -> None:
     raise RateLimitError(str(e), retry_after=retry_after, provider='ollama') from e
 
 
+_INLINE_TOOL_CALL_RE = re.compile(r'<tool_call>\s*(.*?)\s*</tool_call>', re.DOTALL)
+
+
+def _extract_inline_tool_calls(text: str) -> tuple[str, list]:
+    """Extract <tool_call>...</tool_call> blocks from *text*.
+
+    Returns (cleaned_text, tool_call_entries). Blocks that fail JSON parsing,
+    contain no dict, or whose name/action does not resolve in AbilityRegistry
+    are skipped silently. All matched blocks are stripped from the text
+    regardless of whether they parsed successfully.
+    """
+    entries = []
+    for idx, match in enumerate(_INLINE_TOOL_CALL_RE.finditer(text)):
+        raw = match.group(1)
+        try:
+            payload = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+
+        name = None
+        arguments = {}
+
+        # Path A — explicit "name" key
+        candidate = payload.get('name')
+        if isinstance(candidate, str):
+            try:
+                AbilityRegistry.get(candidate)
+                name = candidate
+                args_val = payload.get('arguments', {})
+                arguments = args_val if isinstance(args_val, dict) else {k: v for k, v in payload.items() if k != 'name'}
+            except KeyError:
+                pass
+
+        # Path B — "action" key as name
+        if name is None:
+            action = payload.get('action')
+            if isinstance(action, str):
+                try:
+                    AbilityRegistry.get(action)
+                    name = action
+                    arguments = {k: v for k, v in payload.items() if k != 'action'}
+                except KeyError:
+                    pass
+
+        if name is None:
+            continue
+
+        entries.append({'id': f"ollama_{name}_{idx}", 'name': name, 'input': arguments})
+
+    cleaned = _INLINE_TOOL_CALL_RE.sub('', text)
+    cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
+    return cleaned, entries
+
+
 def _parse_chat_response(data: dict, default_model: str) -> LLMResponse:
     """Build an LLMResponse from a raw Ollama /api/chat response dict."""
     msg = data.get('message', {})
@@ -395,6 +452,10 @@ def _parse_chat_response(data: dict, default_model: str) -> LLMResponse:
             }
             for i, tc in enumerate(raw_tool_calls)
         ]
+    else:
+        text, inline_calls = _extract_inline_tool_calls(text)
+        if inline_calls:
+            tool_calls = inline_calls
     return LLMResponse(
         text=text,
         model=data.get('model', default_model),

--- a/backend/tests/test_ollama_service.py
+++ b/backend/tests/test_ollama_service.py
@@ -1,0 +1,103 @@
+"""Unit tests for _extract_inline_tool_calls and its integration with
+_parse_chat_response.
+
+Covers Qwen-style <tool_call>...</tool_call> markup extraction when the
+structured tool_calls channel is empty or null.
+"""
+
+import pytest
+
+from abilities._registry import AbilityRegistry
+
+pytestmark = pytest.mark.unit
+
+
+class TestExtractInlineToolCalls:
+    def _extract(self, text):
+        from services.ollama_service import _extract_inline_tool_calls
+        return _extract_inline_tool_calls(text)
+
+    def _real_ability(self):
+        """Return the NAME of any registered ability to use as a real name."""
+        abilities = AbilityRegistry.all()
+        assert abilities, "Registry must contain at least one ability"
+        return abilities[0].NAME
+
+    def test_path_a_explicit_name_with_arguments(self):
+        """Path A: dict has 'name' key recognised by registry + 'arguments' dict."""
+        name = self._real_ability()
+        text = f'<tool_call>{{"name": "{name}", "arguments": {{"source": "https://example.com"}}}}</tool_call>'
+        cleaned, calls = self._extract(text)
+        assert len(calls) == 1
+        assert calls[0]['name'] == name
+        assert calls[0]['input'] == {'source': 'https://example.com'}
+        assert '<tool_call>' not in cleaned
+
+    def test_path_b_action_as_name(self):
+        """Path B — 039 case: dict has 'action' key whose value is a registered name.
+        The 'action' key must NOT appear in the extracted input."""
+        name = self._real_ability()
+        text = f'<tool_call>{{"source": "https://example.com", "action": "{name}"}}</tool_call>'
+        cleaned, calls = self._extract(text)
+        assert len(calls) == 1
+        assert calls[0]['name'] == name
+        assert 'action' not in calls[0]['input']
+        assert calls[0]['input'] == {'source': 'https://example.com'}
+        assert '<tool_call>' not in cleaned
+
+    def test_unregistered_action_skipped(self):
+        """An action value not in the registry must be silently skipped.
+        The block is still stripped from the text."""
+        text = '<tool_call>{"action": "check", "items": ["milk"]}</tool_call>'
+        cleaned, calls = self._extract(text)
+        assert calls == []
+        assert '<tool_call>' not in cleaned
+
+    def test_multiple_blocks_both_extracted(self):
+        """Two valid <tool_call> blocks produce two entries in order."""
+        name = self._real_ability()
+        text = (
+            f'<tool_call>{{"action": "{name}", "query": "foo"}}</tool_call>\n'
+            f'<tool_call>{{"action": "{name}", "query": "bar"}}</tool_call>'
+        )
+        cleaned, calls = self._extract(text)
+        assert len(calls) == 2
+        assert calls[0]['input']['query'] == 'foo'
+        assert calls[1]['input']['query'] == 'bar'
+        assert '<tool_call>' not in cleaned
+
+    def test_malformed_json_skipped_block_still_stripped(self):
+        """Non-parseable JSON is skipped silently; markup is still removed."""
+        text = '<tool_call>not json{</tool_call>'
+        cleaned, calls = self._extract(text)
+        assert calls == []
+        assert '<tool_call>' not in cleaned
+
+    def test_no_inline_blocks_passthrough(self):
+        """Plain text with no blocks returns the original text and empty list."""
+        text = 'Hello, I have no tool calls here.'
+        cleaned, calls = self._extract(text)
+        assert calls == []
+        assert cleaned == text
+
+    def test_structured_channel_wins_inline_ignored(self):
+        """When raw_tool_calls is present, _parse_chat_response must not call
+        _extract_inline_tool_calls — inline blocks stay in the text unchanged."""
+        name = self._real_ability()
+        from services.ollama_service import _parse_chat_response
+
+        data = {
+            'message': {
+                'content': f'<tool_call>{{"action": "{name}"}}</tool_call>',
+                'tool_calls': [
+                    {'function': {'name': 'structured_tool', 'arguments': {'k': 'v'}}}
+                ],
+            },
+            'model': 'qwen2.5:7b',
+        }
+        resp = _parse_chat_response(data, 'qwen2.5:7b')
+        assert len(resp.tool_calls) == 1
+        assert resp.tool_calls[0]['name'] == 'structured_tool'
+        # Inline block untouched — content preserved as-is
+        assert '<tool_call>' in resp.text
+        assert resp.stop_reason == 'tool_use'


### PR DESCRIPTION
## Bug

Qwen occasionally emits tool calls as inline `<tool_call>JSON</tool_call>` markup in `message.content` instead of via the API's structured `tool_calls` field. Result: `metrics.tools={}`, the tool never fires, ACT loop ends, scenario fails. Observed in nightly run 362 across multiple scenarios.

### Concrete evidence — scenario 039 step-1 (Read URL)

User: *"Can you read this page and tell me what it says? https://example.com"*

Ollama response:
```json
{
  "message": {
    "content": "<tool_call> { \"source\": \"https://example.com\", \"action\": \"read\" } </tool_call>\n<p>I am accessing the page now…</p>",
    "tool_calls": null
  }
}
```

`metrics.tools={}`. Read tool never fires. Fastpath `SELECT COUNT(*) FROM tool_calls WHERE tool_name='read'` returns 0.

Same failure mode also seen in 036 step-3 (check-off) + step-5 (delete), and 083 (weather fabricate from prior context after model decided not to fire weather tool).

## Fix

In `backend/services/ollama_service.py::_parse_chat_response`, **only when the structured `tool_calls` field is empty/None**, scan `content` for `<tool_call>...</tool_call>` blocks and try to extract dispatchable calls.

Two registry-validated paths:

- **Path A** — well-formed Qwen: JSON has `name` field whose value matches a registered ability → use `name` + `arguments`.
- **Path B** — flat-with-action: JSON has `action` field whose value matches a registered ability (e.g., `action: "read"`) → use action as tool name, rest of dict as arguments.

Both paths require `AbilityRegistry.get(name)` to succeed before routing. Unmatched action values (e.g., `action: "check"` for the list ability) are skipped — the registry check is the safety boundary against false-positive routing.

Inline blocks are stripped from `content` regardless of parse outcome (no raw markup leaking to user). Multiple consecutive newlines collapsed.

Defensive scope: structured-channel path unchanged. When `msg.tool_calls` is populated, the extractor never runs.

## Verification — targeted run 365

| scenario | baseline (362) | improve (365) | Δ |
|---|---|---|---|
| 036 list | WARN 0.615 | **PASS 0.973** | +0.358 |
| 039 read | WARN 0.483 | **PASS 0.97** | +0.487 |
| 083 weather | WARN 0.575 | **PASS 0.978** | +0.403 |
| 106 fitness | WARN 0.637 | **PASS 0.728** | +0.091 |

All four targets PASS. The fix is defensive: when Qwen emits the proper structured channel (most turns), the extractor doesn't run. When Qwen leaks inline markup with an empty structured channel, the extractor recovers a routable call.

## Tests

`backend/tests/test_ollama_service.py::TestExtractInlineToolCalls` — 7 unit tests:

1. Path A — well-formed `{"name":"read","arguments":{...}}`
2. Path B — `{"source":"...","action":"read"}` (the 039 case) — `action` stripped from input
3. Action not in registry — skipped, markup stripped from text
4. Multiple `<tool_call>` blocks — both extracted in order
5. Malformed JSON — skipped silently, markup stripped
6. No inline blocks — passthrough
7. Both inline AND structured tool_calls — structured wins, inline ignored

Real `AbilityRegistry`, no mocks.

`pytest -m unit -q`: 2107 passed, 32 skipped. Ruff clean.