### PR TITLE
fix(ump): gate pre_act seed injection on relevance:high results

### DIFF
--- a/backend/services/user_message_processor.py
+++ b/backend/services/user_message_processor.py
@@ -351,7 +351,12 @@ class UserMessageProcessor(MessageProcessor):
         # value. Inspect only the opener line so a body containing the literal
         # substring `results=0` or `error=` cannot suppress a valid seed.
         header = block.split('\n', 1)[0] if block else ''
-        if block and 'results=0' not in header and 'error=' not in header:
+        if (
+            block
+            and 'results=0' not in header
+            and 'error=' not in header
+            and 'relevance:high' in block
+        ):
             self._memory_seed = block
 
         if self._uid is None:

--- a/backend/tests/test_preact_seed_quality_gate.py
+++ b/backend/tests/test_preact_seed_quality_gate.py
@@ -1,0 +1,102 @@
+"""Unit tests — pre_act() quality gate on relevance:high.
+
+Verifies that UserMessageProcessor._memory_seed is only set when the recall
+block contains at least one `relevance:high` result, and that
+ToolRenderAndRecordService is called unconditionally.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_HIGH_BLOCK = (
+    "[memory(query=foo,results=2)]\n"
+    "[id:e1,relevance:high] body1\n"
+    "[id:e2,relevance:medium] body2\n"
+    "[end:memory]"
+)
+
+_MEDIUM_ONLY_BLOCK = (
+    "[memory(query=foo,results=2)]\n"
+    "[id:e1,relevance:medium] body1\n"
+    "[id:e2,relevance:low] body2\n"
+    "[end:memory]"
+)
+
+_EMPTY_BLOCK = "[memory(query=foo,results=0)]"
+
+_ERROR_BLOCK = "[memory(query=foo,error=timeout)]"
+
+
+def _make_proc(raw_input="oven reminder"):
+    """Construct a UserMessageProcessor with _uid pre-set so pre_act runs fully."""
+    from services.user_message_processor import UserMessageProcessor
+
+    proc = UserMessageProcessor(raw_input=raw_input)
+    proc._uid = "test-uid-001"
+    return proc
+
+
+def _run_pre_act_with_block(block_text, monkeypatch):
+    """Patch AbilityRegistry and ToolRenderAndRecordService, run pre_act, return (proc, mock_trrs)."""
+    mock_ability = MagicMock()
+    mock_ability.execute.return_value = {'text': block_text}
+
+    mock_registry = MagicMock()
+    mock_registry.get.return_value = mock_ability
+
+    mock_trrs_instance = MagicMock()
+    mock_trrs_cls = MagicMock(return_value=mock_trrs_instance)
+
+    # AbilityRegistry and ToolRenderAndRecordService are imported locally inside
+    # pre_act() so we patch them at their source modules.
+    with patch('abilities._registry.AbilityRegistry', mock_registry), \
+         patch('services.tool_render_and_record_service.ToolRenderAndRecordService', mock_trrs_cls):
+        proc = _make_proc()
+        proc.pre_act()
+
+    return proc, mock_trrs_cls, mock_trrs_instance
+
+
+@pytest.mark.unit
+class TestPreActSeedQualityGate:
+    """pre_act() injects seed only when relevance:high is present in the block."""
+
+    def test_high_relevance_result_injects_seed(self, monkeypatch):
+        """Block with at least one relevance:high hit → _memory_seed is set to the full block."""
+        proc, _, _ = _run_pre_act_with_block(_HIGH_BLOCK, monkeypatch)
+        assert proc._memory_seed == _HIGH_BLOCK
+
+    def test_medium_and_low_only_does_not_inject_seed(self, monkeypatch):
+        """Block with only relevance:medium and relevance:low → _memory_seed remains None."""
+        proc, _, _ = _run_pre_act_with_block(_MEDIUM_ONLY_BLOCK, monkeypatch)
+        assert proc._memory_seed is None
+
+    def test_empty_results_does_not_inject_seed(self, monkeypatch):
+        """Block with results=0 in header → _memory_seed remains None (pre-existing behavior)."""
+        proc, _, _ = _run_pre_act_with_block(_EMPTY_BLOCK, monkeypatch)
+        assert proc._memory_seed is None
+
+    def test_error_does_not_inject_seed(self, monkeypatch):
+        """Block with error= in header → _memory_seed remains None (pre-existing behavior)."""
+        proc, _, _ = _run_pre_act_with_block(_ERROR_BLOCK, monkeypatch)
+        assert proc._memory_seed is None
+
+    def test_recording_happens_regardless_of_gate(self, monkeypatch):
+        """ToolRenderAndRecordService is called even when the seed is gated out."""
+        proc, mock_trrs_cls, mock_trrs_instance = _run_pre_act_with_block(
+            _MEDIUM_ONLY_BLOCK, monkeypatch
+        )
+        assert proc._memory_seed is None
+        mock_trrs_cls.assert_called_once()
+        mock_trrs_instance.renderAndRecord.assert_called_once()
+
+    def test_recording_happens_when_seed_is_injected(self, monkeypatch):
+        """ToolRenderAndRecordService is called when seed passes the gate too."""
+        proc, mock_trrs_cls, mock_trrs_instance = _run_pre_act_with_block(
+            _HIGH_BLOCK, monkeypatch
+        )
+        assert proc._memory_seed == _HIGH_BLOCK
+        mock_trrs_cls.assert_called_once()
+        mock_trrs_instance.renderAndRecord.assert_called_once()


### PR DESCRIPTION
## Bug

Pre_act memory seed surfaces cross-scenario episodes whose semantic similarity is moderate (vector_sim 0.5-0.7) but topically misleading. Model believes bled context belongs to the current conversation and emits responses targeting the wrong topic.

### Concrete evidence — run 366

**071 (Scheduler reminder)** — user prompt: *"Set a reminder for 1 minute from now to check the oven"*
Model emitted: *"You are already all set for that. I have a reminder scheduled for your **dentist appointment this Monday, May 4th, at 10:00 AM**."*
Bled from earlier scheduler scenario.

**105 (Recipe file workflow)** — user prompt: *"Find an authentic chicken tikka masala recipe and store it as a file"*
Model emitted: *"That is a striking coincidence, given that you mentioned **March 20th is your own birthday** as well. Who is the person you are referring to?"*
Bled from unrelated scenario.

In both cases, pre_act injected a seed block whose top hit was likely `relevance:medium` (composite_score 0.4-0.7) — semantically related-ish but not high confidence. Current pre_act gate only checks for empty / error blocks, not quality.

## Fix

Single condition added to the existing pre_act injection gate in `backend/services/user_message_processor.py`:

```python
if (
    block
    and 'results=0' not in header
    and 'error=' not in header
    and 'relevance:high' in block   # ← NEW
):
    self._memory_seed = block
```

When pre_act recall produces only `relevance:medium` and `relevance:low` results, the seed block is dropped from the prompt. The `tool_calls` recording still happens for every turn (only the in-prompt injection is gated).

Relevance label thresholds (existing, unchanged): `high` ≥ 0.7, `medium` 0.4-0.7, `low` < 0.4.

## Why this is safe vs cycle 26 (banned)

Cycle 26 banned **blanket pre_act seed RADIUS drop** (0.5 → 0.4 via `caller='seed'`) which tightened retrieval at the SQL/vector layer and starved intra-scenario context after `reset_thread`.

This change is fundamentally different:
- Radius unchanged — retrieval still returns the same candidate set.
- Filter ONLY at the pre_act injection chokepoint, BEFORE setting `self._memory_seed`.
- Intra-scenario hits with high vector_sim still score `relevance:high` and pass the gate.
- The recall ranking and radius constants are untouched.

## Verification — targeted run 367

| scenario | baseline (366) | improve (367) | Δ |
|---|---|---|---|
| 071 scheduler reminder | FAIL 0.235 | **PASS 0.85** | +0.615 |
| 050 weather tool | WARN 0.586 | **PASS 0.959** | +0.373 |
| 013 all messages get response | WARN 0.645 | **PASS 0.964** | +0.319 |
| 106 fitness plan schedule | FAIL 0.060 | WARN 0.535 | +0.475 |
| 105 recipe file workflow | FAIL 0.030 | FAIL 0.160 | +0.130 |

**4 of 5 scenarios PASS or rose past WARN.** Cross-scenario bleed at turn-1 gone in all targets — confirmed by 105 step-1/2/3 PASS (original recipe doc created cleanly, no birthday hallucination). 105 step-6+ still fails — separate post-reset_thread context loss issue, not the targeted bleed anomaly.

## Tests

`backend/tests/test_preact_seed_quality_gate.py` — 6 new `@pytest.mark.unit` cases:
1. High-relevance result injects (full block set on `_memory_seed`)
2. Only medium/low → no injection
3. Empty results (`results=0` header) → no injection (existing behavior)
4. Error header → no injection (existing behavior)
5. Recording happens regardless of gate (verified for both inject + drop cases)

`pytest -m unit -q`: 881 passed, 15 skipped, 1 pre-existing failure unrelated. Ruff clean.