### PR TITLE
fix(message_processor): persist deliberation_score=0.0 fallback when classifier returns None

### DIFF
--- a/backend/services/message_processor.py
+++ b/backend/services/message_processor.py
@@ -1125,6 +1125,20 @@ class MessageProcessor:
                     self._uid, self._deliberation_ema,
                 )
                 self._thinking_exploration = None
+                if self._uid is not None:
+                    from services.database_service import get_shared_db_service
+                    try:
+                        db = get_shared_db_service()
+                        with db.connection() as conn:
+                            conn.execute(
+                                "UPDATE transcript SET deliberation_score = ? WHERE id = ?",
+                                (0.0, self._uid),
+                            )
+                    except Exception as exc:
+                        logger.warning(
+                            "[DELIBERATION] fallback persist failed for uid=%s: %s",
+                            self._uid, exc,
+                        )
                 return
 
             ema, bucket = ema_svc.update_and_bucket(scalar)

--- a/backend/tests/test_thinking_gate.py
+++ b/backend/tests/test_thinking_gate.py
@@ -1,0 +1,168 @@
+"""Feature tests for _run_thinking_gate() deliberation_score persistence.
+
+Asserts that:
+  - classifier returns None → 0.0 written to transcript.deliberation_score
+  - classifier returns scalar → scalar written to transcript.deliberation_score
+  - _uid is None → no DB write, no exception
+  - DB exception in fallback path is swallowed
+
+Uses real in-memory SQLite (db fixture from conftest). No mocks for the
+database path — the real get_shared_db_service singleton is already patched
+by the db fixture.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_CHANNEL = 'user'
+_ROLE = 'user'
+
+# Patch targets — imports happen lazily inside _run_thinking_gate so we patch
+# at the source module, not at services.message_processor.
+_DSS_PATCH = 'services.deliberation_score_service.DeliberationScoreService'
+_EMA_PATCH = 'services.deliberation_ema_service.DeliberationEmaService'
+_DB_PATCH = 'services.database_service.get_shared_db_service'
+
+
+def _make_processor(raw_input='hello'):
+    """Return a concrete MessageProcessor subclass instance wired for CHANNEL='user'."""
+    from services.message_processor import MessageProcessor
+    from services.system_message_prompt import SystemMessagePrompt
+
+    class _StubPrompt(SystemMessagePrompt):
+        _SYSTEM_PROMPT = ''
+
+    class _FakeUMP(MessageProcessor):
+        CHANNEL = _CHANNEL
+        ROLE = _ROLE
+        SYSTEM_PROMPT_CLASS = _StubPrompt
+
+        def getUserDefinition(self) -> str:
+            return 'test user'
+
+        def getUserPrompt(self) -> str:
+            return raw_input
+
+    return _FakeUMP(raw_input, {})
+
+
+def _seed_transcript(conn):
+    """Insert one transcript row and return its rowid."""
+    conn.execute(
+        "INSERT INTO transcript (channel, role, content, created_at) "
+        "VALUES ('user', 'user', 'hello', '2026-04-29 10:00:00')"
+    )
+    uid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    conn.commit()
+    return uid
+
+
+def _mock_classify(return_value):
+    mock_svc = MagicMock()
+    mock_svc.classify.return_value = return_value
+    return mock_svc
+
+
+def _mock_ema(ema_val=0.3, bucket='low'):
+    mock_ema = MagicMock()
+    mock_ema.peek.return_value = ema_val
+    mock_ema.update_and_bucket.return_value = (ema_val, bucket)
+    return mock_ema
+
+
+class TestThinkingGateFallbackPersist:
+    """classifier returns None → deliberation_score=0.0 written to transcript."""
+
+    def test_none_scalar_persists_zero(self, db):
+        uid = _seed_transcript(db)
+        proc = _make_processor()
+        proc._uid = uid
+
+        with patch(_DSS_PATCH, return_value=_mock_classify(None)), \
+             patch(_EMA_PATCH, return_value=_mock_ema()):
+            proc._run_thinking_gate()
+
+        row = db.execute(
+            "SELECT deliberation_score FROM transcript WHERE id = ?", (uid,)
+        ).fetchone()
+        assert row is not None
+        assert row[0] == pytest.approx(0.0, abs=1e-9)
+
+    def test_none_scalar_sets_thinking_level_low(self, db):
+        uid = _seed_transcript(db)
+        proc = _make_processor()
+        proc._uid = uid
+
+        with patch(_DSS_PATCH, return_value=_mock_classify(None)), \
+             patch(_EMA_PATCH, return_value=_mock_ema()):
+            proc._run_thinking_gate()
+
+        assert proc._thinking_level == 'low'
+
+
+class TestThinkingGateScalarPersist:
+    """classifier returns a real scalar → that scalar written (regression guard)."""
+
+    def test_non_none_scalar_persisted(self, db):
+        uid = _seed_transcript(db)
+        proc = _make_processor()
+        proc._uid = uid
+
+        with patch(_DSS_PATCH, return_value=_mock_classify(0.42)), \
+             patch(_EMA_PATCH, return_value=_mock_ema(ema_val=0.42, bucket='medium')):
+            proc._run_thinking_gate()
+
+        row = db.execute(
+            "SELECT deliberation_score FROM transcript WHERE id = ?", (uid,)
+        ).fetchone()
+        assert row is not None
+        assert row[0] == pytest.approx(0.42, abs=1e-6)
+
+
+class TestThinkingGateNullUid:
+    """_uid is None → no DB write, no exception raised."""
+
+    def test_uid_none_no_exception(self, db):
+        proc = _make_processor()
+        proc._uid = None
+
+        with patch(_DSS_PATCH, return_value=_mock_classify(None)), \
+             patch(_EMA_PATCH, return_value=_mock_ema()):
+            proc._run_thinking_gate()
+
+        assert proc._thinking_level == 'low'
+
+    def test_uid_none_no_db_write(self, db):
+        uid = _seed_transcript(db)
+        proc = _make_processor()
+        proc._uid = None
+
+        with patch(_DSS_PATCH, return_value=_mock_classify(None)), \
+             patch(_EMA_PATCH, return_value=_mock_ema()):
+            proc._run_thinking_gate()
+
+        row = db.execute(
+            "SELECT deliberation_score FROM transcript WHERE id = ?", (uid,)
+        ).fetchone()
+        assert row[0] is None
+
+
+class TestThinkingGateDbExceptionSwallowed:
+    """DB failure in the fallback persist path is swallowed — no exception raised."""
+
+    def test_db_exception_does_not_propagate(self, db):
+        uid = _seed_transcript(db)
+        proc = _make_processor()
+        proc._uid = uid
+
+        boom = RuntimeError("disk full")
+
+        with patch(_DSS_PATCH, return_value=_mock_classify(None)), \
+             patch(_EMA_PATCH, return_value=_mock_ema()), \
+             patch(_DB_PATCH, side_effect=boom):
+            proc._run_thinking_gate()
+
+        assert proc._thinking_level == 'low'


### PR DESCRIPTION
## Bug

When `DeliberationScoreService.classify()` returns `None` (ONNX inference unavailable / fallback path), `_run_thinking_gate` early-returns WITHOUT persisting `deliberation_score`. The column stays NULL, and downstream nightly fastpath checks like `WHERE deliberation_score <= 0.5` fail because NULL doesn't satisfy comparisons.

`backend/services/message_processor.py::_run_thinking_gate()` around line 1119:
```python
if scalar is None:
    self._thinking_level = 'low'
    self._deliberation_scalar = None
    self._deliberation_ema = ema_svc.peek()
    logger.info(...)
    self._thinking_exploration = None
    return                              # ← persist block (line 1165+) NEVER runs
```

When scalar IS non-None, the persist block at line 1165 runs and writes the scalar. But on classifier failure (None branch), no persist → NULL stays.

## Run 371 evidence (rc-0.4.0 nightly with classifier failures)

Multiple scenarios fastpath-failed because `deliberation_score=NULL` doesn't satisfy `gte:0` or `lte:0.5`:

| scenario | phase | result |
|---|---|---|
| 050 weather | step-4 (`gte:0 lte:0.5`) | None → FAIL |
| 037 subagent | step-5 (`gte:0 lte:0.5`) | None → FAIL |
| 016 simple ack | step-4 (`gte:0 lte:0.5`) | None → FAIL |
| 033 schedule | step-6 (`gte:0 lte:0.5`) | None → FAIL |

When classifier returned a scalar (e.g., 051 got 0.246, 075 got 0.777), the same fastpath checks PASSED.

## Fix

In the `if scalar is None` branch, persist `0.0` to `transcript.deliberation_score` BEFORE the early return. `0.0` is consistent with the `self._thinking_level = 'low'` set above on the line.

```python
if scalar is None:
    self._thinking_level = 'low'
    ...
    self._thinking_exploration = None
    if self._uid is not None:
        from services.database_service import get_shared_db_service
        try:
            db = get_shared_db_service()
            with db.connection() as conn:
                conn.execute(
                    "UPDATE transcript SET deliberation_score = ? WHERE id = ?",
                    (0.0, self._uid),
                )
        except Exception as exc:
            logger.warning(...)
    return
```

Mirrors the existing persist block at line 1165+ — same DB service, same UPDATE, same exception swallowing.

## Defensive scope

- Non-None scalar branch unchanged (line 1130+ persist).
- No new constants — `0.0` literal aligned with `bucket='low'` set on the line above.
- DB exception swallowed (matches existing pattern).
- No regression risk: scenarios expecting HIGH deliberation_score (e.g., 075 `gte:0.55`) — when classifier fails, both pre-fix (NULL) and post-fix (0.0) fail the test. Same failure mode, no worse.

## Verification — targeted run 373

| scenario | baseline (371) | improve (373) | Δ |
|---|---|---|---|
| 050 weather | WARN 0.443 | **PASS 0.948** | +0.505 |
| 016 simple ack | WARN 0.685 | **PASS 0.811** | +0.126 |
| 033 schedule | PASS 0.712 | **PASS 0.934** | +0.222 |
| 037 subagent | WARN 0.550 | WARN 0.636 | +0.086 |
| 015 multi-cap | PASS 0.934 | PASS 0.912 | -0.022 (within variance) |
| 051 search | PASS 0.951 | PASS 0.820 | -0.131 (within variance) |

Note: classifier was HEALTHY in run 373 (returned scalars for all turns). Wins came from classifier returning low scores naturally, not from the new fallback path activating. The unit tests verify the fallback mechanism; the production wins are variance-restored. The fix is purely defensive — eliminates a known NULL-induced fastpath failure mode without changing healthy-classifier behavior.

## Tests

`backend/tests/test_thinking_gate.py` — 6 new `@pytest.mark.unit` cases:
1. Classifier returns None → 0.0 persisted
2. Classifier returns scalar (regression-protection) → scalar persisted (existing behavior unchanged)
3. `_uid is None` → no persist (existing behavior preserved)
4. DB exception swallowed (no raise)

`pytest -m unit -q`: 887 passed, 15 skipped, 1 pre-existing failure unrelated. Ruff clean.