### PR TITLE
fix(read): detect captcha widgets, redirect to browser tool

### DIFF
--- a/backend/abilities/read.py
+++ b/backend/abilities/read.py
@@ -118,6 +118,19 @@ class ReadAbility(Ability):
             return {"text": _skill_tag("read", source=source, error=str(e)[:200])}
 
 
+def _has_captcha_markers(html: str) -> bool:
+    markers = (
+        "g-recaptcha", "h-captcha", "data-sitekey=",
+        'name="captcha"', "name='captcha'",
+        'id="captcha"', "id='captcha'",
+        'class="captcha', "class='captcha",
+        'class="g-recaptcha', "class='g-recaptcha",
+        'class="h-captcha', "class='h-captcha",
+        'name="g-recaptcha-response"', "name='g-recaptcha-response'",
+    )
+    return any(m in html for m in markers)
+
+
 def _classify_source(source: str) -> str:
     parsed = urlparse(source)
     if parsed.scheme in ("http", "https", "ftp"):
@@ -156,6 +169,14 @@ def _read_url(url: str, max_chars: int) -> str:
             html = response.text
     except requests.RequestException as e:
         return _skill_tag("read", source=url, error=f"fetch-failed:{str(e)[:150]}")
+
+    if _has_captcha_markers(html):
+        return _skill_tag(
+            "read",
+            source=url,
+            error="captcha-or-interactive-widget-detected",
+            hint="Page contains a captcha widget. Use the browser tool with action='interact' to solve it (read only extracts static text — it cannot type into fields or click buttons).",
+        )
 
     from services.text_extractor import extract_html
     content = extract_html(html, url=url)

--- a/backend/tests/test_read_skill.py
+++ b/backend/tests/test_read_skill.py
@@ -194,6 +194,70 @@ class TestUrlReading:
         assert '[end:read]' in result
 
 
+# ─── Captcha detection ───────────────────────────────────────────────────────
+
+@pytest.mark.unit
+class TestCaptchaDetection:
+    """Tests for _has_captcha_markers and the early-return in _read_url."""
+
+    def _patch_session(self, html):
+        """Patch requests.Session on the already-imported abilities.read module."""
+        mock_session = MagicMock()
+        mock_session.headers = {}
+        mock_response = MagicMock()
+        mock_response.text = html
+        mock_response.raise_for_status = MagicMock()
+        mock_session.get.return_value = mock_response
+        mock_session.__enter__.return_value = mock_session
+        mock_session.__exit__.return_value = False
+        mock_requests = MagicMock()
+        mock_requests.Session.return_value = mock_session
+        import requests as real_requests
+        mock_requests.RequestException = real_requests.RequestException
+        return patch('abilities.read.requests', mock_requests)
+
+    def test_read_url_detects_g_recaptcha(self):
+        html = '<div class="g-recaptcha" data-sitekey="abc123"></div>'
+        with self._patch_session(html), \
+             patch('abilities.read._is_private_url', return_value=False):
+            from abilities.read import _read_url
+            result = _read_url('https://example.com', 4000)
+        assert 'error=captcha-or-interactive-widget-detected' in result
+        assert 'browser' in result
+        assert '[end:read]' in result
+
+    def test_read_url_detects_h_captcha(self):
+        html = '<div class="h-captcha" data-sitekey="xyz789"></div>'
+        with self._patch_session(html), \
+             patch('abilities.read._is_private_url', return_value=False):
+            from abilities.read import _read_url
+            result = _read_url('https://example.com', 4000)
+        assert 'error=captcha-or-interactive-widget-detected' in result
+        assert 'browser' in result
+        assert '[end:read]' in result
+
+    def test_read_url_detects_named_captcha_input(self):
+        html = '<form><input type="text" name="captcha" /></form>'
+        with self._patch_session(html), \
+             patch('abilities.read._is_private_url', return_value=False):
+            from abilities.read import _read_url
+            result = _read_url('https://example.com', 4000)
+        assert 'error=captcha-or-interactive-widget-detected' in result
+        assert 'browser' in result
+        assert '[end:read]' in result
+
+    def test_read_url_no_false_positive_on_article_text(self):
+        html = '<html><body><p>This article explains how captcha works and why it stops bots.</p></body></html>'
+        with self._patch_session(html), \
+             patch('abilities.read._is_private_url', return_value=False), \
+             patch('services.text_extractor.extract_html', return_value='This article explains how captcha works.'):
+            from abilities.read import _read_url
+            result = _read_url('https://example.com', 4000)
+        assert 'captcha-or-interactive-widget-detected' not in result
+        assert 'This article explains' in result
+        assert '[end:read]' in result
+
+
 # ─── File reading ─────────────────────────────────────────────────────────────
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

`read` ability silently strips `<form>` markup via `extract_html` (text_extractor.py:95), leaving the model with prose-only HTML and no signal that the page is interactive. Three prior cycles (read_browser_disambig_negative_signal, browser-nav-verb-rule, browser-profile-nav-verbs) tried prompt/metadata pushes toward `browser` — all noise-band, anomaly unchanged.

New angle: `read` itself fails loudly with a directive when the page is captcha-shaped, so the model reroutes to `browser` on the next ACT iteration.

## Evidence

**Run 385 (rc-0.5.1) trace, scenario 054:**
> "My current capabilities allow me to read the text of a page, but I cannot see the image containing the captcha characters, nor can I interact with the site by typing into fields or clicking buttons."

Model called `read` once (metrics.tools={'read': 1}). Judge diagnostic:
> "The model hallucinated a limitation, claiming it cannot interact with fields or see images, despite the browser tool being available."

**Run 387 (this branch) trace, scenario 054:**
- `read` returned reroute hint
- Model invoked `browser` tool 8 times across the ACT loop
- Anomaly **"Model refused task based on incorrect self-perception of capabilities" — GONE**
- Score 0.443 → 0.458 (WARN→WARN, marginal)
- Remaining issues are downstream (sentinel extraction, latency) — separate bug class

## Implementation

`backend/abilities/read.py`:
- New `_has_captcha_markers(html)` — substring scan for stable HTML attribute markers (`g-recaptcha`, `h-captcha`, `data-sitekey=`, `name="captcha"`, etc.). 13 markers, both quote variants.
- In `_read_url`, before `extract_html`, return `_skill_tag(error="captcha-or-interactive-widget-detected", hint="Page contains a captcha widget. Use the browser tool with action='interact'...")` when markers detected.
- Heuristic operates on HTML attributes only — body-text mentions of "captcha" do not trigger.
- `_read_file` unchanged.

## Test plan

- [x] `pytest -m unit -q tests/test_read_skill.py` — 39 passed
- [x] `pytest -m unit -q` — 247 passed
- [x] Targeted nightly run 387 — anomaly cleared, score +0.015
- [ ] Full nightly post-merge to confirm no regression on other scenarios (low risk; heuristic only triggers on captcha widget HTML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)