### PR TITLE
fix(prompt): line-level relevance filter on pre_act memory seed

### DIFF
--- a/backend/services/user_message_processor.py
+++ b/backend/services/user_message_processor.py
@@ -23,6 +23,7 @@ callback, and getSystemPrompt() override.
 """
 
 import logging
+import re
 import threading
 from collections.abc import Callable
 
@@ -71,6 +72,52 @@ def _fire_lazy_synthesis() -> None:
 
     threading.Thread(target=_run, daemon=True, name="user-summary-lazy").start()
     logger.info("[USER MSG] Lazy synthesis daemon spawned")
+
+
+_RESULTS_RE = re.compile(r'results=\d+')
+
+
+def _filter_seed_to_high_relevance(block: str) -> 'str | None':
+    """Return a rebuilt memory block containing only relevance:high lines.
+
+    Parses the [memory(...)] / [end:memory] block produced by MemoryAbility.
+    Keeps only body lines that contain 'relevance:high'. Rewrites the header's
+    results=N to match the kept count. Returns None when:
+      - the block is malformed (missing header or footer), or
+      - zero relevance:high lines remain after filtering.
+
+    This is a consumer-side filter applied after recall — it does not change
+    retrieval radius, relevance bands, or anything in memory.py.
+    """
+    if not block:
+        return None
+
+    lines = block.splitlines()
+    if not lines:
+        return None
+
+    header = lines[0]
+    if not header.startswith('[memory('):
+        return None
+
+    # Footer must be the last non-empty line
+    footer_idx = None
+    for i in range(len(lines) - 1, -1, -1):
+        if lines[i].strip():
+            footer_idx = i
+            break
+
+    if footer_idx is None or lines[footer_idx].strip() != '[end:memory]':
+        return None
+
+    body_lines = lines[1:footer_idx]
+    high_lines = [ln for ln in body_lines if 'relevance:high' in ln]
+
+    if not high_lines:
+        return None
+
+    new_header = _RESULTS_RE.sub(f'results={len(high_lines)}', header)
+    return '\n'.join([new_header] + high_lines + [lines[footer_idx]])
 
 
 class UserMessageProcessor(MessageProcessor):
@@ -362,9 +409,17 @@ class UserMessageProcessor(MessageProcessor):
         # error (`error=...`) header args yield blocks that add noise without
         # value. Inspect only the opener line so a body containing the literal
         # substring `results=0` or `error=` cannot suppress a valid seed.
+        # After the early-out guard, apply a line-level relevance filter: keep
+        # only `relevance:high` body lines and rewrite the header count. This
+        # prevents low/medium cross-scenario contamination from reaching the
+        # prompt while leaving the block present whenever high-confidence hits
+        # exist. (Materially different from the cycle-32 whole-block boolean
+        # gate which was reverted on rc-0.4.0.)
         header = block.split('\n', 1)[0] if block else ''
         if block and 'results=0' not in header and 'error=' not in header:
-            self._memory_seed = block
+            filtered = _filter_seed_to_high_relevance(block)
+            if filtered is not None:
+                self._memory_seed = filtered
 
         if self._uid is None:
             logger.warning(

--- a/backend/tests/test_pre_act_seed_filter.py
+++ b/backend/tests/test_pre_act_seed_filter.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Dylan Grech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Unit tests for _filter_seed_to_high_relevance in user_message_processor.
+
+Verifies line-level relevance filtering of the pre_act memory seed block.
+Only relevance:high body lines are retained; the header results=N is rewritten
+to match the kept count. The block is dropped (returns None) when zero
+high-relevance lines survive or the block is structurally malformed.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _filter(block: str):
+    from services.user_message_processor import _filter_seed_to_high_relevance
+    return _filter_seed_to_high_relevance(block)
+
+
+class TestFilterSeedToHighRelevance:
+    """Tests for the line-level relevance filter applied in pre_act()."""
+
+    def test_all_high_passthrough(self):
+        """Three relevance:high lines all survive; results count stays 3."""
+        block = (
+            "[memory(query=test, results=3)]\n"
+            "[id:key1,relevance:high] fact one\n"
+            "[id:key2,relevance:high] fact two\n"
+            "[id:key3,relevance:high] fact three\n"
+            "[end:memory]"
+        )
+        result = _filter(block)
+
+        assert result is not None
+        lines = result.splitlines()
+        assert lines[0] == "[memory(query=test, results=3)]"
+        assert lines[-1] == "[end:memory]"
+        assert "[id:key1,relevance:high] fact one" in result
+        assert "[id:key2,relevance:high] fact two" in result
+        assert "[id:key3,relevance:high] fact three" in result
+        assert "results=3" in lines[0]
+
+    def test_mixed_keeps_only_high(self):
+        """Only the relevance:high line survives from a mixed block; results=1."""
+        block = (
+            "[memory(query=test, results=3)]\n"
+            "[id:key1,relevance:high] important fact\n"
+            "[id:key2,relevance:medium] meh fact\n"
+            "[id:key3,relevance:low] weak fact\n"
+            "[end:memory]"
+        )
+        result = _filter(block)
+
+        assert result is not None
+        lines = result.splitlines()
+        assert "results=1" in lines[0]
+        assert "[id:key1,relevance:high] important fact" in result
+        assert "relevance:medium" not in result
+        assert "relevance:low" not in result
+
+    def test_all_low_returns_none(self):
+        """A block with no relevance:high lines must return None."""
+        block = (
+            "[memory(query=test, results=2)]\n"
+            "[id:key1,relevance:medium] medium fact\n"
+            "[id:key2,relevance:low] low fact\n"
+            "[end:memory]"
+        )
+        assert _filter(block) is None
+
+    def test_malformed_missing_footer_returns_none(self):
+        """A block missing [end:memory] is malformed and must return None."""
+        block = (
+            "[memory(query=test, results=1)]\n"
+            "[id:key1,relevance:high] some fact\n"
+        )
+        assert _filter(block) is None
+
+    def test_empty_string_returns_none(self):
+        """Empty input must return None without raising."""
+        assert _filter("") is None
+
+    def test_results_count_rewritten_correctly(self):
+        """results=N in header is rewritten to match the number of kept lines."""
+        block = (
+            "[memory(query=weather, results=5)]\n"
+            "[id:a,relevance:high] sunny\n"
+            "[id:b,relevance:low] rainy\n"
+            "[id:c,relevance:high] cloudy\n"
+            "[id:d,relevance:medium] windy\n"
+            "[id:e,relevance:high] foggy\n"
+            "[end:memory]"
+        )
+        result = _filter(block)
+
+        assert result is not None
+        header = result.splitlines()[0]
+        assert "results=3" in header
+        assert "results=5" not in header


### PR DESCRIPTION
## Why

Run 385 (rc-0.5.1, 46 scenarios) showed three WARN scenarios driven by **cross-scenario contamination** of the pre_act memory seed:

- **051 Search tool** — WARN 0.671
- **025 Memory recall** — WARN 0.603
- **032 Memory dynamic radius** — WARN 0.633

The pre_act memory seed (`UserMessageProcessor.pre_act()`) calls `memory.recall` every turn and injects the result block verbatim into the prompt. The block body is `[id:KEY,relevance:high|medium|low] text` lines. Today the only filter is "block has any results and isn't an error" — low/medium-relevance rows from prior scenarios get injected and the model weaves them into responses despite current-turn tools succeeding.

## Change

Line-level filter added at the pre_act consumer side (single chokepoint, no recall-side change):

- New module-level helper `_filter_seed_to_high_relevance(block) -> str | None`
- Drop body lines that don't contain `relevance:high`
- Rewrite `results=N` in the header to the kept-line count
- If zero high lines remain → leave `self._memory_seed = None` (the prompt section is omitted)

Radius, bands, recall scoring untouched.

## Differentiation from cycle 32 (banned)

Cycle 32 was a whole-block boolean gate that suppressed the seed entirely if `relevance:high` was absent anywhere. Reverted on rc-0.4.0 because the XML/Qwen-sentinel tool-format codepath relied on the seed's narrative shape for tool-format calibration. That codepath was removed on rc-0.5.1 (commit 02c951c, native tool calling only). This filter is line-level — block stays present whenever at least one high line survives — and runs on a branch where the calibration concern is structurally absent.

## Run 388 (this branch)

| Scenario | Run 385 | Run 388 | Δ |
|----------|---------|---------|---|
| 051 Search tool | 0.671 WARN | **0.895 PASS** | +0.224 |
| 025 Memory recall | 0.603 WARN | 0.615 WARN | +0.012 |
| 032 Memory dynamic radius | 0.633 WARN | **0.709 PASS** | +0.076 |

Two WARN→PASS escalations, zero regressions, average +0.104.

## Tests

`backend/tests/test_pre_act_seed_filter.py` — 6 unit tests on `_filter_seed_to_high_relevance`: all-high passthrough, mixed keep, all-low → None, malformed → None, empty → None, results-count rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)