### PR TITLE
prompt: prefer general knowledge for static facts

### DIFF
--- a/backend/services/system_message_prompt.py
+++ b/backend/services/system_message_prompt.py
@@ -97,7 +97,8 @@ Guiding framework for all interactions (internalize, do not recite):
 5. **Never fabricate tool results.** If you did not call a tool — or a call returned an error — do not pretend the action succeeded. Only reference information from actual tool results in this conversation.
 6. **Use code for math.** If a request requires calculation (e.g., mortgage, interest, percentages), use the `code_eval` tool. Do not perform complex arithmetic inline.
 7. **Avoid tool use for simple acknowledgments.** Do not invoke tools for messages like "thanks", "got it", or "ok".
-8. **Handle ambiguity with search.** If a user's request is ambiguous (e.g., "check my schedule" when multiple calendars exist), use `memory` or other tools to disambiguate before finalizing an action.
+8. **Answer from general knowledge for static facts.** When a question is about static, well-known information that no API plausibly covers (geography of other planets, definitions, scientific basics, historical facts), respond directly from your training rather than spawning a subagent or web search. Reach for tools only when the answer requires fresh data, personal context, or specific computation.
+9. **Handle ambiguity with search.** If a user's request is ambiguous (e.g., "check my schedule" when multiple calendars exist), use `memory` or other tools to disambiguate before finalizing an action.
 
 ────────────────────────────────
 


### PR DESCRIPTION
## Summary

Adds operational principle 8 to the unified system prompt instructing Chalie to answer questions about static, well-known information (other planets, definitions, scientific basics, historical facts) directly from training rather than spawning a subagent or web search.

## Why

Nightly scenario 056 (\"Tool error — graceful fallback for impossible location\") scored **0.640 (WARN)** in run 406. The user asked *\"What is the weather on the surface of Mars right now?\"* and Chalie spawned a 50-second \`[subagent(prompt=\"Search for the most recent weather data from Mars...\")]\` web_surfer chain.

Judge diagnostic verbatim:

> The system prompt should guide the model to recognize that weather tools are Earth-specific and to gracefully explain limitations without resorting to expensive web searches.
>
> Anomalies: Unnecessary web surfer subagent invocation; Extremely high latency (50s) for a simple chat query; No weather skill attempted; fallback not demonstrated.

## Result

Targeted re-run on this branch:

| Scenario | Baseline (run 406) | This branch (run 417) | Δ |
|---|---|---|---|
| 056 — Tool error fallback | 0.640 (WARN) | **0.865 (PASS)** | +0.225 |
| 041 — Find tools skill | 0.625 (WARN) | ERROR* | n/a |

*041 ERROR is a judge-side Ollama 503 (\"Server overloaded\"), unrelated to the change. Steps 1, 3, 4 all passed mechanically.

## Test plan
- [x] Scenario 056 passes on improve branch (run 417, 0.865)
- [ ] No regressions across full nightly (next scheduled run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)