### PR TITLE
prompt(dmn): add convergence hint to bound tick latency

### DIFF
--- a/backend/services/system_message_prompt.py
+++ b/backend/services/system_message_prompt.py
@@ -139,7 +139,11 @@ The user has provided with a synthesis about themselves under `About the User` a
 ## How to ACT
 
 * Use the supplied tools to learn more topics the user discusses so that the next time they discuss such a topic you are aware of latest news, research, etc... You can use the `news`, `search` and `browser` tools for this. Save your findings using the `memory` tool so that you can reference them later.
-* Analyse patterns where the user seemed genuinely satisfied or dissatisfied with your responses or approach and store feedback to not repeat the same mistakes or reinforce good behaviour. Use the `memory` tool for this.\
+* Analyse patterns where the user seemed genuinely satisfied or dissatisfied with your responses or approach and store feedback to not repeat the same mistakes or reinforce good behaviour. Use the `memory` tool for this.
+
+## When to stop
+
+Aim for 2–3 substantive findings per tick — quality over quantity. Once you have saved meaningful insights via the `memory` tool, conclude with a brief one-line summary of what you saved. Do not pad with redundant tool calls or speculative topics.\
 """
 
 


### PR DESCRIPTION
## Why

Scenario 104 (run 406) and scenario 122 (run 416) — both gating the rc-0.6.0 DMN-into-Subconscious masterplan — were failing because the synchronous `/api/probe/subconscious/tick` request handler was hitting harness `ReadTimeout` budgets. Step 5 of each scenario fires `SubconsciousWorker._tick()` which runs five LLM-driven steps in sequence, the heaviest being `_step_dmn` (full DMNMessageProcessor ACT loop, MAX_ITERATIONS=15) and `_step_synthesis` (UserSummaryProcessor ACT loop).

Trace evidence:
- Run 406 / scenario 104 step-5: `ReadTimeout after 600s on POST /api/probe/subconscious/tick`
- Run 416 / scenario 122 step-5: `status_code: None` — harness `requests.ReadTimeout` at 300s

The DMN system prompt (`DMNSystemMessagePrompt._SYSTEM_PROMPT`) had two open-ended ACT bullets ("learn more topics", "analyse patterns") and **no termination signal**. The model had no reason to stop short of the 15-iteration ceiling, so each tick drifted toward worst-case latency.

## Change

Added a `## When to stop` section to the DMN system prompt: aim for 2–3 substantive findings per tick, conclude with a one-line summary of what was saved via the `memory` tool, no padding with redundant tool calls.

Single file, +5/-1 lines.

## Result (pipeline run 420)

| Scenario | Before | After | Targeted anomaly |
|---|---|---|---|
| 104-user-summary-synthesis | FAIL 0.37 | **PASS 0.785** | step-5 ReadTimeout → cleared (\"Synthesis step completed successfully\") |
| 122-subconscious-tick-orchestration | WARN 0.408 | **WARN 0.646** | step-5 ReadTimeout → cleared (latency 0.5, no timeout) |

Judge diagnostic on scenario 104 step 5 (post-fix):
> Synthesis step completed successfully.

Judge diagnostic on scenario 122 step 5 (post-fix):
> The tick response dict has steps in wrong order: dmn appears before pattern_match and synthesis.

The 122 residual WARN is unrelated to this change — it's the Flask `jsonify` alphabetical-key-sort issue tracked by chalie-ai/chalie-nightly-test PR #778 (cycle 155, not yet merged). DMN itself ran and produced 17 new data_graph rows on time.

## Why this isn't risky

- Prompt-only change. No code behaviour modified, no tools, no schema.
- DMN's `MAX_ITERATIONS=15` cap and the 5-step worker loop are unchanged — this just nudges the model toward early convergence on routine ticks.
- Anomaly inversion (under-thinking): if DMN saved 0 findings, scenario 122 step-7 ("DMN produced ≥1 new data_graph row") would FAIL. Run 420 step-7 PASS 0.925 with 17 rows confirms the model still does substantive work.

## Cycle 162 / improve-chalie

Generated by the `/improve-chalie` cycle skill.