### PR TITLE
fix(file-tags): gate recent-upload fallback on content presence, not status

### DIFF
--- a/backend/api/websocket.py
+++ b/backend/api/websocket.py
@@ -269,17 +269,6 @@ def _resolve_image_tag(svc, image_id: str, deadline: float, request_id: str) -> 
     return f"[image id={image_id} status=timeout]"
 
 
-def _format_ready_upload_tag(svc, doc_id: str, original_name: str, fallback_text: str, source_type: str) -> str:
-    """Format the tag for a ready recent-upload. Re-reads for the final committed row."""
-    final = svc.get_document(doc_id) or {}
-    if source_type == 'chat_image':
-        return _image_ocr_tag(final, doc_id)
-    final_text = (final.get('clean_text') or fallback_text or '').strip()
-    if final_text:
-        return f"[document id={doc_id} name={original_name} content={final_text[:2000]}]"
-    return f"[document id={doc_id} name={original_name} content=<empty>]"
-
-
 def _fetch_recent_upload_row(db):
     """SELECT the most recent upload/chat_image within the last 120 seconds."""
     with db.connection() as conn:
@@ -299,13 +288,17 @@ def _fetch_recent_upload_row(db):
 def _resolve_recent_upload(db, svc, request_id: str):
     """Return (tag, doc_id_if_injected) for the recent-upload fallback, or (None, None).
 
-    Only fires when the most recent upload is already 'ready' at lookup time.
-    The fallback exists to cover paste/drop where the chat turn races the
-    upload XHR — that race is sub-second, so anything still in-flight after
-    the row appears here is far more likely to be a stale upload from earlier
-    in the conversation than the user's intent for *this* turn. Injecting a
-    `status=timeout` or `status=failed` tag in that case derails the model
-    into apologising about a missing attachment the user never made.
+    Inject only when extracted content is *actually available* — i.e. the
+    document has clean_text, or (for chat_image) extracted_metadata.ocr_text.
+    The previous behaviour polled an in-flight upload for 10 s and then
+    injected ``[document id=… status=timeout]`` (or ``status=failed``) when it
+    could not reach a terminal state, which derailed the model into
+    apologising about a missing attachment the user never sent — see nightly
+    scenario 060 step-6 in run 425.
+
+    A content-presence check is more robust than a status check: chat_image
+    writes ``extracted_metadata`` before flipping ``status`` to ``'ready'``, so
+    a status-only gate races OCR completion in scenario 062.
     """
     try:
         row = _fetch_recent_upload_row(db)
@@ -315,10 +308,18 @@ def _resolve_recent_upload(db, svc, request_id: str):
     if not row:
         return None, None
 
-    doc_id, original_name, doc_status, clean_text, source_type = row
-    if doc_status != 'ready':
+    doc_id, original_name, _doc_status, clean_text, source_type = row
+    final = svc.get_document(doc_id) or {}
+    if source_type == 'chat_image':
+        ocr = (_parse_meta(final.get('extracted_metadata')).get('ocr_text') or '').strip()
+        if not ocr:
+            return None, None
+        return _image_ocr_tag(final, doc_id), doc_id
+
+    final_text = (final.get('clean_text') or clean_text or '').strip()
+    if not final_text:
         return None, None
-    return _format_ready_upload_tag(svc, doc_id, original_name, clean_text, source_type), doc_id
+    return f"[document id={doc_id} name={original_name} content={final_text[:2000]}]", doc_id
 
 
 def _resolve_file_tags(image_ids: list, request_id: str) -> list:

--- a/backend/api/websocket.py
+++ b/backend/api/websocket.py
@@ -297,8 +297,16 @@ def _fetch_recent_upload_row(db):
 
 
 def _resolve_recent_upload(db, svc, request_id: str):
-    """Return (tag, doc_id_if_injected) for the recent-upload fallback, or (None, None)."""
-    import time as _time
+    """Return (tag, doc_id_if_injected) for the recent-upload fallback, or (None, None).
+
+    Only fires when the most recent upload is already 'ready' at lookup time.
+    The fallback exists to cover paste/drop where the chat turn races the
+    upload XHR — that race is sub-second, so anything still in-flight after
+    the row appears here is far more likely to be a stale upload from earlier
+    in the conversation than the user's intent for *this* turn. Injecting a
+    `status=timeout` or `status=failed` tag in that case derails the model
+    into apologising about a missing attachment the user never made.
+    """
     try:
         row = _fetch_recent_upload_row(db)
     except Exception as e:
@@ -308,17 +316,9 @@ def _resolve_recent_upload(db, svc, request_id: str):
         return None, None
 
     doc_id, original_name, doc_status, clean_text, source_type = row
-    if doc_status not in ('ready', 'failed'):
-        doc_status = _poll_until_terminal(svc, doc_id, _time.monotonic() + 10.0)
-
-    tag_kind = 'image' if source_type == 'chat_image' else 'document'
-    if doc_status == 'ready':
-        return _format_ready_upload_tag(svc, doc_id, original_name, clean_text, source_type), doc_id
-    if doc_status == 'failed':
-        logger.warning(f"[WS] file_tags recent upload failed doc_id={doc_id} source_type={source_type} request_id={request_id}")
-        return f"[{tag_kind} id={doc_id} status=failed]", None
-    logger.warning(f"[WS] file_tags recent upload timed out doc_id={doc_id} source_type={source_type} status={doc_status} request_id={request_id}")
-    return f"[{tag_kind} id={doc_id} status=timeout]", None
+    if doc_status != 'ready':
+        return None, None
+    return _format_ready_upload_tag(svc, doc_id, original_name, clean_text, source_type), doc_id
 
 
 def _resolve_file_tags(image_ids: list, request_id: str) -> list:

--- a/backend/tests/test_file_tags_resolution.py
+++ b/backend/tests/test_file_tags_resolution.py
@@ -319,17 +319,17 @@ def test_empty_image_ids_picks_up_recent_chat_image_document(_ft_db):
 
 
 @pytest.mark.unit
-def test_recent_upload_skipped_when_not_ready(_ft_db):
+def test_recent_upload_skipped_when_no_content(_ft_db):
     """
-    When the most-recent upload is still 'analyzing' (or any non-ready state),
-    the recent-upload fallback must inject NO tag at all — not a
-    `status=timeout` tag, not a `status=failed` tag, nothing.
+    Recent-upload fallback must inject no tag when the most-recent upload
+    has no extracted content yet (clean_text is empty / NULL).
 
     Regression for nightly scenario 060 step-6: the user typed an unrelated
     chat turn after uploading a document earlier in the conversation; the
     fallback fired on the still-analyzing row and injected
     `[document id=... status=timeout]`, which derailed the model into
     apologising about a missing attachment the user never made for that turn.
+    Skipping silently when content is missing keeps the prompt clean.
     """
     _, seed_conn = _ft_db
     _insert_doc(
@@ -370,3 +370,31 @@ def test_recent_upload_skipped_when_failed(_ft_db):
     tags = _resolve_file_tags([], "req-007")
 
     assert tags == []
+
+
+@pytest.mark.unit
+def test_recent_chat_image_injects_when_ocr_present_even_if_status_not_ready(_ft_db):
+    """
+    chat_image documents have extracted_metadata.ocr_text written *before*
+    `status` flips to 'ready' (see api/chat_image.py:_run_analysis).  The
+    fallback must inject the OCR tag as soon as that content is available,
+    not wait for the status field to catch up.
+
+    Regression for nightly scenario 062 step-4: a status-only gate raced
+    OCR completion and dropped the OCR tag, causing the model to hallucinate
+    instead of citing the image text.
+    """
+    _, seed_conn = _ft_db
+    _insert_doc(
+        seed_conn,
+        "img00099",
+        source_type="chat_image",
+        status="analyzing",
+        extracted_metadata={"ocr_text": "HELLO CHALIE 2040", "has_text": True},
+    )
+
+    tags = _resolve_file_tags([], "req-008")
+
+    assert len(tags) == 1
+    assert tags[0].startswith("[image id=img00099 ocr=")
+    assert "HELLO CHALIE 2040" in tags[0]

--- a/backend/tests/test_file_tags_resolution.py
+++ b/backend/tests/test_file_tags_resolution.py
@@ -316,3 +316,57 @@ def test_empty_image_ids_picks_up_recent_chat_image_document(_ft_db):
     assert len(tags) == 1
     assert tags[0].startswith("[image id=img00003 ocr=")
     assert "Meeting notes: action items" in tags[0]
+
+
+@pytest.mark.unit
+def test_recent_upload_skipped_when_not_ready(_ft_db):
+    """
+    When the most-recent upload is still 'analyzing' (or any non-ready state),
+    the recent-upload fallback must inject NO tag at all — not a
+    `status=timeout` tag, not a `status=failed` tag, nothing.
+
+    Regression for nightly scenario 060 step-6: the user typed an unrelated
+    chat turn after uploading a document earlier in the conversation; the
+    fallback fired on the still-analyzing row and injected
+    `[document id=... status=timeout]`, which derailed the model into
+    apologising about a missing attachment the user never made for that turn.
+    """
+    _, seed_conn = _ft_db
+    _insert_doc(
+        seed_conn,
+        "doc00099",
+        source_type="upload",
+        original_name="report.pdf",
+        mime_type="application/pdf",
+        status="analyzing",
+        clean_text=None,
+    )
+
+    tags = _resolve_file_tags([], "req-006")
+
+    assert tags == []
+
+
+@pytest.mark.unit
+def test_recent_upload_skipped_when_failed(_ft_db):
+    """
+    Recent-upload fallback must not emit a `status=failed` tag either.
+    Same reasoning as the not-ready case: the user did not attach anything
+    for THIS turn — they merely have a failed upload from earlier in the
+    conversation, and surfacing it as if it were the user's intent for the
+    current turn produces incoherent model behaviour.
+    """
+    _, seed_conn = _ft_db
+    _insert_doc(
+        seed_conn,
+        "doc00098",
+        source_type="upload",
+        original_name="report.pdf",
+        mime_type="application/pdf",
+        status="failed",
+        clean_text=None,
+    )
+
+    tags = _resolve_file_tags([], "req-007")
+
+    assert tags == []


### PR DESCRIPTION
## Summary

`_resolve_recent_upload` polled an in-flight upload for 10 s and then injected `[document id=… status=timeout]` (or `status=failed`) when it could not reach a terminal state. The fallback exists to cover the paste/drop race where the chat turn beats the upload XHR by under a second; once a row appears in this lookup in any state other than terminal-with-content, it is far more likely to be a stale upload from earlier in the conversation than the user's intent for *this* turn — and the misleading status tag tells the model "the user attached something that failed," derailing the response.

Switch the gate from `status` to **content presence**: inject only when `clean_text` is non-empty (uploads) or `extracted_metadata.ocr_text` is non-empty (chat_image). Drop the polling and the misleading status tags. A status-only gate raced OCR completion in `chat_image` (extracted_metadata is written before status flips to `'ready'`); a content-presence gate side-steps the race.

## Smoking gun (run 425, scenario 060 step-6, FAIL composite=0.0)

User: *Search my documents for information about coral bleaching* — no attachment.

Model: *I would be happy to read that for you, but it seems the image didn't quite make the trip. The system is flagging a timeout…*

Metrics: `file_tags_wait: 10401 ms` — the heuristic polled the in-flight row to its 10 s deadline, then injected `[document id=… status=timeout]`.

## Targeted-scenario results (run 428 vs run 425 baseline)

| scenario | run 425 | run 428 | targeted-step delta |
|---|---|---|---|
| 060-document-lifecycle | PASS 0.778 | **PASS 0.886** | step-6: 0.0 → **0.82** |
| 063-pdf-upload-and-context | FAIL 0.165 | **PASS 0.903** | side-benefit: clean fallback no longer derails |
| 062-image-upload-and-context | WARN 0.522 | FAIL 0.24 | step-4: 0.045 → 0.255 (model now hallucinates instead of timeout-apologising — file_tags inject correctly; aggregate dropped because run 425's step-5 PASS was a bogus transcript match from prior nightly state, not a real fix) |

Targeted anomaly (060 step-6) is gone. 062 aggregate dropped on lost prior-state contamination, but its file_tags hot path improved.

## Test plan

- [x] `tests/test_file_tags_resolution.py::test_recent_upload_skipped_when_no_content` — analyzing/empty → no tag.
- [x] `tests/test_file_tags_resolution.py::test_recent_upload_skipped_when_failed` — failed → no tag.
- [x] `tests/test_file_tags_resolution.py::test_recent_chat_image_injects_when_ocr_present_even_if_status_not_ready` — chat_image race → still injects OCR.
- [x] Existing 5 tests still pass.
- [x] Targeted nightly run #428 on `improve/recent-upload-ready-only-…` — 060/063 PASS; 062 step-4 improved (see table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
