### PR TITLE
fix(output): exclude response events from notifications:recent catch-up

### DIFF
--- a/backend/services/output_service.py
+++ b/backend/services/output_service.py
@@ -143,12 +143,21 @@ class OutputService:
             # Buffer for catch-up: events published during a brief drift stream
             # reconnect gap are permanently lost from pub/sub. Push to a list so
             # the stream endpoint can drain missed events on next connect.
-            try:
-                self.store.rpush(_KEY_NOTIFICATIONS_RECENT, event_payload)
-                self.store.ltrim(_KEY_NOTIFICATIONS_RECENT, -200, -1)
-                self.store.expire(_KEY_NOTIFICATIONS_RECENT, 86400)  # 24h TTL
-            except Exception as e:
-                logger.warning(f"Notification buffer push failed: {e}")
+            #
+            # Response events are explicitly excluded: they are already persisted
+            # as transcript rows and replayed via /conversation/recent on every
+            # reconnect. Parking them here too causes stale response payloads to
+            # leak into subsequent turns when a new WS connection drains the
+            # buffer (nightly 105 step-5 / step-12 duplicate output_id bug).
+            # Only reminders, tasks, notifications, escalations, and cards —
+            # which have no transcript replay path — belong in this buffer.
+            if event_type != 'response':
+                try:
+                    self.store.rpush(_KEY_NOTIFICATIONS_RECENT, event_payload)
+                    self.store.ltrim(_KEY_NOTIFICATIONS_RECENT, -200, -1)
+                    self.store.expire(_KEY_NOTIFICATIONS_RECENT, 86400)  # 24h TTL
+                except Exception as e:
+                    logger.warning(f"Notification buffer push failed: {e}")
 
         logger.info(
             f"Enqueued TEXT output {output_id} for topic '{_channel}' "

--- a/backend/tests/test_output_service.py
+++ b/backend/tests/test_output_service.py
@@ -95,8 +95,9 @@ class TestOutputService:
         assert "output:events" in channels
 
     def test_enqueue_text_without_sse_uuid_buffers_to_notifications(self, service, mock_store):
-        """Background text is pushed to notifications:recent for catch-up."""
-        metadata = {"source": "proactive"}
+        """Background text with a non-response event type is pushed to notifications:recent."""
+        # 'reminder' maps to event_type='reminder' — should be buffered
+        metadata = {"source": "reminder"}
 
         with patch('api.push.send_push_to_all'):
             service.enqueue_text("topic-1", "Drift", "UNIFIED", 0.8, 0.3, metadata)
@@ -223,7 +224,8 @@ class TestOutputService:
 
     def test_notifications_list_trimmed_to_200(self, service, mock_store):
         """After rpush to notifications:recent, ltrim keeps only the last 200."""
-        metadata = {"source": "proactive"}
+        # 'reminder' maps to event_type='reminder' — eligible for buffering
+        metadata = {"source": "reminder"}
 
         # Pre-populate with 250 items so the trim is verifiable by state
         for i in range(250):
@@ -234,3 +236,47 @@ class TestOutputService:
 
         recent = mock_store.lrange("notifications:recent", 0, -1)
         assert len(recent) <= 200
+
+    # ------------------------------------------------------------------ #
+    # notifications:recent — response events must NOT be buffered
+    # ------------------------------------------------------------------ #
+
+    def test_response_source_not_buffered_in_notifications(self, service, mock_store):
+        """
+        Background outputs whose event_type resolves to 'response' must NOT be
+        pushed to notifications:recent.
+
+        subagent_return is not in source_type_map so it defaults to 'response'.
+        Parking response payloads in the catch-up buffer causes stale events to
+        leak into subsequent WS turns (nightly 105 step-5 / step-12 bug).
+        """
+        with patch('api.push.send_push_to_all'):
+            service.enqueue_text(
+                "topic-1",
+                "subagent result",
+                "UNIFIED",
+                1.0,
+                0.0,
+                original_metadata={"source": "subagent_return"},
+            )
+
+        recent = mock_store.lrange("notifications:recent", 0, -1)
+        assert len(recent) == 0
+
+    def test_task_source_is_buffered_in_notifications(self, service, mock_store):
+        """
+        Background outputs whose event_type resolves to 'task' MUST be pushed
+        to notifications:recent — they have no transcript replay path.
+        """
+        with patch('api.push.send_push_to_all'):
+            service.enqueue_text(
+                "topic-1",
+                "task complete",
+                "UNIFIED",
+                1.0,
+                0.0,
+                original_metadata={"source": "task"},
+            )
+
+        recent = mock_store.lrange("notifications:recent", 0, -1)
+        assert len(recent) > 0


### PR DESCRIPTION
## Summary

`OutputService.enqueue_text()` was buffering background `response` events into the
`notifications:recent` catch-up list. Those entries are then `lpop`'d by every new
WebSocket connection (`backend/api/websocket.py:117–129`), causing stale assistant
responses to re-emit as the *first* event of subsequent chat turns.

Smoking gun — nightly **scenario 105** (`test_run_id=9576`, full nightly run 451):
- Step-5 first event (seq 308): `output_id=d62c0654-2a6d-4f2e-a414-b7c011daf2f2`, `type=response`, content *"The recipe from Madhur Jaffrey has been successfully stored as chicken-tikka-masala-recipe.md"*, `generated_at=2026-05-06T07:01:02.896271+00:00`.
- Step-12 first event (seq 319): **identical** `output_id`, content, and `generated_at`.

Judge commentary: *"strange repetition of a previous response segment at the start of the event stream"*. Step-5 quality 0.4, step-12 quality 0.7, scenario score 0.55.

Root cause: subagent stubs return asynchronously via `OutputService.enqueue_proactive(source='subagent_return')`. Because `'subagent_return'` is not in `source_type_map` (line ~103), `event_type` defaults to `'response'`. The background path then pushes that response into `notifications:recent` (24h TTL), where the next WS connection drains it.

Fix: in the `else:` (no-`sse_channel`) branch of `enqueue_text`, gate the `rpush` / `ltrim` / `expire` block with `if event_type != 'response':`. Pubsub `publish('output:events', ...)` is unchanged — live subscribers continue to receive responses in real time. Web-push is unchanged.

Why this is safe: response events are persisted as transcript rows and replayed via `/conversation/recent` on every reconnect — they don't need the background catch-up list. Reminders, tasks, notifications, escalations, and cards (which have no transcript replay) are still buffered.

## Verification

- `pytest -m unit tests/test_output_service.py -q` → 17 passed (2 new tests asserting the gate; 2 existing tests updated to use `source='reminder'` since their original `source='proactive'` resolves to `event_type='response'` and would no longer be buffered under the new rule).
- `ruff check` clean.
- Targeted nightly: baseline run 461 (rc-0.6.0) score 0.55 WARN → improve run 462 (this branch) score 0.55 WARN. Step-5/step-12 quality unchanged in the targeted runs because subagent did not go async at single-scenario load (a known limitation of targeted reproduction). Architectural correctness verified via the unit test; full-load regression visible in nightly run 451 evidence above.

## Test plan
- [x] Unit tests pass (`pytest -m unit tests/test_output_service.py`)
- [x] `ruff check` clean
- [x] Targeted nightly 105 holds at 0.55 (no regression)
- [ ] Next full nightly should show scenario 105 step-12 quality lift from 0.7 → 1.0 once the buffered-catchup half of the leak is closed (step-5 leak is a separate live-pubsub issue not addressed here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)