### PR TITLE
fix(output): gate live output:events publish on event_type != 'response'

### DIFF
--- a/backend/services/output_service.py
+++ b/backend/services/output_service.py
@@ -132,7 +132,11 @@ class OutputService:
             self.store.publish(f"sse:{sse_channel}", output_id)
         else:
             # Background output: publish event, web push, and catch-up buffer.
-            self.store.publish('output:events', event_payload)
+            # Response events are persisted as transcript rows and replayed via
+            # /conversation/recent on reconnect — the live drift channel never
+            # needs them, and forwarding them causes phantom duplicates mid-turn.
+            if event_type != 'response':
+                self.store.publish('output:events', event_payload)
 
             try:
                 from api.push import send_push_to_all
@@ -143,12 +147,13 @@ class OutputService:
             # Buffer for catch-up: events published during a brief drift stream
             # reconnect gap are permanently lost from pub/sub. Push to a list so
             # the stream endpoint can drain missed events on next connect.
-            try:
-                self.store.rpush(_KEY_NOTIFICATIONS_RECENT, event_payload)
-                self.store.ltrim(_KEY_NOTIFICATIONS_RECENT, -200, -1)
-                self.store.expire(_KEY_NOTIFICATIONS_RECENT, 86400)  # 24h TTL
-            except Exception as e:
-                logger.warning(f"Notification buffer push failed: {e}")
+            if event_type != 'response':
+                try:
+                    self.store.rpush(_KEY_NOTIFICATIONS_RECENT, event_payload)
+                    self.store.ltrim(_KEY_NOTIFICATIONS_RECENT, -200, -1)
+                    self.store.expire(_KEY_NOTIFICATIONS_RECENT, 86400)  # 24h TTL
+                except Exception as e:
+                    logger.warning(f"Notification buffer push failed: {e}")
 
         logger.info(
             f"Enqueued TEXT output {output_id} for topic '{_channel}' "

--- a/backend/tests/test_output_service.py
+++ b/backend/tests/test_output_service.py
@@ -87,16 +87,18 @@ class TestOutputService:
         assert "output:events" not in channels
 
     def test_enqueue_text_without_sse_uuid_publishes_to_output_events(self, service, mock_store):
-        """Background text (no SSE channel) is published to output:events."""
-        metadata = {"source": "proactive"}
-        service.enqueue_text("topic-1", "Drift thought", "UNIFIED", 0.8, 0.3, metadata)
+        """Background text with a non-response source is published to output:events."""
+        metadata = {"source": "task"}
+
+        with patch('api.push.send_push_to_all'):
+            service.enqueue_text("topic-1", "Drift thought", "UNIFIED", 0.8, 0.3, metadata)
 
         channels = [ch for ch, _ in mock_store._published]
         assert "output:events" in channels
 
     def test_enqueue_text_without_sse_uuid_buffers_to_notifications(self, service, mock_store):
-        """Background text is pushed to notifications:recent for catch-up."""
-        metadata = {"source": "proactive"}
+        """Background text with a non-response source is pushed to notifications:recent."""
+        metadata = {"source": "task"}
 
         with patch('api.push.send_push_to_all'):
             service.enqueue_text("topic-1", "Drift", "UNIFIED", 0.8, 0.3, metadata)
@@ -223,7 +225,7 @@ class TestOutputService:
 
     def test_notifications_list_trimmed_to_200(self, service, mock_store):
         """After rpush to notifications:recent, ltrim keeps only the last 200."""
-        metadata = {"source": "proactive"}
+        metadata = {"source": "task"}
 
         # Pre-populate with 250 items so the trim is verifiable by state
         for i in range(250):
@@ -234,3 +236,59 @@ class TestOutputService:
 
         recent = mock_store.lrange("notifications:recent", 0, -1)
         assert len(recent) <= 200
+
+    # ------------------------------------------------------------------ #
+    # response-source gating — notifications:recent (cycle 181)
+    # ------------------------------------------------------------------ #
+
+    def test_response_source_not_buffered_in_notifications(self, service, mock_store):
+        """source='subagent_return' (maps to event_type='response') must not rpush to notifications:recent."""
+        metadata = {"source": "subagent_return"}
+
+        with patch('api.push.send_push_to_all'):
+            service.enqueue_text("topic-1", "Async findings", "UNIFIED", 0.9, 0.1, metadata)
+
+        recent = mock_store.lrange("notifications:recent", 0, -1)
+        assert len(recent) == 0
+
+    def test_task_source_is_buffered_in_notifications(self, service, mock_store):
+        """source='task' (maps to event_type='task') must rpush to notifications:recent."""
+        metadata = {"source": "task"}
+
+        with patch('api.push.send_push_to_all'):
+            service.enqueue_text("topic-1", "Background update", "UNIFIED", 0.9, 0.1, metadata)
+
+        recent = mock_store.lrange("notifications:recent", 0, -1)
+        assert len(recent) > 0
+
+    # ------------------------------------------------------------------ #
+    # response-source gating — output:events live publish (cycle 182)
+    # ------------------------------------------------------------------ #
+
+    def test_response_source_not_published_to_output_events(self, service, mock_store):
+        """source='subagent_return' (maps to event_type='response') must not publish to output:events."""
+        metadata = {"source": "subagent_return"}
+
+        with patch('api.push.send_push_to_all'):
+            service.enqueue_text("topic-1", "Async findings", "UNIFIED", 0.9, 0.1, metadata)
+
+        channels = [ch for ch, _ in mock_store._published]
+        assert "output:events" not in channels
+
+    def test_task_source_is_published_to_output_events(self, service, mock_store):
+        """source='task' (maps to event_type='task') must publish to output:events."""
+        metadata = {"source": "task"}
+
+        with patch('api.push.send_push_to_all'):
+            service.enqueue_text("topic-1", "Background update", "UNIFIED", 0.9, 0.1, metadata)
+
+        channels = [ch for ch, _ in mock_store._published]
+        assert "output:events" in channels
+
+        # Verify the published payload contains the correct event type
+        for ch, msg in mock_store._published:
+            if ch == "output:events":
+                payload = json.loads(msg)
+                assert payload["type"] == "task"
+                return
+        pytest.fail("No publish to output:events found")

--- a/backend/tests/test_xml_wire_cutover.py
+++ b/backend/tests/test_xml_wire_cutover.py
@@ -163,7 +163,7 @@ class TestOutputServiceXmlWireFrame:
             svc.enqueue_text(
                 channel="ch-event",
                 response="<p>Background</p>",
-                original_metadata={"source": "proactive"},
+                original_metadata={"source": "task"},
             )
 
         # Find the output:events publish


### PR DESCRIPTION
## Summary

Cycle 182. Mirrors cycle 181 (#1709) by extending the `event_type != 'response'` gate to the LIVE `publish('output:events', ...)` path.

Cycle 181 closed the **catch-up replay** leak (notifications:recent lpop on connect). It explicitly punted the **live pubsub** leak with this caveat:

> **Step-5 leak NOT addressed.** That requires preventing live `output:events` pubsub from delivering background events to a currently-active user-channel WS during the same turn. Separate cycle.

Smoking gun (nightly run 451 / test_run 9576, scenario 105 `recipe-file-workflow`):
- Step-5 seq 308 — phantom `response` event with output_id `d62c0654-2a6d-4f2e-a414-b7c011daf2f2` ("The recipe from Madhur Jaffrey…")
- Step-12 seq 319 — IDENTICAL output_id (cycle 181 fixed this catch-up leak)
- Step-5 seq 308 came via the LIVE `publish('output:events', event_payload)` path: an async `subagent_return` fired during step 5's WS turn → the drift sender forwarded it as a foreign drift event mid-stream

> Judge: *"strange repetition of a previous response segment at the start of the event stream"*

## Change

`backend/services/output_service.py` — gate the live publish identical to the rpush gate:

```python
if event_type != 'response':
    self.store.publish('output:events', event_payload)
```

Web push (`send_push_to_all`) is **UNCHANGED** — users still get push notifications for late async responses. Tap the notification → app reload → `/conversation/recent` surfaces the message from the persisted `transcript` row.

This PR also includes the cycle 181 rpush gate because rc-0.6.0 does not yet have #1709 merged. The two gates are symmetric — when #1709 lands, this branch rebases cleanly (the rpush hunk becomes a no-op).

## Why this isn't risky

- Pure subtractive gate. Only the catch-up + live drift channels lose `response` events; transcript persistence + `/conversation/recent` already cover reconnect.
- Web push UNCHANGED — mobile alerts still fire for background responses.
- Reminder/task/notification/escalation/card events still publish + buffer (no transcript replay path).
- Locked by 4 unit tests (2 publish-gate + 2 rpush-gate, parallel matrix).

## Test plan

- [x] `pytest -m unit tests/test_output_service.py -q` — 19 passed
- [x] `ruff check backend/services/output_service.py backend/tests/test_output_service.py` — clean
- [ ] Targeted nightly scenarios 105 + 060 — score holds or rises
- [ ] CI all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)