### PR TITLE
improve(memory): detect intra-query topic dispersion to fire expand_factor

### DIFF
--- a/backend/abilities/memory.py
+++ b/backend/abilities/memory.py
@@ -9,7 +9,6 @@ import hashlib
 import json
 import logging
 import math
-import re
 from typing import ClassVar, Dict, List, Optional, Tuple
 
 from abilities._base import Ability
@@ -627,14 +626,16 @@ def _compute_expand_factor(
     return min(MemoryAbility.EXPAND_FACTOR_CEILING, max(1.0, factor)), max_drift
 
 
-_QUERY_CLAUSE_SPLITTER = re.compile(r"\s+(?:and|or|but)\s+|[,;?]\s*", re.IGNORECASE)
+_CLAUSE_SEPARATORS = (";", "?", ",")
 
 
 def _split_query_clauses(query: str) -> List[str]:
     if not query:
         return []
-    parts = _QUERY_CLAUSE_SPLITTER.split(query.strip())
-    return [p.strip() for p in parts if p and len(p.strip()) > 10]
+    s = query.strip()
+    for ch in _CLAUSE_SEPARATORS:
+        s = s.replace(ch, "\x00")
+    return [p.strip() for p in s.split("\x00") if len(p.strip()) > 10]
 
 
 def _intra_query_drift(emb_svc, query: str) -> float:
@@ -666,8 +667,6 @@ def _expand_factor_from_drift(drift: float) -> float:
     if drift >= MemoryAbility.EXPAND_MAX_DIST:
         return MemoryAbility.EXPAND_FACTOR_CEILING
     span = MemoryAbility.EXPAND_MAX_DIST - MemoryAbility.EXPAND_MIN_DIST
-    if span <= 0:
-        return MemoryAbility.EXPAND_FACTOR_CEILING
     t = (drift - MemoryAbility.EXPAND_MIN_DIST) / span
     return min(MemoryAbility.EXPAND_FACTOR_CEILING, max(1.0, 1.0 + t * (MemoryAbility.EXPAND_FACTOR_CEILING - 1.0)))
 

--- a/backend/abilities/memory.py
+++ b/backend/abilities/memory.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import logging
 import math
+import re
 from typing import ClassVar, Dict, List, Optional, Tuple
 
 from abilities._base import Ability
@@ -626,6 +627,51 @@ def _compute_expand_factor(
     return min(MemoryAbility.EXPAND_FACTOR_CEILING, max(1.0, factor)), max_drift
 
 
+_QUERY_CLAUSE_SPLITTER = re.compile(r"\s+(?:and|or|but)\s+|[,;?]\s*", re.IGNORECASE)
+
+
+def _split_query_clauses(query: str) -> List[str]:
+    if not query:
+        return []
+    parts = _QUERY_CLAUSE_SPLITTER.split(query.strip())
+    return [p.strip() for p in parts if p and len(p.strip()) > 10]
+
+
+def _intra_query_drift(emb_svc, query: str) -> float:
+    clauses = _split_query_clauses(query)
+    if len(clauses) < 2:
+        return 0.0
+    embeddings = []
+    for c in clauses:
+        try:
+            e = emb_svc.generate_embedding(c)
+            if e:
+                embeddings.append(e)
+        except Exception:
+            continue
+    if len(embeddings) < 2:
+        return 0.0
+    max_d = 0.0
+    for i in range(len(embeddings)):
+        for j in range(i + 1, len(embeddings)):
+            d = _cosine_distance(embeddings[i], embeddings[j])
+            if d > max_d:
+                max_d = d
+    return max_d
+
+
+def _expand_factor_from_drift(drift: float) -> float:
+    if drift <= MemoryAbility.EXPAND_MIN_DIST:
+        return 1.0
+    if drift >= MemoryAbility.EXPAND_MAX_DIST:
+        return MemoryAbility.EXPAND_FACTOR_CEILING
+    span = MemoryAbility.EXPAND_MAX_DIST - MemoryAbility.EXPAND_MIN_DIST
+    if span <= 0:
+        return MemoryAbility.EXPAND_FACTOR_CEILING
+    t = (drift - MemoryAbility.EXPAND_MIN_DIST) / span
+    return min(MemoryAbility.EXPAND_FACTOR_CEILING, max(1.0, 1.0 + t * (MemoryAbility.EXPAND_FACTOR_CEILING - 1.0)))
+
+
 def _embedding_hash(embedding: List[float]) -> str:
     if not embedding:
         return "empty"
@@ -755,6 +801,9 @@ def recall_episodes(
 
         narrow_factor, _min_dist = _compute_narrow_factor(q_embedding, history)
         expand_factor, _max_drift = _compute_expand_factor(q_embedding, history)
+        intra_drift = _intra_query_drift(emb_svc, query)
+        if intra_drift > _max_drift:
+            expand_factor = max(expand_factor, _expand_factor_from_drift(intra_drift))
         input_radius = baseline_radius * narrow_factor * expand_factor
 
         episodes, telemetry = episodic_retrieval_service.retrieve(


### PR DESCRIPTION
## Cycle 188 — surface intra-query topic dispersion in expand_factor (additive)

**Targets scenario 032** (memory-dynamic-radius). Baseline: 0.86 with step-4 deterministic FAIL (8 consecutive runs). Step 4 polls memory_recall_log for ≥1 row with `expand_factor > 1.0` after a multi-topic probe — count is always 0.

## Root cause

For the FIRST turn after reset_thread, `_gather_query_history` populates history with a single seed entry whose query equals the current query. `_compute_expand_factor` measures `cosine_distance(q_emb, q_emb)` = 0.0 → expand_factor stays at 1.0. The controller can sense INTER-query drift across turns, but never INTRA-query topic dispersion within a single multi-topic question.

Judge diagnostic (most recent run): *"The harness executed the database query efficiently to verify the internal state."* Step 4 deterministic 0/1.

## Change

Single file: `backend/abilities/memory.py` (+49 LOC, additive).

1. New helper `_split_query_clauses(query)` — splits on \`and|or|but|,;?\`.
2. New helper `_intra_query_drift(emb_svc, query)` — embeds each clause (≥2 clauses, ≥10 chars) and returns max pairwise cosine distance.
3. New helper `_expand_factor_from_drift(drift)` — same MIN/MAX/CEIL ramp as `_compute_expand_factor`.
4. In `recall_episodes`: after computing inter-query expand_factor, take `max(expand_factor, intra_drift_factor)`.

## Why additive

Deductive doesn't apply — there is no logic to remove. The bug is a missing signal source (intra-query distance), not stale code. Existing inter-query expansion path is unchanged; the patch is purely additive observability of a second signal.