### PR TITLE
fix(episodic): lower super-episode threshold 0.90 -> 0.85

### DIFF
--- a/backend/services/episodic_constants.py
+++ b/backend/services/episodic_constants.py
@@ -6,9 +6,12 @@ them mechanically. Do NOT read these from config/env at import time.
 """
 
 # Pairwise cosine similarity floor for super-episode cluster membership.
-# gte-modernbert packs densely (unrelated English ≈ 0.80-0.85); 0.90 is
-# the "same topic" floor validated by research on that encoder family.
-SUPER_EPISODE_THRESHOLD = 0.90
+# gte-modernbert packs densely (unrelated English ≈ 0.80-0.85). The
+# connected-components clustering only requires *one* edge per chain, so
+# 0.85 catches same-topic discussions that diverge across sub-issues
+# (e.g. one JWT-debugging cluster spanning dotenv ordering, clock drift,
+# and proxy headers) which otherwise stayed isolated at 0.90.
+SUPER_EPISODE_THRESHOLD = 0.85
 
 # Minimum cluster size to fire the SuperEpisodeEncoder LLM call.
 SUPER_EPISODE_MIN_CLUSTER = 3

--- a/backend/tests/test_super_episode_pipeline.py
+++ b/backend/tests/test_super_episode_pipeline.py
@@ -264,7 +264,7 @@ class TestFindSuperCandidates:
 
         from services.episodic_service import find_super_candidates
 
-        # 60° apart → cosine ≈ 0.5, well below 0.90 threshold
+        # 60° apart → cosine ≈ 0.5, well below 0.85 threshold
         self._insert_apex(db, _sim_vec(angle_deg=0.0), gist="ep1")
         self._insert_apex(db, _sim_vec(angle_deg=60.0), gist="ep2")
         self._insert_apex(db, _sim_vec(angle_deg=120.0), gist="ep3")
@@ -327,12 +327,12 @@ class TestFindSuperCandidates:
 
         from services.episodic_service import find_super_candidates
 
-        # A–B cosine ≈ 0.966 (15° apart) → above 0.90
-        # B–C cosine ≈ 0.966 (B at 15°, C at 30°)
-        # A–C cosine ≈ 0.866 (30° apart) → BELOW 0.90
+        # A–B cosine ≈ 0.940 (20° apart) → above 0.85
+        # B–C cosine ≈ 0.940 (B at 20°, C at 40°)
+        # A–C cosine ≈ 0.766 (40° apart) → BELOW 0.85
         a = self._insert_apex(db, _sim_vec(angle_deg=0.0), gist="a")
-        b = self._insert_apex(db, _sim_vec(angle_deg=15.0), gist="b")
-        c = self._insert_apex(db, _sim_vec(angle_deg=30.0), gist="c")
+        b = self._insert_apex(db, _sim_vec(angle_deg=20.0), gist="b")
+        c = self._insert_apex(db, _sim_vec(angle_deg=40.0), gist="c")
 
         clusters = find_super_candidates("ch1")
         # Connected components via A–B and B–C edges → single cluster of 3.


### PR DESCRIPTION
## Summary

Lower `SUPER_EPISODE_THRESHOLD` from 0.90 to 0.85 so connected-components clustering can form chains across sub-topic divergence (same conversation, different angles).

## Evidence

Nightly run 9574 — scenario 103-super-episode-and-apex (rc-0.6.0 baseline 0.835):

- step 7 `/api/probe/subconscious/tick` returned: `"detail": "checked channel=user, no clusters formed"`
- step 9 deterministic `MAX(json_array_length(consolidated_from)) >= 3` → 0
- step 11 deterministic `COUNT consolidated_into IS NOT NULL >= 3` → 0

The 3 JWT-debugging leaves (dotenv ordering, clock drift, nginx proxy headers) are unambiguously the same topic but pairwise cosine under gte-modernbert did not reach 0.90, so `find_super_candidates` returned `[]`.

Judge diagnostic was effectively "the consolidate step ran but no super-episode was emitted."

## Why threshold (deductive)

`92f4ac3` already replaced pairwise-clique with connected-components — i.e. the algorithm was tightened so a *single* chain edge is enough. The 0.90 floor was carried over from the old algorithm and is now over-strict; lowering it is subtractive in spirit (we are unblocking the new algorithm rather than adding logic).

## Test plan

- [x] `pytest -m unit -q tests/test_super_episode_pipeline.py` (18 passed locally)
- [x] Chain-cluster test rotated to angles 0/20/40 deg (A-B and B-C above 0.85, A-C below) so the "B is the bridge" semantics still hold
- [ ] Targeted nightly run 103 on this branch (post-CI)

## CI

Pre-existing flake `test_subagent_ability.py::TestDeliverEnvelopeDiscriminator::test_case_b_fires_when_parent_turn_finished` may show — same flake exists on rc-0.6.0 baseline (see cycle 188 #1715).

🤖 Generated with [Claude Code](https://claude.com/claude-code)