### PR TITLE
fix(docs): populate clean_text for text documents

### DIFF
--- a/backend/services/document_service.py
+++ b/backend/services/document_service.py
@@ -282,6 +282,14 @@ class DocumentService:
             doc_id=doc_id,
         )
 
+        def _set_clean(did=doc_id, txt=text_content, db=self.db):
+            with db.connection() as conn:
+                conn.execute(
+                    "UPDATE documents SET clean_text = ? WHERE id = ?",
+                    (txt, did),
+                )
+        self._write_queue.submit_sync(_set_clean)
+
         logger.info(f"[DOCS] Created text document '{original_name}' (id={doc_id})")
         return doc_id
 


### PR DESCRIPTION
## Summary
- `create_document_from_text` never set `documents.clean_text`, leaving it NULL for all text-created documents
- Added a `_write_queue.submit_sync` UPDATE after the INSERT to populate `clean_text` with the text content
- 8 LOC net addition in `document_service.py`

## Evidence
- **Scenario 092** (`document-artifact-unification`): permanent 0.0 FAIL since May 6 (runs 453, 454, 483, 486)
- **Pipeline 487** (this branch): **1.0 PASS** — `clean_text LIKE '%Kelly%'` matched after document creation
- Root cause: `create_document` INSERT never included `clean_text`; the column stayed NULL

## Judge diagnostic (run 9694)
> "The harness performed the database poll efficiently and verified the record existence without unnecessary iterations or latency."

Step 3 deterministic: 1/1 PASS, composite 1.0.

## Test plan
- [x] 2205 unit tests pass (`pytest -m unit -q`)
- [x] Ruff clean
- [x] CI green
- [x] Pipeline 487 scenario 092 = 1.0 PASS (baseline 0.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)