### PR TITLE
fix(memory): restore schedule search delegation in recall

### DIFF
--- a/backend/abilities/memory.py
+++ b/backend/abilities/memory.py
@@ -306,6 +306,10 @@ def _handle_recall(channel: str, params: dict) -> str:
                     'name': 'document',
                     'input': {'action': 'search', 'query': query},
                 })
+                proc.handleTool({
+                    'name': 'schedule',
+                    'input': {'action': 'search', 'query': query},
+                })
         except Exception as exc:
             logger.warning(f"{LOG_PREFIX} recall delegation failed: {exc}")
 


### PR DESCRIPTION
## Summary

Re-adds the `handleTool` delegation for `schedule` search in `_handle_recall()` that was erroneously removed by commit `6b47e38`.

After a transcript reset, the LLM has no context to call `schedule` directly. The recall delegation is the only path that surfaces scheduled items and records the `tool_call` row that scenario 106 step 6 checks.

**Judge diagnostic (baseline):** "The assistant failed to invoke the 'schedule' tool when asked to recall a plan after a transcript reset, suggesting the memory system did not provide the necessary context to trigger the skill."

## Evidence

- **Baseline (pipeline 492, run 9701):** 106 = 0.68 WARN. Step 6 FAIL — `tool_calls WHERE tool_name='schedule'` = 0.
- **Improve (pipeline 493, run 9702):** 106 = 0.68 WARN. Step 6 **PASS** — `tool_calls WHERE tool_name='schedule'` = 2. Targeted anomaly cleared.
- Step 3 FAIL in improve run is model variance (1 daily-recurrence item vs 6 per-day items) — unrelated to this 4-line recall-path change.
- Cycle 187 (PR #1714) originally proved this: 106 went 0.667→0.987. Commit `6b47e38` reverted it → 0.68.

## Change

+4 lines in `backend/abilities/memory.py` — `handleTool` delegation for `schedule` search, identical pattern to the document delegation above it.

Taskie: TKT-221