### PR TITLE
refactor(memory): consolidate narrow+expand factor compute into single pass

### DIFF
--- a/backend/abilities/memory.py
+++ b/backend/abilities/memory.py
@@ -549,13 +549,18 @@ def _cosine_distance(a: List[float], b: List[float]) -> float:
     return 1.0 - sim
 
 
-def _compute_narrow_factor(
+def _compute_radius_factors(
     q_embedding: List[float], history: List[Dict]
-) -> Tuple[float, float]:
+) -> Tuple[float, float, float, float]:
+    """Single-pass narrow + expand factor computation.
+
+    Returns: (narrow_factor, expand_factor, min_dist, max_drift)
+    """
     if not history:
-        return 1.0, float("inf")
+        return 1.0, 1.0, float("inf"), 0.0
 
     min_dist = float("inf")
+    max_drift = 0.0
     for entry in history:
         emb = entry.get("embedding")
         if not emb:
@@ -563,48 +568,38 @@ def _compute_narrow_factor(
         d = _cosine_distance(q_embedding, emb)
         if d < min_dist:
             min_dist = d
-
-    if min_dist == float("inf") or min_dist >= MemoryAbility.NARROW_MIN_DIST:
-        return 1.0, min_dist
-
-    if min_dist <= MemoryAbility.NARROW_MAX_DIST:
-        return MemoryAbility.NARROW_FACTOR_FLOOR, min_dist
-
-    span = MemoryAbility.NARROW_MIN_DIST - MemoryAbility.NARROW_MAX_DIST
-    if span <= 0:
-        return MemoryAbility.NARROW_FACTOR_FLOOR, min_dist
-    t = (MemoryAbility.NARROW_MIN_DIST - min_dist) / span
-    factor = 1.0 - t * (1.0 - MemoryAbility.NARROW_FACTOR_FLOOR)
-    return max(MemoryAbility.NARROW_FACTOR_FLOOR, min(1.0, factor)), min_dist
-
-
-def _compute_expand_factor(
-    q_embedding: List[float], history: List[Dict]
-) -> Tuple[float, float]:
-    if not history:
-        return 1.0, 0.0
-
-    max_drift = 0.0
-    for entry in history:
-        emb = entry.get("embedding")
-        if not emb:
-            continue
-        d = _cosine_distance(q_embedding, emb)
         if d > max_drift:
             max_drift = d
 
+    # narrow factor
+    if min_dist == float("inf") or min_dist >= MemoryAbility.NARROW_MIN_DIST:
+        narrow_factor = 1.0
+    elif min_dist <= MemoryAbility.NARROW_MAX_DIST:
+        narrow_factor = MemoryAbility.NARROW_FACTOR_FLOOR
+    else:
+        span = MemoryAbility.NARROW_MIN_DIST - MemoryAbility.NARROW_MAX_DIST
+        if span <= 0:
+            narrow_factor = MemoryAbility.NARROW_FACTOR_FLOOR
+        else:
+            t = (MemoryAbility.NARROW_MIN_DIST - min_dist) / span
+            f = 1.0 - t * (1.0 - MemoryAbility.NARROW_FACTOR_FLOOR)
+            narrow_factor = max(MemoryAbility.NARROW_FACTOR_FLOOR, min(1.0, f))
+
+    # expand factor
     if max_drift <= MemoryAbility.EXPAND_MIN_DIST:
-        return 1.0, max_drift
+        expand_factor = 1.0
+    elif max_drift >= MemoryAbility.EXPAND_MAX_DIST:
+        expand_factor = MemoryAbility.EXPAND_FACTOR_CEILING
+    else:
+        span = MemoryAbility.EXPAND_MAX_DIST - MemoryAbility.EXPAND_MIN_DIST
+        if span <= 0:
+            expand_factor = MemoryAbility.EXPAND_FACTOR_CEILING
+        else:
+            t = (max_drift - MemoryAbility.EXPAND_MIN_DIST) / span
+            f = 1.0 + t * (MemoryAbility.EXPAND_FACTOR_CEILING - 1.0)
+            expand_factor = min(MemoryAbility.EXPAND_FACTOR_CEILING, max(1.0, f))
 
-    if max_drift >= MemoryAbility.EXPAND_MAX_DIST:
-        return MemoryAbility.EXPAND_FACTOR_CEILING, max_drift
-
-    span = MemoryAbility.EXPAND_MAX_DIST - MemoryAbility.EXPAND_MIN_DIST
-    if span <= 0:
-        return MemoryAbility.EXPAND_FACTOR_CEILING, max_drift
-    t = (max_drift - MemoryAbility.EXPAND_MIN_DIST) / span
-    factor = 1.0 + t * (MemoryAbility.EXPAND_FACTOR_CEILING - 1.0)
-    return min(MemoryAbility.EXPAND_FACTOR_CEILING, max(1.0, factor)), max_drift
+    return narrow_factor, expand_factor, min_dist, max_drift
 
 
 def _embedding_hash(embedding: List[float]) -> str:
@@ -734,8 +729,7 @@ def recall_episodes(
         proc = current_processor()
         history, turn_uid, transcript_id = _gather_query_history(proc, emb_svc)
 
-        narrow_factor, _min_dist = _compute_narrow_factor(q_embedding, history)
-        expand_factor, _max_drift = _compute_expand_factor(q_embedding, history)
+        narrow_factor, expand_factor, _min_dist, _max_drift = _compute_radius_factors(q_embedding, history)
         input_radius = baseline_radius * narrow_factor * expand_factor
 
         episodes, telemetry = episodic_retrieval_service.retrieve(

--- a/backend/tests/test_memory_radius_factors.py
+++ b/backend/tests/test_memory_radius_factors.py
@@ -1,0 +1,210 @@
+"""Unit tests for _compute_radius_factors — single-pass narrow + expand helper.
+
+Pure function tests: no DB, no LLM, no mocking required.
+"""
+
+import math
+
+import pytest
+
+from abilities.memory import MemoryAbility, _compute_radius_factors
+
+pytestmark = pytest.mark.unit
+
+# Shorthand constants pulled from MemoryAbility so tests stay in sync if
+# the meta-harness tunes the values.
+NARROW_MIN = MemoryAbility.NARROW_MIN_DIST      # 0.25
+NARROW_MAX = MemoryAbility.NARROW_MAX_DIST      # 0.05
+NARROW_FLOOR = MemoryAbility.NARROW_FACTOR_FLOOR  # 0.35
+
+EXPAND_MIN = MemoryAbility.EXPAND_MIN_DIST      # 0.30
+EXPAND_MAX = MemoryAbility.EXPAND_MAX_DIST      # 0.55
+EXPAND_CEIL = MemoryAbility.EXPAND_FACTOR_CEILING  # 2.2
+
+
+def _unit_vec(dim: int, index: int) -> list:
+    """Return a unit vector of length `dim` with 1.0 at `index`."""
+    v = [0.0] * dim
+    v[index] = 1.0
+    return v
+
+
+def _make_entry(embedding) -> dict:
+    return {"embedding": embedding}
+
+
+# ---------------------------------------------------------------------------
+# Empty history
+# ---------------------------------------------------------------------------
+
+def test_empty_history_returns_neutral_factors():
+    q = _unit_vec(4, 0)
+    narrow, expand, min_d, max_d = _compute_radius_factors(q, [])
+    assert narrow == 1.0
+    assert expand == 1.0
+    assert math.isinf(min_d)
+    assert max_d == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Entries with empty / None embeddings are skipped
+# ---------------------------------------------------------------------------
+
+def test_all_empty_embeddings_treated_as_empty_history():
+    q = _unit_vec(4, 0)
+    history = [
+        _make_entry(None),
+        _make_entry([]),
+        _make_entry(None),
+    ]
+    narrow, expand, min_d, max_d = _compute_radius_factors(q, history)
+    assert narrow == 1.0
+    assert expand == 1.0
+    assert math.isinf(min_d)
+    assert max_d == 0.0
+
+
+def test_mixed_valid_and_empty_embeddings_skips_empties():
+    """Valid entries drive the result; None/empty entries are ignored."""
+    q = _unit_vec(4, 0)
+    # orthogonal vector → cosine distance = 1.0 (max)
+    far = _unit_vec(4, 1)
+    history = [
+        _make_entry(None),
+        _make_entry(far),
+        _make_entry([]),
+    ]
+    narrow, expand, min_d, max_d = _compute_radius_factors(q, history)
+    assert min_d == pytest.approx(1.0, abs=1e-9)
+    assert max_d == pytest.approx(1.0, abs=1e-9)
+    # min_dist=1.0 >= NARROW_MIN_DIST → narrow_factor = 1.0
+    assert narrow == 1.0
+    # max_drift=1.0 >= EXPAND_MAX_DIST → expand_factor = EXPAND_CEIL
+    assert expand == EXPAND_CEIL
+
+
+# ---------------------------------------------------------------------------
+# Near-duplicate query → narrow factor floor
+# ---------------------------------------------------------------------------
+
+def test_near_duplicate_returns_narrow_floor():
+    """min_dist <= NARROW_MAX_DIST ⟹ narrow_factor == NARROW_FACTOR_FLOOR."""
+    q = [1.0, 0.0]
+    # Almost identical: tiny perpendicular component
+    tiny = 1e-6
+    norm = math.sqrt(1.0 + tiny ** 2)
+    near = [1.0 / norm, tiny / norm]
+    d = 1.0 - (q[0] * near[0] + q[1] * near[1])
+    assert d <= NARROW_MAX, f"expected near-duplicate distance, got {d}"
+
+    history = [_make_entry(near)]
+    narrow, _, min_d, _ = _compute_radius_factors(q, history)
+    assert min_d == pytest.approx(d, rel=1e-6)
+    assert narrow == NARROW_FLOOR
+
+
+# ---------------------------------------------------------------------------
+# Far-drift query → expand factor ceiling
+# ---------------------------------------------------------------------------
+
+def test_far_drift_returns_expand_ceiling():
+    """max_drift >= EXPAND_MAX_DIST ⟹ expand_factor == EXPAND_FACTOR_CEILING."""
+    q = _unit_vec(4, 0)
+    far = _unit_vec(4, 1)   # orthogonal → distance = 1.0 > EXPAND_MAX (0.55)
+
+    history = [_make_entry(far)]
+    _, expand, _, max_d = _compute_radius_factors(q, history)
+    assert max_d == pytest.approx(1.0, abs=1e-9)
+    assert expand == EXPAND_CEIL
+
+
+# ---------------------------------------------------------------------------
+# Neutral zones → both factors stay at 1.0
+# ---------------------------------------------------------------------------
+
+def test_mid_range_distance_neutral_zone():
+    """Distance in (NARROW_MIN, EXPAND_MIN] → both factors == 1.0."""
+    # Pick a distance between 0.25 and 0.30: e.g. 0.27
+    target_sim = 1.0 - 0.27
+    # Build a 2-D vector with cosine similarity == target_sim to [1,0]
+    # sim = a[0] / |a| → a = [target_sim, sqrt(1 - target_sim^2)]
+    a0 = target_sim
+    a1 = math.sqrt(max(0.0, 1.0 - a0 ** 2))
+    entry_vec = [a0, a1]
+
+    q = [1.0, 0.0]
+    history = [_make_entry(entry_vec)]
+    narrow, expand, min_d, max_d = _compute_radius_factors(q, history)
+    assert min_d == pytest.approx(0.27, abs=1e-6)
+    assert max_d == pytest.approx(0.27, abs=1e-6)
+    assert narrow == 1.0
+    assert expand == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Mixed case: small min_dist AND large max_drift ⟹ floor × ceiling
+# ---------------------------------------------------------------------------
+
+def test_mixed_near_and_far_returns_floor_and_ceiling():
+    """With one near entry and one far entry, get FLOOR and CEILING together."""
+    q = [1.0, 0.0]
+
+    # near: distance ~ 0 (identical)
+    near = [1.0, 0.0]
+
+    # far: orthogonal → distance = 1.0
+    far = [0.0, 1.0]
+
+    history = [_make_entry(near), _make_entry(far)]
+    narrow, expand, min_d, max_d = _compute_radius_factors(q, history)
+
+    assert min_d == pytest.approx(0.0, abs=1e-9)
+    assert max_d == pytest.approx(1.0, abs=1e-9)
+    assert narrow == NARROW_FLOOR
+    assert expand == EXPAND_CEIL
+
+
+# ---------------------------------------------------------------------------
+# Interpolated narrow factor (midpoint check)
+# ---------------------------------------------------------------------------
+
+def test_interpolated_narrow_factor():
+    """Distance midway between NARROW_MAX and NARROW_MIN ⟹ interpolated factor."""
+    mid = (NARROW_MAX + NARROW_MIN) / 2.0  # 0.15
+    a0 = 1.0 - mid
+    a1 = math.sqrt(max(0.0, 1.0 - a0 ** 2))
+    entry_vec = [a0, a1]
+
+    q = [1.0, 0.0]
+    history = [_make_entry(entry_vec)]
+    narrow, _, min_d, _ = _compute_radius_factors(q, history)
+
+    assert min_d == pytest.approx(mid, abs=1e-6)
+    span = NARROW_MIN - NARROW_MAX
+    t = (NARROW_MIN - mid) / span
+    expected = max(NARROW_FLOOR, min(1.0, 1.0 - t * (1.0 - NARROW_FLOOR)))
+    assert narrow == pytest.approx(expected, rel=1e-9)
+    assert NARROW_FLOOR <= narrow <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Interpolated expand factor (midpoint check)
+# ---------------------------------------------------------------------------
+
+def test_interpolated_expand_factor():
+    """Distance midway between EXPAND_MIN and EXPAND_MAX ⟹ interpolated factor."""
+    mid = (EXPAND_MIN + EXPAND_MAX) / 2.0  # 0.425
+    a0 = 1.0 - mid
+    a1 = math.sqrt(max(0.0, 1.0 - a0 ** 2))
+    entry_vec = [a0, a1]
+
+    q = [1.0, 0.0]
+    history = [_make_entry(entry_vec)]
+    _, expand, _, max_d = _compute_radius_factors(q, history)
+
+    assert max_d == pytest.approx(mid, abs=1e-6)
+    span = EXPAND_MAX - EXPAND_MIN
+    t = (mid - EXPAND_MIN) / span
+    expected = min(EXPAND_CEIL, max(1.0, 1.0 + t * (EXPAND_CEIL - 1.0)))
+    assert expand == pytest.approx(expected, rel=1e-9)
+    assert 1.0 <= expand <= EXPAND_CEIL


### PR DESCRIPTION
## Summary
Consolidate `_compute_narrow_factor` + `_compute_expand_factor` into a single `_compute_radius_factors` helper. Mathematically equivalent — single pass over `_memory_query_history` instead of two redundant loops. Net -6 LOC in `backend/abilities/memory.py`.

## Why
Hot path on every recall (pre_act + LLM-invoked `recall`). Two functions iterated the same deque computing min/max distance separately; now a single pass returns both. Pure deductive refactor — no behavioral change.

## Evidence
- 9 deterministic unit tests in `test_memory_radius_factors.py` covering empty history, all-empty embeddings, mixed valid/empty, near-duplicate (floor case), far-drift (ceiling case), neutral zone, mixed floor+ceiling, two interpolated midpoints — all pass.
- Broader memory unit suite (`test_ability_memory.py` + `test_memory_radius_factors.py` + `test_memory_recall_body_format.py`): 15 passed in 147.41s.
- Targeted nightly scenario `030-skill-memory.yaml`:
  - Baseline run 494 (rc-0.6.0): PASS, score 1.0
  - This branch run 495: PASS, score 1.0 (duration 20.2s vs 76.8s)

## Approach
Deductive — mathematical equivalence + single-pass consolidation, removed dead code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)