### PR TITLE
fix(read): preserve dates and URLs in trafilatura extraction

### DIFF
--- a/backend/services/text_extractor.py
+++ b/backend/services/text_extractor.py
@@ -76,7 +76,7 @@ def extract_html(html: str, url: str = None) -> str:
     # 1. trafilatura (primary) — trusts its result regardless of length
     try:
         import trafilatura
-        content = trafilatura.extract(html, url=url, include_comments=False)
+        content = trafilatura.extract(html, url=url, include_comments=False, include_links=True)
         if content and content.strip():
             return content.strip()
     except ImportError:

--- a/backend/tests/test_text_extractor.py
+++ b/backend/tests/test_text_extractor.py
@@ -159,6 +159,19 @@ class TestExtractHtml:
             result = te.extract_html(html)
         assert result == "Hi."
 
+    def test_include_links_passed_to_trafilatura(self):
+        """trafilatura.extract is always called with include_links=True."""
+        html = "<html><body><p>Article.</p></body></html>"
+        mock_traf = MagicMock()
+        mock_traf.extract.return_value = "Article."
+        with patch.dict('sys.modules', {'trafilatura': mock_traf}):
+            import importlib
+            import services.text_extractor as te
+            importlib.reload(te)
+            te.extract_html(html, url='https://example.com')
+        _, kwargs = mock_traf.extract.call_args
+        assert kwargs.get('include_links') is True
+
 
 # ─── extract_text dispatch ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Cycle 203 — TKT-227

### Opportunity
Scenario `039-skill-read.yaml` regressed from PASS 0.94 → WARN 0.58 because the read skill could no longer find when a blog post was published. The page lists post titles next to dates ("6 Apr 2026", "21 Apr 2026"), but our extraction was returning text with **zero** date mentions.

### Root cause
`services.text_extractor.extract_html()` calls `trafilatura.extract(html, url=url, include_comments=False)`. Trafilatura's default boilerplate filter strips the inline date metadata and link slugs that live next to article titles on index pages — exactly the data the model needs to answer "when was this first posted?"

Verified by running `requests.get('https://chalie.ai/blog/')` then `extract_html()` against rc-0.6.0:
- Output: 928 chars, no "Apr"/"April" anywhere
- Page clearly shows "6 Apr 2026" rendered in the DOM

With `include_links=True`, the extractor preserves both the visible date AND the URL slug (`2026-04-06-building-the-meta-harness/`), giving the model two independent date signals.

### Change
Single line: `include_links=True` added to the trafilatura call in `backend/services/text_extractor.py`. One unit test asserting the kwarg is passed.

`+14 / -1`, deductive (removing the boilerplate filter that was suppressing useful data).

### Results

| | Pipeline | Test run | Verdict | Score | Step 3 |
|---|---|---|---|---|---|
| Baseline (rc-0.6.0) | 502 | 9715 | WARN | 0.58 | FAIL |
| Improve | 503 | 9716 | **PASS** | **1.0** | **PASS** |

Model response on improve branch:
> Looking at your blog, the first mention of the meta-harness appears in your post from **April 6, 2026**, titled *Building an AI That Improves Itself: The Meta-Harness*.

### Impact analysis
- `services.text_extractor.extract_html` callers: `abilities/read.py` (URL + HTML file paths only)
- `abilities/browser.py` uses a **separate** `tools.browser.extraction.extract_html` function — unaffected
- `api/documents.py` and `folder_watcher_service.py` use `extract_text`, not `extract_html` — unaffected
- Output gains markdown link syntax for embedded URLs; the model handles this fluently as the test result shows

### Tests
- `pytest tests/test_text_extractor.py` — 25 passed / 2 skipped
- Full unit suite: 2206 passed / 17 skipped
- Ruff clean