### PR TITLE
refactor(super-ep): consolidate transcript-id collection and dead gist guards

### DIFF
--- a/backend/services/super_episode_encoder_processor.py
+++ b/backend/services/super_episode_encoder_processor.py
@@ -96,20 +96,18 @@ def _collect_transcript_ids(episodes: list[dict]) -> set[int]:
     return ids
 
 
-def _fetch_transcript_spans(sources: list[dict], db) -> str:
-    """Fetch and format the raw transcript rows spanning all source episodes.
+def _fetch_transcript_spans(t_ids: set[int], db) -> str:
+    """Fetch and format the raw transcript rows for the given transcript IDs.
 
-    Collects the union of transcript IDs from the source episodes, then
-    fetches those rows and formats them as ``[id] (ts) role: content`` lines.
+    Fetches those rows and formats them as ``[id] (ts) role: content`` lines.
 
     Returns formatted string oldest-first, or '' if no transcript IDs found.
     """
-    all_t_ids = _collect_transcript_ids(sources)
-    if not all_t_ids:
+    if not t_ids:
         return ''
 
     try:
-        placeholders = ','.join('?' * len(all_t_ids))
+        placeholders = ','.join('?' * len(t_ids))
         with db.connection() as conn:
             cursor = conn.cursor()
             cursor.execute(
@@ -119,7 +117,7 @@ def _fetch_transcript_spans(sources: list[dict], db) -> str:
                 WHERE id IN ({placeholders})
                 ORDER BY id ASC
                 """,
-                list(all_t_ids),
+                list(t_ids),
             )
             rows = cursor.fetchall()
             cursor.close()
@@ -297,7 +295,8 @@ class SuperEpisodeEncoderProcessor(MessageProcessor):
         if len(sources) < min_cluster:
             return False
 
-        transcript_spans = _fetch_transcript_spans(sources, db)
+        all_t_ids = _collect_transcript_ids(sources)
+        transcript_spans = _fetch_transcript_spans(all_t_ids, db)
 
         # Wire per-cluster state so getUserPrompt() picks it up
         self._sources = sources
@@ -324,14 +323,14 @@ class SuperEpisodeEncoderProcessor(MessageProcessor):
             return False
 
         super_ep['channel'] = self._target_channel
-        unique_t_ids = sorted(_collect_transcript_ids(sources))
+        unique_t_ids = sorted(all_t_ids)
         super_ep['transcript_ids'] = unique_t_ids
         super_ep['transcript_id_start'] = min(unique_t_ids) if unique_t_ids else None
         super_ep['transcript_id_end'] = max(unique_t_ids) if unique_t_ids else None
         super_ep['consolidated_from'] = [ep['id'] for ep in sources]
 
-        gist = super_ep.get('gist', '')
-        embedding = emb_svc.generate_embedding(gist) if gist else None
+        gist = super_ep['gist']
+        embedding = emb_svc.generate_embedding(gist)
         novelty = compute_novelty(embedding, prior_embeddings) if embedding else 1.0
         super_ep['salience'] = compute_salience(
             valence=float(super_ep.get('emotional_valence') or 0.0),


### PR DESCRIPTION
## Summary

Cycle 204 (TKT-228, deductive). Net **-1 LOC** in `backend/services/super_episode_encoder_processor.py`.

Two consolidations:

1. **Hoist `_collect_transcript_ids`**: `_process_cluster` previously walked the source episodes twice — once inside `_fetch_transcript_spans` and again to populate `super_ep['transcript_ids']`. Hoist the call to the orchestrator and reuse the single set. `_fetch_transcript_spans(t_ids: set[int], db)` now takes the precomputed set.

2. **Drop dead gist conditionals**: the early-return guard at `_process_cluster` (`if not super_ep or not super_ep.get('gist'): return False`) makes the subsequent `gist = super_ep.get('gist', '')` plus `if gist`/`if embedding else None` paths dead. Collapse `gist = super_ep['gist']` and `embedding = emb_svc.generate_embedding(gist)` to unconditional. Defensive `compute_novelty(...) if embedding else 1.0` is preserved because `generate_embedding` may legitimately return None.

## Test plan
- [x] 18/18 super-ep unit tests pass on worktree
- [x] Baseline pipeline 506 (rc-0.6.0, 122-subconscious-tick): **PASS 1.0**
- [x] Improve pipeline 507 (this branch, 122-subconscious-tick): **PASS 1.0** — score holds

## Evidence

> "Subconscious tick — five steps run in order, DMN writes via memory tool: PASS"

— pipeline 507 last_result on `improve/super-ep-encoder-deadcode-1778219670`

🤖 Generated with [Claude Code](https://claude.com/claude-code)