### PR TITLE
fix(find_tools): reframe SUMMARY to cover user-named skills/tools

### DIFF
--- a/backend/abilities/find_tools.py
+++ b/backend/abilities/find_tools.py
@@ -18,7 +18,7 @@ KNN_DEPTH = 30
 
 class FindToolsAbility(Ability):
     NAME = "find_tools"
-    SUMMARY = "Discover external tools by semantic search — use when built-in skills cannot handle the task."
+    SUMMARY = "Discover tools by semantic search — call this whenever the user names a skill, tool, or capability you don't see in your current toolbox, or when none of your loaded tools can handle the task."
     EXAMPLES = [
         "I want to check if Apple's Q2 earnings report is out yet",
         "can you look up a flight for me",


### PR DESCRIPTION
## Summary

Reframes `FindToolsAbility.SUMMARY` so the model treats `find_tools` as the obvious next call when the user explicitly names a skill, tool, or capability that isn't in its current toolbox.

**Old:**
> Discover external tools by semantic search — use when built-in skills cannot handle the task.

**New:**
> Discover tools by semantic search — call this whenever the user names a skill, tool, or capability you don't see in your current toolbox, or when none of your loaded tools can handle the task.

The "external vs built-in" framing was misleading: when scenario 037 explicitly asked for the **subagent** skill, the model classified it as a "skill" outside `find_tools`' scope and refused — telling the user it lacked the ability — instead of discovering it via `find_tools`.

## Evidence

Targeted scenario: `037-skill-subagent-explicit.yaml` (FAIL 0.0 baseline, run 508 on rc-0.6.0).

**Baseline (rc-0.6.0 run 508):**
- Step 1 quality 0.1 — *"model explicitly stated it does not possess the 'subagent' skill and cannot run background processes"*
- Steps 2/3/4/5 all FAIL (no dispatch ever happened)
- Pre-gate score **0.128**, FAIL

**Improve branch (run 510):**
- Step 1 quality 0.4 — *"ACT loop required 3 iterations (including a redundant find_tools call) to eventually dispatch the subagent"*
- Steps 2/3/4 all PASS (dispatch + canonical tag + completion row all correct)
- Step 5 FAIL — *"harness failed to surface the subagent's findings back to the user channel. Despite the subagent completing its work, no synthetic turn or steer was triggered"*
- Pre-gate score **0.752**, gate-FAIL on a different (pre-existing) anomaly

**Targeted anomaly** ("Model refusal of existing skill") is **cleared**. Step 5 failure is the async-return-flow / synthetic-turn-steer pipeline bug also visible in earlier dispatching runs (2026-05-06, pre-gate 0.776) — separate issue, separate ticket.

## Approach

Additive (deductive previously failed via TKT-209/TKT-210). One-line copy change to a tool SUMMARY string.

## Diff

`backend/abilities/find_tools.py` line 21 — 1 file, +1/-1.

Improve-chalie cycle, [TKT-231](https://taskie/tickets/231).