### PR TITLE
chore(transcript): drop dead helpers prune_old + get_latest_id

### DIFF
--- a/backend/services/transcript_service.py
+++ b/backend/services/transcript_service.py
@@ -6,7 +6,6 @@ Stores every exchange turn (user, assistant, tool, internal) in SQLite.
 Key operations:
 - append(): Write a turn to the transcript
 - get_recent(): Retrieve the most recent N entries for a topic
-- prune_old(): Delete entries older than TTL (90 days default)
 """
 
 import logging
@@ -15,9 +14,6 @@ from typing import List, Dict, Optional
 
 logger = logging.getLogger(__name__)
 LOG_PREFIX = "[TRANSCRIPT]"
-
-# Default TTL for pruning (90 days in seconds)
-_PRUNE_TTL_DAYS = 90
 
 # Rolling episode extraction — DB-state-driven.
 #
@@ -143,27 +139,6 @@ def get_recent(channel: str, limit: int = 20, since_id: int = None, _context=Non
         return []
 
 
-def get_latest_id(channel: str) -> Optional[int]:
-    """Get the highest transcript entry ID for a channel (compaction watermark)."""
-    try:
-        from services.database_service import get_shared_db_service
-        db = get_shared_db_service()
-
-        with db.connection() as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                "SELECT MAX(id) FROM transcript WHERE channel = ?",
-                (channel,),
-            )
-            row = cursor.fetchone()
-            cursor.close()
-            return row[0] if row and row[0] else None
-
-    except Exception as e:
-        logger.warning(f"{LOG_PREFIX} get_latest_id failed: {e}")
-        return None
-
-
 def cleanup_unlinked_entries(channel: str = None) -> int:
     """Delete transcript entries not linked to any episode and below compaction watermark.
 
@@ -260,45 +235,6 @@ def cleanup_unlinked_entries(channel: str = None) -> int:
 
     except Exception as e:
         logger.warning(f"{LOG_PREFIX} cleanup_unlinked_entries failed: {e}")
-        return 0
-
-
-def prune_old(ttl_days: int = _PRUNE_TTL_DAYS) -> int:
-    """Delete transcript entries older than ttl_days. Returns the number deleted."""
-    try:
-        from services.database_service import get_shared_db_service
-        db = get_shared_db_service()
-
-        with db.connection() as conn:
-            cursor = conn.cursor()
-
-            cursor.execute(
-                """
-                SELECT rowid FROM transcript
-                WHERE created_at < datetime('now', ?)
-                """,
-                (f'-{ttl_days} days',),
-            )
-            old_rowids = [r[0] for r in cursor.fetchall()]
-
-            if not old_rowids:
-                cursor.close()
-                return 0
-
-            placeholders = ','.join('?' * len(old_rowids))
-            cursor.execute(
-                f"DELETE FROM transcript WHERE rowid IN ({placeholders})",
-                old_rowids,
-            )
-
-            deleted = len(old_rowids)
-            cursor.close()
-
-        logger.info(f"{LOG_PREFIX} Pruned {deleted} entries older than {ttl_days} days")
-        return deleted
-
-    except Exception as e:
-        logger.warning(f"{LOG_PREFIX} Pruning failed: {e}")
         return 0
 
 

--- a/backend/tests/test_transcript_service.py
+++ b/backend/tests/test_transcript_service.py
@@ -3,7 +3,6 @@
 Tests cover:
 - append()
 - get_recent() with and without since_id
-- get_latest_id()
 - TestDbStateExtractionTrigger: DB-state-driven extraction trigger
 
 All tests use the real production stack against the shared `db` fixture
@@ -108,20 +107,6 @@ class TestGetRecent:
         results = get_recent('topic-a')
         assert len(results) == 1
         assert results[0]['content'] == 'A message'
-
-
-class TestGetLatestId:
-    def test_returns_highest_id(self, db):
-        from services.transcript_service import append, get_latest_id
-
-        append('test', 'user', 'First')
-        id2 = append('test', 'user', 'Second')
-
-        assert get_latest_id('test') == id2
-
-    def test_returns_none_for_empty_topic(self, db):
-        from services.transcript_service import get_latest_id
-        assert get_latest_id('nonexistent') is None
 
 
 class TestDbStateExtractionTrigger:


### PR DESCRIPTION
## Summary

Deductive net-negative cleanup (improve-cycle 210 / TKT-248). Drops three dead symbols from `backend/services/transcript_service.py`:

- `prune_old(ttl_days=...)` — zero callers anywhere in the codebase (production OR tests). Verified by grep across `backend/`, `frontend/`, scripts, docs, configs.
- `get_latest_id(channel)` — zero production callers; only two unit tests exercised it. Tests deleted with the function.
- `_PRUNE_TTL_DAYS = 90` — only fed `prune_old`'s default arg; dies with it.

Also removes the matching bullet from the module docstring header.

**Net change: -79 LOC, two files. Zero behavioural impact.**

## Evidence

Targeted nightly canaries on `rc-0.6.0` baseline vs improve branch:

| Scenario | Baseline (run 518) | Improve (run 519) | Δ |
|---|---|---|---|
| 030-skill-memory.yaml | PASS 1.0 | PASS 1.0 | 0 |
| 122-subconscious-tick-orchestration.yaml | PASS 1.0 | PASS 1.0 | 0 |

Scores hold at ceiling. Both scenarios exercise `transcript_service.append`/`get_recent`/`cleanup_unlinked_entries` — the surviving public API — and pass deterministic checks plus LLM-judge composite at 1.0.

## Test plan
- [x] `grep -rnE 'prune_old|_PRUNE_TTL_DAYS|get_latest_id'` returns zero hits across the repo
- [x] `pytest -m unit -q` — 304 passed, 15 skipped (1 unrelated pre-existing ONNX failure)
- [x] Build-log CI green
- [x] Nightly canaries 030 + 122 hold at PASS 1.0 on improve branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)