### PR TITLE
chore: drop dead _unpack_blob helper from episodic_retrieval_service

### DIFF
--- a/backend/services/episodic_retrieval_service.py
+++ b/backend/services/episodic_retrieval_service.py
@@ -21,7 +21,6 @@ level function API so there is no per-call EpisodicService construction cost.
 import logging
 import math
 import re
-import struct
 from typing import Optional
 
 from services.episodic_constants import APEX_TRAVERSAL_MAX_DEPTH
@@ -162,12 +161,6 @@ def _pack_embedding(embedding) -> Optional[bytes]:
     except Exception as exc:
         logger.warning(f"[RETRIEVAL] _pack_embedding failed: {exc}")
         return None
-
-
-def _unpack_blob(blob: bytes) -> list[float]:
-    """Unpack a sqlite-vec binary blob into a list of floats."""
-    n = len(blob) // 4
-    return list(struct.unpack(f'{n}f', blob))
 
 
 def _generate_embedding(text: str) -> Optional[list[float]]:


### PR DESCRIPTION
## Summary
- Removes a private helper `_unpack_blob` in `backend/services/episodic_retrieval_service.py` that has zero callers and the now-orphaned `import struct`.
- Net change: -7 LOC, 1 file.

## Why this is safe
The only consumers of `_unpack_blob` are inside `backend/services/episodic_service.py`, which uses its **own local definition** at line 345 of that file. There is no `from services.episodic_retrieval_service import _unpack_blob` anywhere in the codebase. The `struct` import in this file existed solely for the dead helper.

## Verification
- `python -c "import services.episodic_retrieval_service"` — OK
- `pytest -m unit -q tests/test_super_episode_pipeline.py` — 18/18 PASS (the only test file importing from `episodic_retrieval_service`)

## Nightly scenarios
- Baseline (rc-0.6.0, run 520): `030-skill-memory` PASS 1.0, `122-subconscious-tick-orchestration` PASS 1.0
- Improve branch (run 521): `030-skill-memory` PASS 1.0, `122-subconscious-tick-orchestration` PASS 1.0
- Score holds across both scenarios.

Improve-Chalie cycle 210 — TKT-249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)