### PR TITLE
chore: drop dead DocumentService.search_by_metadata

### DIFF
--- a/backend/services/document_service.py
+++ b/backend/services/document_service.py
@@ -716,54 +716,6 @@ class DocumentService:
             logger.error(f"[DOCS] purge_expired failed: {e}")
             return 0
 
-    def search_by_metadata(self, filters: Dict[str, Any]) -> List[Dict[str, Any]]:
-        """
-        Query documents by extracted_metadata JSON fields.
-        Supported filters: document_type, company, has_expiration.
-        """
-        try:
-            conditions = ["deleted_at IS NULL", "status = 'ready'"]
-            params = []
-
-            if 'document_type' in filters:
-                conditions.append("json_extract(extracted_metadata, '$.document_type.value') = ?")
-                params.append(filters['document_type'])
-
-            if 'company' in filters:
-                conditions.append(
-                    "EXISTS (SELECT 1 FROM json_each(json_extract(extracted_metadata, '$.companies')) c "
-                    "WHERE json_extract(c.value, '$.name') LIKE ?)"
-                )
-                params.append(f"%{filters['company']}%")
-
-            if filters.get('has_expiration'):
-                conditions.append("json_array_length(COALESCE(json_extract(extracted_metadata, '$.expiration_dates'), '[]')) > 0")
-
-            where = " AND ".join(conditions)
-
-            with self.db.connection() as conn:
-                cursor = conn.cursor()
-                cursor.execute(f"""
-                    SELECT id, original_name, mime_type, file_size_bytes, file_path,
-                           file_hash, page_count, status, error_message, chunk_count,
-                           source_type, tags, summary, extracted_metadata, supersedes_id,
-                           clean_text, language, fingerprint,
-                           doc_category, doc_project, doc_date, meta_locked,
-                           watched_folder_id,
-                           created_at, updated_at, deleted_at, purge_after
-                    FROM documents
-                    WHERE {where}
-                    ORDER BY created_at DESC
-                """, params)
-                rows = cursor.fetchall()
-                cursor.close()
-
-            return [self._row_to_dict(row) for row in rows]
-
-        except Exception as e:
-            logger.error(f"[DOCS] search_by_metadata failed: {e}")
-            return []
-
     # ─────────────────────────────────────────────
     # Watched folder helpers
     # ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Deductive cycle 211 (TKT-250). Dropped `DocumentService.search_by_metadata` — 48 LOC of dead code with zero production callers.
- Method built a `json_extract`-based SQL query for filtering by `document_type` / `company` / `has_expiration`. Grep confirmed the only references were the def line and an internal `logger.error` string.

## Evidence
- Baseline (run 522, rc-0.6.0): 060 PASS 1.0; 092 FAIL 0.0.
- Improve (run 523, this branch): 060 PASS 1.0; 092 FAIL 0.0.
- Canary 060 holds — score and judge diagnostic identical ("Vantage Labs has 342 employees").
- 092 is LLM-flaky (depends on whether the model writes literal "Kelly" into `clean_text`); recent history shows ~4/15 PASS rate. Dead-code drop has zero relationship to its execution path.

## Diff
`backend/services/document_service.py | 48 ------------------------------------`

## Test plan
- [x] py_compile + 13 unit tests in test_document_service.py pass
- [x] CI green
- [x] Targeted scenarios run on improve branch — canary holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)