### PR TITLE
chore: drop 8 unused public methods on DataGraphService

### DIFF
--- a/backend/services/data_graph_service.py
+++ b/backend/services/data_graph_service.py
@@ -1146,50 +1146,6 @@ class DataGraphService:
             logger.error("[DATA GRAPH] fetch failed: %s", e)
             return []
 
-    # ── find_similar_by_kind() ────────────────────────────────────────
-
-    def find_similar_by_kind(self, embedding, kind: str, exclude_id: int, limit: int = 3) -> list:
-        try:
-            blob = pack_embedding(embedding) if embedding else None
-            if blob is None:
-                return []
-            with self.db.connection() as conn:
-                cursor = conn.cursor()
-                cursor.execute("""
-                    SELECT v.rowid, v.distance
-                    FROM data_graph_value_vec v
-                    WHERE v.embedding MATCH ? AND k = ?
-                    ORDER BY v.distance
-                """, (blob, limit * 5))
-                vec_results = cursor.fetchall()
-
-                results = []
-                for rowid, dist in vec_results:
-                    if dist >= 0.25:
-                        continue
-                    cursor.execute(
-                        "SELECT id, key, value, retrieval_weight, kind "
-                        "FROM data_graph WHERE id=? AND kind=? AND id!=? AND deleted_at IS NULL AND active=1",
-                        (rowid, kind, exclude_id)
-                    )
-                    row = cursor.fetchone()
-                    if row:
-                        results.append({
-                            'id': row[0],
-                            'key': row[1],
-                            'value': row[2],
-                            'retrieval_weight': row[3],
-                            'kind': row[4],
-                        })
-                    if len(results) >= limit:
-                        break
-
-                cursor.close()
-                return results
-        except Exception as e:
-            logger.error("[DATA GRAPH] find_similar_by_kind failed: %s", e)
-            return []
-
     # ── Edge operations ───────────────────────────────────────────────
 
     def _add_edge_with_conn(self, conn, from_id: int, to_id: int, edge_type: str = 'related', strength: float = 1.0) -> int:
@@ -1205,88 +1161,6 @@ class DataGraphService:
         ).fetchone()
         return row[0] if row else 0
 
-    def add_edge(self, from_id: int, to_id: int, *, edge_type: str = 'related', strength: float = 1.0) -> int:
-        try:
-            with self.db.connection() as conn:
-                return self._add_edge_with_conn(conn, from_id, to_id, edge_type, strength)
-        except Exception as e:
-            logger.warning("[DATA GRAPH] add_edge failed from=%s to=%s type=%s: %s", from_id, to_id, edge_type, e)
-            return 0
-
-    def expand_edges(self, seed_ids: list, *, edge_types=None) -> list:
-        if not seed_ids:
-            return []
-        try:
-            with self.db.connection() as conn:
-                cursor = conn.cursor()
-                placeholders = ','.join('?' for _ in seed_ids)
-                params = list(seed_ids)
-                type_clause = ""
-                if edge_types:
-                    type_placeholders = ','.join('?' for _ in edge_types)
-                    type_clause = f" AND edge_type IN ({type_placeholders})"
-                    params.extend(edge_types)
-                cursor.execute(
-                    f"SELECT * FROM data_graph_edges WHERE from_id IN ({placeholders}){type_clause}",
-                    params
-                )
-                rows = cursor.fetchall()
-                cursor.close()
-                return [self._row_to_dict(r) for r in rows]
-        except Exception as e:
-            logger.error("[DATA GRAPH] expand_edges failed: %s", e)
-            return []
-
-    def touch_edge(self, from_id: int, to_id: int, edge_type: str) -> None:
-        try:
-            with self.db.connection() as conn:
-                conn.execute("""
-                    UPDATE data_graph_edges
-                    SET last_accessed_at=?
-                    WHERE from_id=? AND to_id=? AND edge_type=?
-                """, (utc_now().isoformat(), from_id, to_id, edge_type))
-        except Exception as e:
-            logger.warning("[DATA GRAPH] touch_edge failed: %s", e)
-
-    # ── Reinforcement / demotion ──────────────────────────────────────
-
-    def reinforce(self, row_id: int) -> None:
-        try:
-            with self.db.connection() as conn:
-                cursor = conn.cursor()
-                cursor.execute(
-                    "SELECT evidence_count, storage_strength FROM data_graph WHERE rowid=?",
-                    (row_id,)
-                )
-                row = cursor.fetchone()
-                cursor.close()
-                if not row:
-                    return
-                old_evidence, old_strength = row
-                new_evidence = old_evidence + 1
-                boost = 0.05 / math.log2(new_evidence + 1)
-                new_strength = min(1.0, old_strength + boost)
-                now_iso = utc_now().isoformat()
-                conn.execute("""
-                    UPDATE data_graph
-                    SET evidence_count=?, storage_strength=?, retrieval_weight=1.0,
-                        last_confirmed_at=?, last_accessed_at=?
-                    WHERE rowid=?
-                """, (new_evidence, new_strength, now_iso, now_iso, row_id))
-        except Exception as e:
-            logger.warning("[DATA GRAPH] reinforce failed for rowid=%s: %s", row_id, e)
-
-    def demote(self, row_id: int, factor: float = 0.5) -> None:
-        try:
-            with self.db.connection() as conn:
-                conn.execute("""
-                    UPDATE data_graph
-                    SET retrieval_weight = retrieval_weight * ?
-                    WHERE rowid=?
-                """, (factor, row_id))
-        except Exception as e:
-            logger.warning("[DATA GRAPH] demote failed for rowid=%s: %s", row_id, e)
-
     # ── Deletion operations ───────────────────────────────────────────
 
     def soft_delete_by_id(self, row_id: int) -> bool:
@@ -1300,18 +1174,6 @@ class DataGraphService:
             return True
         except Exception as e:
             logger.warning("[DATA GRAPH] soft_delete_by_id failed for rowid=%s: %s", row_id, e)
-            return False
-
-    def hard_delete_by_id(self, row_id: int) -> bool:
-        try:
-            with self.db.connection() as conn:
-                self._remove_fts(conn, row_id)
-                conn.execute(_SQL_DELETE_DG_ROW, (row_id,))
-                conn.execute(_SQL_DELETE_DG_KEY_VEC, (row_id,))
-                conn.execute(_SQL_DELETE_DG_VALUE_VEC, (row_id,))
-            return True
-        except Exception as e:
-            logger.warning("[DATA GRAPH] hard_delete_by_id failed for rowid=%s: %s", row_id, e)
             return False
 
     def hard_delete_by_source_prefix(self, source_prefix: str) -> int:
@@ -1340,16 +1202,6 @@ class DataGraphService:
         except Exception as e:
             logger.warning("[DATA GRAPH] hard_delete_by_source_prefix failed for '%s': %s", safe(source_prefix), e)
             return 0
-
-    def set_active(self, row_id: int, active: int) -> None:
-        try:
-            with self.db.connection() as conn:
-                conn.execute(
-                    "UPDATE data_graph SET active=? WHERE rowid=?",
-                    (int(active), row_id)
-                )
-        except Exception as e:
-            logger.warning("[DATA GRAPH] set_active failed for rowid=%s: %s", row_id, e)
 
     def _make_forget_result(
         self,

--- a/backend/tests/test_data_graph_service.py
+++ b/backend/tests/test_data_graph_service.py
@@ -749,166 +749,6 @@ class TestFetch:
         assert len(rows) == 3
 
 
-# TestEdges
-# ══════════════════════════════════════════════════════════════════
-
-@pytest.mark.unit
-class TestEdges:
-
-    def test_add_edge_basic(self, svc, db_service):
-        """add_edge returns a positive edge id and the edge is persisted."""
-        ra = _insert_row(db_service, kind=KIND_USER_SPECIFIC, key='a', value='av')
-        rb = _insert_row(db_service, kind=KIND_USER_SPECIFIC, key='b', value='bv')
-        id_a = _get_db_id(db_service, ra)
-        id_b = _get_db_id(db_service, rb)
-
-        edge_id = svc.add_edge(id_a, id_b, edge_type='related')
-        assert edge_id > 0
-
-        with db_service.connection() as conn:
-            row = conn.execute(
-                "SELECT * FROM data_graph_edges "
-                "WHERE from_id=? AND to_id=? AND edge_type='related'",
-                (id_a, id_b)
-            ).fetchone()
-        assert row is not None
-
-    def test_add_edge_duplicate_ignored_returns_same_id(self, svc, db_service):
-        """Inserting the same edge twice uses INSERT OR IGNORE and returns the same edge id."""
-        ra = _insert_row(db_service, kind=KIND_USER_SPECIFIC, key='x', value='xv')
-        rb = _insert_row(db_service, kind=KIND_USER_SPECIFIC, key='y', value='yv')
-        id_a = _get_db_id(db_service, ra)
-        id_b = _get_db_id(db_service, rb)
-
-        edge_id_1 = svc.add_edge(id_a, id_b, edge_type='related')
-        edge_id_2 = svc.add_edge(id_a, id_b, edge_type='related')
-        assert edge_id_1 == edge_id_2
-
-        with db_service.connection() as conn:
-            count = conn.execute(
-                "SELECT COUNT(*) FROM data_graph_edges "
-                "WHERE from_id=? AND to_id=? AND edge_type='related'",
-                (id_a, id_b)
-            ).fetchone()[0]
-        assert count == 1
-
-    def test_expand_edges_returns_outgoing(self, svc, db_service):
-        """expand_edges returns all edges from the given seed node ids."""
-        ra = _insert_row(db_service, kind=KIND_USER_SPECIFIC, key='hub', value='v')
-        rb = _insert_row(db_service, kind=KIND_USER_SPECIFIC, key='leaf1', value='v')
-        rc = _insert_row(db_service, kind=KIND_USER_SPECIFIC, key='leaf2', value='v')
-        id_a = _get_db_id(db_service, ra)
-        id_b = _get_db_id(db_service, rb)
-        id_c = _get_db_id(db_service, rc)
-
-        svc.add_edge(id_a, id_b, edge_type='related')
-        svc.add_edge(id_a, id_c, edge_type='causes')
-
-        edges = svc.expand_edges([id_a])
-        to_ids = {e['to_id'] for e in edges}
-        assert id_b in to_ids
-        assert id_c in to_ids
-
-    def test_expand_edges_type_filter(self, svc, db_service):
-        """edge_types= filters edges to only the specified types."""
-        ra = _insert_row(db_service, kind=KIND_USER_SPECIFIC, key='src', value='v')
-        rb = _insert_row(db_service, kind=KIND_USER_SPECIFIC, key='dst1', value='v')
-        rc = _insert_row(db_service, kind=KIND_USER_SPECIFIC, key='dst2', value='v')
-        id_a = _get_db_id(db_service, ra)
-        id_b = _get_db_id(db_service, rb)
-        id_c = _get_db_id(db_service, rc)
-
-        svc.add_edge(id_a, id_b, edge_type='causes')
-        svc.add_edge(id_a, id_c, edge_type='related')
-
-        edges = svc.expand_edges([id_a], edge_types=['causes'])
-        assert all(e['edge_type'] == 'causes' for e in edges)
-        to_ids = {e['to_id'] for e in edges}
-        assert id_b in to_ids
-        assert id_c not in to_ids
-
-    def test_touch_edge_updates_last_accessed_at(self, svc, db_service):
-        """touch_edge sets last_accessed_at on the matching edge row."""
-        ra = _insert_row(db_service, kind=KIND_USER_SPECIFIC, key='p', value='v')
-        rb = _insert_row(db_service, kind=KIND_USER_SPECIFIC, key='q', value='v')
-        id_a = _get_db_id(db_service, ra)
-        id_b = _get_db_id(db_service, rb)
-
-        svc.add_edge(id_a, id_b, edge_type='related')
-
-        # Verify last_accessed_at starts NULL
-        with db_service.connection() as conn:
-            before = conn.execute(
-                "SELECT last_accessed_at FROM data_graph_edges "
-                "WHERE from_id=? AND to_id=? AND edge_type='related'",
-                (id_a, id_b)
-            ).fetchone()[0]
-        assert before is None
-
-        svc.touch_edge(id_a, id_b, 'related')
-
-        with db_service.connection() as conn:
-            after = conn.execute(
-                "SELECT last_accessed_at FROM data_graph_edges "
-                "WHERE from_id=? AND to_id=? AND edge_type='related'",
-                (id_a, id_b)
-            ).fetchone()[0]
-        assert after is not None
-
-
-# TestReinforceAndDemote
-# ══════════════════════════════════════════════════════════════════
-
-@pytest.mark.unit
-class TestReinforceAndDemote:
-
-    def test_reinforce_increments_evidence_and_resets_retrieval_weight(self, svc, db_service):
-        """reinforce() increments evidence_count, boosts storage_strength, resets retrieval_weight=1.0."""
-        rowid = _insert_row(db_service, kind=KIND_USER_SPECIFIC, key='r_key', value='r_val',
-                            evidence_count=2, storage_strength=0.6, retrieval_weight=0.5)
-
-        svc.reinforce(rowid)
-
-        raw = _raw_row(db_service, rowid)
-        assert raw['evidence_count'] == 3
-        assert raw['storage_strength'] > 0.6
-        assert raw['retrieval_weight'] == pytest.approx(1.0)
-
-    def test_reinforce_storage_strength_capped_at_one(self, svc, db_service):
-        """storage_strength never exceeds 1.0 after reinforcement."""
-        rowid = _insert_row(db_service, kind=KIND_USER_SPECIFIC, key='strong', value='v',
-                            storage_strength=0.999, evidence_count=100)
-
-        svc.reinforce(rowid)
-
-        raw = _raw_row(db_service, rowid)
-        assert raw['storage_strength'] <= 1.0
-
-    def test_demote_reduces_retrieval_weight_by_factor(self, svc, db_service):
-        """demote() multiplies retrieval_weight by the given factor."""
-        rowid = _insert_row(db_service, kind=KIND_USER_SPECIFIC, key='d_key', value='d_val',
-                            retrieval_weight=0.8)
-
-        svc.demote(rowid, factor=0.5)
-
-        raw = _raw_row(db_service, rowid)
-        assert raw['retrieval_weight'] == pytest.approx(0.4, abs=0.001)
-
-    def test_demote_does_not_touch_storage_strength(self, svc, db_service):
-        """demote() only modifies retrieval_weight, not storage_strength."""
-        rowid = _insert_row(db_service, kind=KIND_USER_SPECIFIC, key='ss_key', value='v',
-                            storage_strength=0.75, retrieval_weight=1.0)
-
-        svc.demote(rowid, factor=0.5)
-
-        raw = _raw_row(db_service, rowid)
-        assert raw['storage_strength'] == pytest.approx(0.75, abs=0.001)
-
-    def test_demote_unknown_rowid_is_no_op(self, svc):
-        """demote() on a non-existent rowid silently does nothing (no exception raised)."""
-        svc.demote(999999, factor=0.1)  # must not raise
-
-
 # TestDeletion
 # ══════════════════════════════════════════════════════════════════
 
@@ -945,37 +785,6 @@ class TestDeletion:
         svc.soft_delete_by_id(rowid)
         raw = _raw_row(db_service, rowid)
         assert raw is not None
-
-    def test_hard_delete_removes_row_completely(self, svc, db_service):
-        """hard_delete_by_id physically removes the row from data_graph."""
-        rowid = _insert_row(db_service, kind=KIND_MISC, key='hard', value='gone')
-
-        result = svc.hard_delete_by_id(rowid)
-        assert result is True
-
-        raw = _raw_row(db_service, rowid)
-        assert raw is None
-
-    def test_hard_delete_removes_from_fts(self, svc, db_service):
-        """hard_delete_by_id removes the FTS entry so it can't be searched."""
-        rowid = _insert_row(db_service, kind=KIND_MISC, key='hd_fts', value='erasedtoken')
-
-        svc.hard_delete_by_id(rowid)
-
-        fts_hits = _raw_fts(db_service, '"erasedtoken"*')
-        assert rowid not in fts_hits
-
-    def test_set_active_toggles_flag(self, svc, db_service):
-        """set_active() writes the active flag as given."""
-        rowid = _insert_row(db_service, kind=KIND_USER_SPECIFIC, key='toggle', value='v')
-
-        svc.set_active(rowid, 0)
-        raw = _raw_row(db_service, rowid)
-        assert raw['active'] == 0
-
-        svc.set_active(rowid, 1)
-        raw = _raw_row(db_service, rowid)
-        assert raw['active'] == 1
 
 
 # TestDecayCycle
@@ -1143,20 +952,6 @@ class TestDocumentKind:
 
         assert _rid(r2) == _rid(r1)
         assert r2['evidence_count'] == 1
-
-    def test_document_hard_delete(self, svc, db_service):
-        """document kind uses hard deletion — hard_delete_by_id removes the row completely."""
-        assert _KIND_POLICY[KIND_DOCUMENT]['deletion'] == 'hard'
-
-        result = svc.store(KIND_DOCUMENT, 'doc:xyz:000', 'deletable chunk', source='doc:xyz')
-        assert result is not None
-        row_id = _rid(result)
-
-        deleted = svc.hard_delete_by_id(row_id)
-        assert deleted is True
-
-        raw = _raw_row(db_service, row_id)
-        assert raw is None
 
     def test_document_no_decay(self, svc, db_service):
         """document kind has d_base=0.0 — decay_cycle does not modify retrieval_weight."""
@@ -1360,7 +1155,12 @@ class TestForget:
         new_id = _get_db_id(db_service, new_rowid)
 
         # Wire a supersedes edge between the two so we can assert it is also removed.
-        svc.add_edge(new_id, old_id, edge_type='supersedes')
+        with db_service.connection() as conn:
+            conn.execute(
+                "INSERT OR IGNORE INTO data_graph_edges (from_id, to_id, edge_type, strength, created_at) "
+                "VALUES (?, ?, 'supersedes', 1.0, datetime('now'))",
+                (new_id, old_id)
+            )
 
         svc._generate_embedding = MagicMock(return_value=self._FAKE_EMB)
         with patch.object(svc, '_lookup_concept_lut', return_value=self._lut_hit('residence', 'temporal')):


### PR DESCRIPTION
## Summary

Deductive cycle 213 (TKT-253). Removes 8 dead public methods from `DataGraphService` plus their associated tests. Net diff: 2 files, +6 / -354 LOC.

Removed methods (zero callers verified via grep + vulture):
- `find_similar_by_kind`, `add_edge`, `expand_edges`, `touch_edge`
- `reinforce`, `demote`, `hard_delete_by_id`, `set_active`

Internal `_add_edge_with_conn` retained — still used at supersedes/superseded_by edge sites.

## Verification

| Run | Branch | 030 | 122 | Score |
|-----|--------|-----|-----|-------|
| 527 baseline | rc-0.6.0 | PASS | PASS | 1.000 |
| 528 improve | this branch | PASS | PASS | 1.000 |

All 5 step-checks for 122 PASS, 030 single check PASS. Score holds at 1.0 with -354 lines.

## Test plan

- [x] Targeted scenarios 030 + 122 both PASS at score 1.0
- [x] Self-review 8-point gate clean
- [x] No callers of removed methods (vulture + grep verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)