### PR TITLE
fix(routing): hoist find_tools to ALWAYS_AVAILABLE index 0

### DIFF
--- a/backend/services/user_message_processor.py
+++ b/backend/services/user_message_processor.py
@@ -48,8 +48,8 @@ class UserMessageProcessor(MessageProcessor):
     # weather/search/news/browser via find_tools rather than appearing as
     # an always-on fallback that biases routing for single-tool lookups.
     ALWAYS_AVAILABLE: list[str] = [
-        "document",
         "find_tools",
+        "document",
         "list",
         "memory",
         "read",


### PR DESCRIPTION
## Summary

Move `find_tools` to index 0 of `UserMessageProcessor.ALWAYS_AVAILABLE`, ahead of `document`. List position influences the model's tool selection on the first ACT iteration; cycle 214 already proved that tightening `DocumentAbility.SUMMARY` does not move the routing needle on weather queries — position does.

The judge's diagnostic on the run-531 baseline 058 failure was unambiguous:

> "The harness failed to invoke the correct tool. It called the 'document' skill instead of 'weather' and then hallucinated a failure to find a dashboard, resulting in a refusal to provide the weather."

After the reorder, on the same scenario the judge reports:

> "The harness reached the correct outcome, but the ACT loop was inefficient, invoking 'document' and 'find_tools' before calling the 'weather' tool."

Same probe path, but `find_tools` is now consulted before bottoming out, so the model gets pulled into the correct skill.

## Result (Cycle 215, TKT-255)

| scenario | baseline run 531 (rc-0.6.0) | improve run 532 | delta |
|---|---|---|---|
| 058-rich-media-weather-card | **FAIL 0.24** (wrong skill) | **WARN 0.87** | **+0.63** |
| 050-tool-weather | **WARN 0.44** (wrong skill) | **WARN 0.76** | **+0.32** |
| 060-document-lifecycle (canary) | PASS 0.96 | PASS 0.96 | held |

Anomaly cleared on both targets: "wrong skill fired (document instead of weather)" gone in run 532. 060 canary held score and verdict.

## Approach

`deductive` (zero-LOC, list reorder).

## Test plan
- [x] Targeted unit suites (test_phase4_invariants, test_find_tools_discovery, test_mode_gate, test_subagent_processor, test_compaction_processor) — 62 passed.
- [x] Set-based invariants in test_phase4_invariants unaffected (compares `frozenset`, not `list`).
- [x] Baseline pipeline on rc-0.6.0 → improve pipeline with same 3 scenarios — see table above.