### PR TITLE
chore(services): drop 3 dead public service methods

### DIFF
--- a/backend/services/document_service.py
+++ b/backend/services/document_service.py
@@ -744,31 +744,6 @@ class DocumentService:
             logger.error(f"[DOCS] get_documents_by_watched_folder failed: {e}")
             return []
 
-    def get_document_by_path(self, file_path: str) -> Optional[Dict[str, Any]]:
-        """Get a non-deleted document by its file_path."""
-        try:
-            with self.db.connection() as conn:
-                cursor = conn.cursor()
-                cursor.execute("""
-                    SELECT id, original_name, mime_type, file_size_bytes, file_path,
-                           file_hash, page_count, status, error_message, chunk_count,
-                           source_type, tags, summary, extracted_metadata, supersedes_id,
-                           clean_text, language, fingerprint,
-                           doc_category, doc_project, doc_date, meta_locked,
-                           watched_folder_id,
-                           created_at, updated_at, deleted_at, purge_after
-                    FROM documents
-                    WHERE file_path = ? AND deleted_at IS NULL
-                """, (file_path,))
-                row = cursor.fetchone()
-                cursor.close()
-            if not row:
-                return None
-            return self._row_to_dict(row)
-        except Exception as e:
-            logger.error(f"[DOCS] get_document_by_path failed: {e}")
-            return None
-
     def update_tags(self, doc_id: str, tags: list) -> None:
         """Update the tags JSON array for a document.
 

--- a/backend/services/interface_registry_service.py
+++ b/backend/services/interface_registry_service.py
@@ -23,7 +23,6 @@ from services.write_queue_service import get_write_queue
 logger = logging.getLogger(__name__)
 
 _HEALTH_CHECK_TIMEOUT = 5  # seconds
-_EXECUTE_TIMEOUT = 15  # seconds
 _PAIRING_KEY_TTL = 600  # 10 minutes
 
 # Module-level failure counter — must survive across InterfaceRegistryService
@@ -441,42 +440,6 @@ class InterfaceRegistryService:
         return capabilities
 
     # ------------------------------------------------------------------
-    # Execution
-    # ------------------------------------------------------------------
-
-    def execute_capability(self, interface_id: str, capability: str, params: dict) -> dict:
-        """Execute a tool on the interface via HTTP POST.
-
-        Args:
-            interface_id: The interface UUID.
-            capability: Name of the capability to execute.
-            params: Parameters to pass to the capability.
-
-        Returns:
-            Dict with ``text``, ``html``, ``data``, or ``error`` — same
-            format as any tool result.
-        """
-        iface = self.get_interface(interface_id)
-        if not iface:
-            return {"error": f"Interface {interface_id} not found"}
-        if iface["status"] != "online":
-            return {"error": f"Interface '{iface['name']}' is offline"}
-
-        base_url = f"http://{iface['host']}:{iface['port']}"
-        try:
-            resp = requests.post(
-                f"{base_url}/execute",
-                json={"capability": capability, "params": params},
-                timeout=_EXECUTE_TIMEOUT,
-            )
-            resp.raise_for_status()
-            return resp.json()
-        except requests.Timeout:
-            return {"error": f"Interface '{iface['name']}' did not respond in time"}
-        except Exception as e:
-            return {"error": f"Interface execution failed: {e}"}
-
-    # ------------------------------------------------------------------
     # Health checks
     # ------------------------------------------------------------------
 
@@ -546,13 +509,6 @@ class InterfaceRegistryService:
             logger.info("[INTERFACE] '%s' recovered — back online", iface["name"])
 
         return True
-
-    def health_check_all(self):
-        """Run health check on all non-revoked interfaces."""
-        interfaces = self.list_interfaces()
-        for iface in interfaces:
-            if iface["status"] != "revoked":
-                self.health_check(iface["id"])
 
     # ------------------------------------------------------------------
     # Removal


### PR DESCRIPTION
## Summary

Pure subtractive cleanup. Three public service methods had **zero callers** anywhere in the production codebase (verified by repo-wide grep on `rc-0.6.0` excluding worktrees and the file itself):

- `InterfaceRegistryService.execute_capability` + companion `_EXECUTE_TIMEOUT` constant — never invoked. The interface registry exposes `register_tool` / `unregister_tool` and a per-interface `health_check`; capability execution is routed through the in-process tool framework, not via the never-wired HTTP execute endpoint.
- `InterfaceRegistryService.health_check_all` — bulk-iteration helper around `health_check`. No worker, scheduler, or blueprint ever called it; the per-interface `health_check` is the only path actually used.
- `DocumentService.get_document_by_path` — sibling of the active `get_documents_by_watched_folder` but never wired up.

Net **-69 LOC across 2 files**, no tests deleted (none referenced any of the removed methods on `rc-0.6.0`). Continues the cleanup pattern from cycles 211 (`DocumentService.search_by_metadata`), 213 (8 `data_graph_service` methods), and 216 (`client_context_service` reentry helpers).

## Test plan

- [x] Repo-wide grep confirms zero non-self references for `execute_capability`, `health_check_all`, `get_document_by_path`, `_EXECUTE_TIMEOUT`
- [x] `services.interface_registry_service` and `services.document_service` import cleanly
- [x] `pytest -m unit tests/test_document_service.py` — 13/13 PASS
- [x] `pytest -m unit tests/test_api_interfaces.py` — 8/8 PASS
- [x] `ruff check` — clean on both touched files
- [ ] Targeted nightly scenarios `030-skill-memory.yaml` + `060-document-lifecycle.yaml` hold or improve vs run 542 baseline (PASS / WARN)