### PR TITLE
chore(tool-config): drop unused is_tool_enabled and get_source_metadata

### DIFF
--- a/backend/services/tool_config_service.py
+++ b/backend/services/tool_config_service.py
@@ -60,11 +60,6 @@ class ToolConfigService:
             logger.debug(f"[TOOL CONFIG] get_tool_config('{tool_name}'): {e}")
             return {}
 
-    def is_tool_enabled(self, tool_name: str) -> bool:
-        """Return True if the tool is enabled (default), False if _enabled=false in DB."""
-        cfg = self.get_tool_config(tool_name)
-        return cfg.get("_enabled", "true").lower() != "false"
-
     def _set_enabled_flag(self, tool_name: str, enabled: bool) -> bool:
         """Write _enabled flag directly, bypassing the reserved-key guard."""
         try:
@@ -112,11 +107,6 @@ class ToolConfigService:
         except Exception as e:
             logger.error(f"[TOOL CONFIG] _set_source_metadata('{tool_name}'): {e}", exc_info=True)
             return False
-
-    def get_source_metadata(self, tool_name: str) -> dict:
-        """Return source tracking fields for a tool: _source_type, _source_url, _installed_tag."""
-        cfg = self.get_tool_config(tool_name)
-        return {k: cfg[k] for k in ("_source_type", "_source_url", "_installed_tag") if k in cfg}
 
     def set_tool_config(self, tool_name: str, config: dict) -> bool:
         """


### PR DESCRIPTION
## Summary
- Deductive cleanup: remove two zero-caller getters in `ToolConfigService` (`is_tool_enabled`, `get_source_metadata`).
- Both are pure read wrappers around `get_tool_config`; matching writers (`_set_enabled_flag`, `_set_source_metadata`) remain in use.
- Net **-10 LOC**, no behavior change.

Verified zero callers across `backend/`, `frontend/`, and `tests/`:
\`\`\`
grep -rn "is_tool_enabled\|get_source_metadata" → no matches
\`\`\`

## Improve-Chalie Cycle (TKT-283)

Targeted scenarios held against rc-0.6.0 baseline (run 547 → run 548):

| Scenario | Baseline | Branch | Δ |
|---|---|---|---|
| 030-skill-memory | PASS 1.0 | PASS 1.0 | held |
| 060-document-lifecycle | WARN 0.72 | WARN 0.72 | held (orthogonal pre-existing anomaly) |

The 060 anomaly ("Missing tool_call record for 'document' skill") is identical pre/post — unrelated to this change.

## Test plan
- [x] `pytest -m unit -k tool_config` (8 passed)
- [x] CI build-log workflow green
- [x] Nightly scenarios 030 + 060 hold against rc-0.6.0 baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)