### PR TITLE
chore(services): drop 5 zero-caller public methods (-54 LOC)

### DIFF
--- a/backend/services/mode_gate_service.py
+++ b/backend/services/mode_gate_service.py
@@ -302,15 +302,6 @@ class ModeGateService:
             )
             return set()
 
-    def get_active_modes(self) -> Set[str]:
-        """Return the set of modes whose current state >= activation_threshold."""
-        try:
-            state = self._load_state()
-            return {m for m in self.MODES if state.get(m, 0.0) >= self._activation_threshold}
-        except Exception as exc:
-            logger.warning("%s get_active_modes failed: %s", LOG_PREFIX, exc)
-            return set()
-
     def get_state(self) -> Dict[str, float]:
         """Return the current per-mode activation state as a fresh dict.
 

--- a/backend/services/output_service.py
+++ b/backend/services/output_service.py
@@ -302,15 +302,3 @@ class OutputService:
         else:
             logger.warning(f"Output {output_id} not found for deletion")
 
-    def register_consumer_heartbeat(self, consumer_type: str) -> None:
-        """
-        Update consumer heartbeat with 60-second TTL.
-
-        Args:
-            consumer_type: Type of consumer (e.g., "text", "act")
-        """
-        heartbeat_key = f"consumer:{consumer_type}:heartbeat"
-        timestamp = utc_now().isoformat()
-
-        self.store.setex(heartbeat_key, 60, timestamp)
-        logger.debug(f"Updated heartbeat for consumer:{consumer_type}")

--- a/backend/services/provider_db_service.py
+++ b/backend/services/provider_db_service.py
@@ -176,21 +176,6 @@ class ProviderDbService:
                 for row in rows
             ]
 
-    def get_provider_by_name(self, name: str) -> Optional[Dict[str, Any]]:
-        """Get provider by name."""
-        with self.db.connection() as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                f"SELECT {self._PROVIDER_COLS} "
-                "FROM providers WHERE name = ? AND is_active = 1",
-                (name,)
-            )
-            row = cursor.fetchone()
-            cursor.close()
-            if not row:
-                return None
-            return self._row_to_provider(row)
-
     def get_provider_by_id(self, provider_id: int) -> Optional[Dict[str, Any]]:
         """Get provider by ID."""
         with self.db.connection() as conn:

--- a/backend/services/providers.py
+++ b/backend/services/providers.py
@@ -149,19 +149,6 @@ class Providers:
             for m in msgs
         )
 
-    def send_async(self, user_prompt, system_prompt, job='unified', tools=None, callback=None):
-        """Fire-and-forget in daemon thread. Calls callback(LLMResponse) when done."""
-        def _run():
-            try:
-                result = self.send(user_prompt, system_prompt, job=job, tools=tools)
-                if callback:
-                    callback(result)
-            except Exception as e:
-                logger.error(f"[Providers] send_async failed: {e}", exc_info=True)
-        t = threading.Thread(target=_run, daemon=True)
-        t.start()
-        return t
-
     def _resolve(self, job):
         """Resolve LLM provider for a job. Uses ConfigService → create_llm_service."""
         from services.config_service import ConfigService

--- a/backend/services/self_model_service.py
+++ b/backend/services/self_model_service.py
@@ -76,11 +76,6 @@ class SelfModelService:
                 logger.debug(f"{LOG_PREFIX} Cache parse failed, refreshing: {e}", exc_info=True)
         return self._refresh()
 
-    def has_noteworthy_state(self) -> bool:
-        """Fast gate — True only when something is degraded."""
-        snapshot = self.get_snapshot()
-        return len(snapshot.get("noteworthy", [])) > 0
-
     def get_memory_richness(self) -> float:
         """0.0 (no activity) to 1.0 (rich memory), from cached snapshot.
 


### PR DESCRIPTION
## What

Deductive cleanup: removes five zero-caller public methods from the services layer. No behaviour change.

| File | Method | LOC |
|------|--------|-----|
| `services/providers.py` | `send_async` | -12 |
| `services/self_model_service.py` | `has_noteworthy_state` | -4 |
| `services/provider_db_service.py` | `get_provider_by_name` | -14 |
| `services/mode_gate_service.py` | `get_active_modes` | -8 |
| `services/output_service.py` | `register_consumer_heartbeat` | -12 |

**Total: -54 LOC.**

## Why

Each method's name was grepped across `services/ abilities/ api/ tools/ tests/ workers/ run.py` and the frontend `.html`/`.js` — zero callers. Pure dead public surface area. Dropping it shortens import time, reduces what future maintainers have to load into their heads, and aligns with CLAUDE.md "Clean removal. No hollow passthroughs."

Imports preserved where still used: `threading` in `providers.py` (still needed for `_lock`), `Set` in `mode_gate_service.py` (still used by `_safe_load_set`).

## Validation

- `python -m py_compile` clean on all 5 files
- Post-removal grep for the 5 method names returns zero matches
- Baseline run 549 on rc-0.6.0: `030-skill-memory.yaml` PASS 1.0, `044-skill-invocation-determinism.yaml` PASS 1.0
- Improvement run will be attached as a comment

## Test plan

- [ ] CI lint + unit tests green
- [ ] Improvement pipeline matches baseline (no score regression, no new anomalies)

Generated as part of [improve-chalie cycle 223 — TKT-284](http://localhost:5555).