### PR TITLE
refactor: drop 5 zero-caller methods (-51 LOC)

### DIFF
--- a/backend/services/config_service.py
+++ b/backend/services/config_service.py
@@ -150,29 +150,3 @@ class ConfigService:
         result = {**provider_config, **agent_config, '_job_name': agent_name}
         return result
 
-    @staticmethod
-    def get_agent_prompt(agent_name: str) -> str:
-        """Load the markdown prompt for a named agent.
-
-        Args:
-            agent_name: Agent prompt name (filename stem under prompts/)
-
-        Returns:
-            Prompt text as a string, or empty string if file not found.
-        """
-        return ConfigService.load_text(str(ConfigService.PROMPTS_DIR / (agent_name + ".md")))
-
-    @staticmethod
-    def get_all_agents() -> list[str]:
-        """List the names of all registered agent configs.
-
-        Returns:
-            List of agent name strings (filename stems from configs/agents/).
-        """
-        agents = []
-
-        for entry in ConfigService.AGENTS_CONFIGS.iterdir():
-            if entry.is_file():
-                agents.append(entry.stem)
-
-        return agents

--- a/backend/services/database_service.py
+++ b/backend/services/database_service.py
@@ -348,15 +348,6 @@ class DatabaseService:
         """Get a connection (thread-local). Compatible with old API."""
         return self._get_connection()
 
-    def release_connection(self, conn):
-        """No-op compatibility shim — SQLite connections are thread-local and reused.
-
-        Args:
-            conn: Ignored.  Present for API compatibility with the old PostgreSQL
-                connection-pool pattern.
-        """
-        pass
-
     @contextmanager
     def connection(self):
         """Yield a thread-local connection, committing or rolling back on exit.

--- a/backend/services/deliberation_ema_service.py
+++ b/backend/services/deliberation_ema_service.py
@@ -118,10 +118,6 @@ class DeliberationEmaService:
         except Exception as exc:
             logger.warning("%s reset failed: %s", LOG_PREFIX, exc)
 
-    def resolve_bucket(self, ema: float) -> str:
-        """Resolve a float EMA to 'high' | 'medium' | 'low'. Exposed for tests."""
-        return self._resolve_bucket(ema)
-
     # ── Private helpers ───────────────────────────────────────────────────────
 
     def _resolve_bucket(self, ema: float) -> str:

--- a/backend/services/settings_service.py
+++ b/backend/services/settings_service.py
@@ -127,17 +127,6 @@ class SettingsService:
             session.commit()
         return True
 
-    def get_all(self) -> dict:
-        """Get all settings (mask sensitive values, never decrypt)."""
-        with self.db.get_session() as session:
-            result = session.execute(
-                text("SELECT key, "
-                     "  CASE WHEN is_sensitive = 1 THEN '***' ELSE value END AS value "
-                     "FROM settings ORDER BY key")
-            )
-            rows = result.fetchall()
-            return {row[0]: row[1] for row in rows}
-
     def get_api_key_or_generate(self) -> str:
         """
         Get API key from settings, or generate and store a new one if not present.

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -168,7 +168,6 @@ def mock_config():
     }
 
     with patch('services.config_service.ConfigService.get_agent_config', side_effect=lambda name: agent_configs.get(name, {})), \
-         patch('services.config_service.ConfigService.get_agent_prompt', side_effect=lambda name: agent_prompts.get(name, '')), \
          patch('services.config_service.ConfigService.connections', return_value=connections):
         yield agent_configs
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -160,7 +160,6 @@ def mock_config():
             'cost_growth_factor': 1.5,
         },
     }
-    agent_prompts = {}
     connections = {
         'memory': {},
         'rest_api': {'host': '0.0.0.0', 'port': 8081},


### PR DESCRIPTION
## Summary

Deductive cycle (Meta-Harness #228, TKT-288): drop 5 zero-caller public methods across 4 services + their conftest patch line.

| File | Method | Why drop |
|---|---|---|
| `services/database_service.py` | `release_connection` | No-op compatibility shim; SQLite is thread-local. |
| `services/deliberation_ema_service.py` | `resolve_bucket` | Public wrapper of `_resolve_bucket`; "exposed for tests" but zero test refs. |
| `services/settings_service.py` | `get_all` | Zero callers across backend, tests, frontend. |
| `services/config_service.py` | `get_agent_prompt` | Zero callers (only mocked in conftest). |
| `services/config_service.py` | `get_all_agents` | Zero callers anywhere. |
| `tests/conftest.py` | `get_agent_prompt` patch line | Removed alongside the deleted method. |

Net **-51 LOC**. Private `_resolve_bucket` retained — has internal callers.

Verified zero callers via AST scan + repo-wide grep (excluding `.git`, `.venv`, `.worktrees`, `chalie-plans`). Unit suite: 1749 passed, 1 pre-existing unrelated failure (`test_enqueue_proactive_called_with_response`, `no such table: telemetry` — predates this branch).

## Test plan

- [ ] CI green (lint + unit + sonar)
- [ ] Targeted scenarios on improve branch hold baseline:
  - 030-skill-memory: PASS ⇒ PASS
  - 044-skill-invocation-determinism: PASS ⇒ PASS
  - 060-document-lifecycle: WARN ⇒ WARN (orthogonal anomaly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)