### PR TITLE
chore(services): drop dead format_tool_result helper

### DIFF
--- a/backend/services/tool_output_utils.py
+++ b/backend/services/tool_output_utils.py
@@ -1,84 +1,8 @@
 """
-Tool Output Utilities — Shared formatting, sanitization, and telemetry.
+Tool Output Utilities — Telemetry construction.
 
-Shared helpers used by ToolRegistryService for result formatting and
-telemetry construction.
+Shared helpers used by ToolRegistryService for telemetry construction.
 """
-
-import json
-from typing import Any
-
-
-MAX_OUTPUT_CHARS = 3000
-
-
-def format_tool_result(result: Any) -> str:
-    """Convert a tool result dict/str into plain text for LLM consumption.
-
-    Handles three structured output patterns:
-    - {"results": [...]} — search-style results with title/snippet/url
-    - {"content": "..."} — page extraction with optional truncation
-    - Generic dict — key/value pairs
-
-    Args:
-        result: Raw tool output (str, dict, or other)
-
-    Returns:
-        Formatted plain text string
-    """
-    if isinstance(result, str):
-        return result
-
-    if not isinstance(result, dict):
-        return str(result)
-
-    lines = []
-
-    # Search-style results
-    if "results" in result and isinstance(result["results"], list):
-        results = result["results"]
-        if not results:
-            lines.append(result.get("message", "No results found."))
-        else:
-            for i, r in enumerate(results, 1):
-                if isinstance(r, dict):
-                    title = r.get("title", "")
-                    snippet = r.get("snippet", "")
-                    url = r.get("url", "")
-                    lines.append(f"{i}. {title}")
-                    if snippet:
-                        lines.append(f"   {snippet}")
-                    if url:
-                        lines.append(f"   {url}")
-                else:
-                    lines.append(f"{i}. {r}")
-        if result.get("count") is not None and result["count"] > 0:
-            lines.append(f"\n{result['count']} results returned.")
-        return "\n".join(lines)
-
-    # Page extraction
-    if "content" in result and isinstance(result["content"], str):
-        content = result["content"]
-        if result.get("error"):
-            return f"Error: {result['error']}"
-        if not content:
-            return "No content extracted from page."
-        parts = [content]
-        if result.get("truncated"):
-            parts.append(f"(truncated to {result.get('char_count', '?')} chars)")
-        return "\n".join(parts)
-
-    # Generic key/value
-    for key, value in result.items():
-        if key in ("budget_remaining",):
-            continue
-        if isinstance(value, (list, dict)):
-            lines.append(f"{key}: {json.dumps(value, default=str)[:500]}")
-        else:
-            lines.append(f"{key}: {value}")
-
-    return "\n".join(lines)
-
 
 def build_tool_telemetry(raw_telemetry: dict) -> dict:
     """Flatten client context telemetry into the tool contract format.

--- a/backend/tests/test_tool_output_utils.py
+++ b/backend/tests/test_tool_output_utils.py
@@ -1,70 +1,15 @@
 """
-Behavioural tests for tool_output_utils — pure formatting functions.
+Behavioural tests for tool_output_utils — telemetry construction.
 
-Both format_tool_result and build_tool_telemetry are deterministic with zero
-collaborators, so they qualify for unit tests per tester.md.
+build_tool_telemetry is deterministic with zero collaborators, qualifying
+for unit tests per tester.md.
 """
 
 import pytest
 
-from services.tool_output_utils import format_tool_result, build_tool_telemetry
+from services.tool_output_utils import build_tool_telemetry
 
 pytestmark = pytest.mark.unit
-
-
-# ── format_tool_result ──────────────────────────────────────────────────────
-
-class TestFormatToolResult:
-    def test_str_passthrough(self):
-        assert format_tool_result("hello") == "hello"
-
-    def test_non_dict_falls_back_to_str(self):
-        assert format_tool_result(42) == "42"
-
-    def test_empty_results_shows_message(self):
-        assert format_tool_result({"results": [], "message": "nope"}) == "nope"
-
-    def test_search_results_formats_numbered_list(self):
-        result = format_tool_result({
-            "results": [
-                {"title": "First", "snippet": "desc", "url": "https://a"},
-                {"title": "Second", "snippet": "", "url": ""},
-            ],
-        })
-        lines = result.split("\n")
-        assert lines[0] == "1. First"
-        assert lines[1] == "   desc"
-        assert lines[2] == "   https://a"
-        assert "2. Second" in result
-
-    def test_search_results_shows_count_when_present(self):
-        result = format_tool_result({
-            "results": [{"title": "X"}],
-            "count": 1,
-        })
-        assert "1 results returned." in result
-
-    def test_page_content_with_truncation(self):
-        result = format_tool_result({
-            "content": "some text",
-            "truncated": True,
-            "char_count": 500,
-        })
-        assert "some text" in result
-        assert "truncated to 500 chars" in result
-
-    def test_page_content_error(self):
-        result = format_tool_result({"content": "", "error": "timeout"})
-        assert result == "Error: timeout"
-
-    def test_generic_dict_skips_budget_remaining(self):
-        result = format_tool_result({"a": 1, "budget_remaining": 500})
-        assert "a: 1" in result
-        assert "budget_remaining" not in result
-
-    def test_generic_dict_lists_serialized(self):
-        result = format_tool_result({"items": [1, 2]})
-        assert "items: [1, 2]" in result
 
 
 # ── build_tool_telemetry ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Pure deductive dead-code drop. `format_tool_result()` and `MAX_OUTPUT_CHARS` in `backend/services/tool_output_utils.py` had **zero non-test callers** anywhere in the codebase (grep-verified). Sibling `build_tool_telemetry` IS live (`backend/services/act_dispatcher_service.py:30`) and remains untouched.

- Drops `format_tool_result()` (~66 LOC) + `MAX_OUTPUT_CHARS` constant from `backend/services/tool_output_utils.py`
- Drops `TestFormatToolResult` test class from `backend/tests/test_tool_output_utils.py`
- Removes orphan `import json` and `from typing import Any` (no longer needed)
- Trims module + test docstrings to match new (telemetry-only) responsibility
- Net: **-131 LOC** across 2 files

## Cycle 229 — improve-chalie ([TKT-289](http://grck.lan:5100/tickets/289))

### Targeted scenarios

| Scenario | Baseline (run 560, rc-0.6.0) | This branch (run 561) |
|---|---|---|
| 030-skill-memory | **PASS** | **PASS** ✓ held |
| 044-skill-invocation-determinism | **PASS** | **PASS** ✓ held |
| 060-document-lifecycle | **WARN** (step-4 \`document\` count=0; step-5 correctness PASS "342 employees") | **WARN** ✓ held — identical orthogonal anomaly fingerprint |

The 060 step-4 \`document\` tool-call anomaly is the same one carried through cycles 220-228 (orthogonal to this drop — `format_tool_result` is not in the document path).

### Verification

- Self-review gate 8/8 PASS
- Lint green (ruff)
- Full unit suite: 2230 passed, 17 skipped
- CI on push: "Update build log" success in 12s

## Test plan
- [x] Full unit suite green (2230 passed)
- [x] Targeted scenarios held vs baseline
- [x] No non-test reference to `format_tool_result` or `MAX_OUTPUT_CHARS` remains
- [x] `build_tool_telemetry` and its caller unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)