### PR TITLE
chore(news): drop dead cluster_trending + helpers

### DIFF
--- a/backend/services/news_service.py
+++ b/backend/services/news_service.py
@@ -32,13 +32,6 @@ PER_FEED_TIMEOUT = 5.0
 TOTAL_BUDGET = 8.0
 RELEVANCE_FLOOR = 0.3
 LEVENSHTEIN_THRESHOLD = 5
-JACCARD_THRESHOLD = 0.5
-
-_STOPWORDS = frozenset({
-    "the", "a", "an", "is", "in", "of", "to", "and", "for", "with",
-    "on", "at", "by", "it", "its", "as", "are", "was", "be", "has",
-    "have", "had", "that", "this", "from", "or", "but", "not", "s", "us",
-})
 
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 _ENTITY_MAP = {"&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": '"', "&#039;": "'", "&nbsp;": " "}
@@ -346,63 +339,6 @@ class NewsService:
         relevant.sort(key=lambda x: x[1], reverse=True)
         return [a for a, _ in relevant]
 
-    # ── Trending clustering ───────────────────────────────────
-
-    def cluster_trending(self, articles: list, min_sources: int = 2, limit: int = 5) -> list:
-        """Jaccard similarity clustering on tokenized titles."""
-        if not articles:
-            return []
-
-        clusters = []  # list of {"articles": [], "word_sets": []}
-
-        for article in articles:
-            words = _tokenize_title(article.title)
-            if not words:
-                continue
-            merged = False
-            for cluster in clusters:
-                for ws in cluster["word_sets"]:
-                    if _jaccard(words, ws) >= JACCARD_THRESHOLD:
-                        cluster["articles"].append(article)
-                        cluster["word_sets"].append(words)
-                        merged = True
-                        break
-                if merged:
-                    break
-            if not merged:
-                clusters.append({"articles": [article], "word_sets": [words]})
-
-        # Finalize
-        result = []
-        for cluster in clusters:
-            # Deduplicate within cluster
-            seen_urls = set()
-            seen_titles = set()
-            deduped = []
-            for a in cluster["articles"]:
-                if a.url in seen_urls:
-                    continue
-                t_lower = a.title.lower()
-                if t_lower in seen_titles:
-                    continue
-                seen_urls.add(a.url)
-                seen_titles.add(t_lower)
-                deduped.append(a)
-
-            if len(deduped) < min_sources:
-                continue
-
-            # Representative title = longest
-            rep_title = max(deduped, key=lambda a: len(a.title)).title
-            result.append({
-                "title": rep_title,
-                "articles": deduped,
-                "coverage": len(deduped),
-            })
-
-        result.sort(key=lambda c: c["coverage"], reverse=True)
-        return result[:limit]
-
     # ── Convenience methods ───────────────────────────────────
 
     def search(self, query: str, source_ids: list = None, limit: int = 10, country_code: str = "US") -> list:
@@ -467,19 +403,6 @@ def _levenshtein(s1: str, s2: str) -> int:
             curr[j] = min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost)
         prev, curr = curr, prev
     return prev[n]
-
-
-def _tokenize_title(title: str) -> set:
-    words = _PUNCT_RE.sub(" ", title.lower()).split()
-    return {w for w in words if w and w not in _STOPWORDS}
-
-
-def _jaccard(set_a: set, set_b: set) -> float:
-    if not set_a and not set_b:
-        return 1.0
-    if not set_a or not set_b:
-        return 0.0
-    return len(set_a & set_b) / len(set_a | set_b)
 
 
 _MEDIA_NS = "{http://search.yahoo.com/mrss/}"

--- a/backend/tests/test_news_service.py
+++ b/backend/tests/test_news_service.py
@@ -9,7 +9,7 @@ import pytest
 from services.news_service import (
     NewsService, NewsArticle,
     _strip_html, _parse_date, _normalize_title, _levenshtein,
-    _tokenize_title, _jaccard, _derive_domain,
+    _derive_domain,
 )
 
 SAMPLE_RSS = b'''<?xml version="1.0" encoding="UTF-8"?>
@@ -115,35 +115,6 @@ class TestHelpers:
 
     def test_levenshtein_different(self):
         assert _levenshtein("cat", "dog") == 3
-
-    def test_tokenize_title_removes_stopwords(self):
-        tokens = _tokenize_title("The cat is on the mat")
-        assert "the" not in tokens
-        assert "is" not in tokens
-        assert "on" not in tokens
-        assert "cat" in tokens
-        assert "mat" in tokens
-
-    def test_tokenize_title_lowercase(self):
-        tokens = _tokenize_title("HELLO WORLD")
-        assert "hello" in tokens
-        assert "world" in tokens
-
-    def test_jaccard_identical(self):
-        assert _jaccard({"a", "b", "c"}, {"a", "b", "c"}) == pytest.approx(1.0, abs=1e-9)
-
-    def test_jaccard_disjoint(self):
-        assert _jaccard({"a", "b"}, {"c", "d"}) == pytest.approx(0.0, abs=1e-9)
-
-    def test_jaccard_partial(self):
-        result = _jaccard({"a", "b", "c"}, {"b", "c", "d"})
-        assert abs(result - 0.5) < 0.01  # 2/4
-
-    def test_jaccard_both_empty(self):
-        assert _jaccard(set(), set()) == pytest.approx(1.0, abs=1e-9)
-
-    def test_jaccard_one_empty(self):
-        assert _jaccard({"a"}, set()) == pytest.approx(0.0, abs=1e-9)
 
     def test_derive_domain_strips_rss_prefix(self):
         assert _derive_domain("https://feeds.bbci.co.uk/news/rss.xml") == "bbci.co.uk"
@@ -313,67 +284,6 @@ class TestRanking:
         ]
         result = self.svc.rank_by_relevance(articles, "query")
         assert len(result) == 2  # All returned, date-sorted
-
-
-# ── Clustering tests ──────────────────────────────────────────
-
-@pytest.mark.unit
-class TestClustering:
-
-    def setup_method(self):
-        self.svc = NewsService()
-
-    def test_similar_titles_clustered(self):
-        articles = [
-            _make_article(title="AI breakthrough in healthcare announced", source="BBC",
-                         url="https://bbc.com/article-1"),
-            _make_article(title="AI breakthrough in healthcare reported", source="CNN",
-                         url="https://cnn.com/article-2"),
-            _make_article(title="Completely unrelated sports story", source="ESPN",
-                         url="https://espn.com/article-3"),
-        ]
-        clusters = self.svc.cluster_trending(articles, min_sources=2, limit=5)
-        assert len(clusters) >= 1
-        assert clusters[0]["coverage"] == 2
-
-    def test_clusters_below_min_sources_filtered(self):
-        articles = [
-            _make_article(title="Unique story one", source="BBC"),
-            _make_article(title="Unique story two", source="CNN"),
-        ]
-        clusters = self.svc.cluster_trending(articles, min_sources=3, limit=5)
-        assert len(clusters) == 0
-
-    def test_representative_title_is_longest(self):
-        articles = [
-            _make_article(title="Short title about AI", source="BBC",
-                         url="https://bbc.com/1"),
-            _make_article(title="A much longer and more detailed title about AI breakthroughs in medicine",
-                         source="CNN", url="https://cnn.com/2"),
-        ]
-        clusters = self.svc.cluster_trending(articles, min_sources=2, limit=5)
-        if clusters:
-            assert "longer" in clusters[0]["title"] or "detailed" in clusters[0]["title"]
-
-    def test_empty_articles(self):
-        assert self.svc.cluster_trending([], min_sources=2, limit=5) == []
-
-    def test_clusters_sorted_by_coverage(self):
-        articles = [
-            _make_article(title="Big story about climate change", source="BBC",
-                         url="https://bbc.com/1"),
-            _make_article(title="Big story about climate change today", source="CNN",
-                         url="https://cnn.com/2"),
-            _make_article(title="Big story about climate change reported", source="AP",
-                         url="https://ap.com/3"),
-            _make_article(title="Small tech news item", source="TechCrunch",
-                         url="https://tc.com/4"),
-            _make_article(title="Small tech news item today", source="Wired",
-                         url="https://wired.com/5"),
-        ]
-        clusters = self.svc.cluster_trending(articles, min_sources=2, limit=5)
-        if len(clusters) >= 2:
-            assert clusters[0]["coverage"] >= clusters[1]["coverage"]
 
 
 # ── Google News country code tests ───────────────────────────


### PR DESCRIPTION
## Cycle 231 — Deductive

Drops `NewsService.cluster_trending` + `_tokenize_title` + `_jaccard` + `JACCARD_THRESHOLD` + `_STOPWORDS` from `backend/services/news_service.py`. Zero production callers — only test references. Matching `TestClustering` / tokenize / jaccard tests removed from `backend/tests/test_news_service.py`.

**Net:** -168 LOC (-77 service, -91 tests).

**Targeted scenarios (baseline run 564 on rc-0.6.0):**
- 053-tool-news.yaml: WARN 0.88 (excessive_latency 357s, deterministic 1.0/1.0)
- 054-tool-news-image.yaml: PASS 0.92

The targeted anomaly is excessive ACT-loop latency in 053 — pure dead-code drop is orthogonal but reduces resident surface area. Targeting hold-or-improve.

## Self-review (8/8)

Pure deletion, zero residue, all surviving regexes/constants verified to still have callers (`_PUNCT_RE` line 387, etc.). 60/60 pytest pass on news suite. Ruff clean.

Taskie: TKT-291.