### PR TITLE
chore(output): drop 3 zero-caller queue-routing methods (-235 LOC)

### DIFF
--- a/backend/services/output_service.py
+++ b/backend/services/output_service.py
@@ -1,10 +1,8 @@
 import json
 import logging
 import uuid
-from typing import Dict, Any, Optional, List
 
 from .memory_client import MemoryClientService
-from .config_service import ConfigService
 from .time_utils import utc_now
 from .markup import actions_to_xml, sanitize
 
@@ -17,13 +15,9 @@ class OutputService:
     """Service for managing output queue and storage with type-based routing."""
 
     def __init__(self):
-        """Initialize the OutputService with MemoryStore connection and config."""
+        """Initialize the OutputService with MemoryStore connection."""
         self.store = MemoryClientService.create_connection()
-        config = ConfigService.connections()
-        topics = config.get("memory", {}).get("topics", {})
-        self.queue_name = topics.get("output_queue", "output-queue")
-
-        logger.info(f"OutputService initialized with queue: {self.queue_name}")
+        logger.info("OutputService initialized")
 
     def enqueue_text(
         self,
@@ -191,114 +185,4 @@ class OutputService:
             metrics=metrics,
         )
 
-    def enqueue_act(
-        self,
-        topic: str = None,
-        actions: List[str] = None,
-        downstream_mode: str = 'ACT',
-        act_history: List[Dict[str, Any]] = None,
-        loop_id: str = '',
-        generation_time: float = 0.0,
-        channel: str = None,
-    ) -> str:
-        """
-        Enqueue an ACT output for action processing.
-
-        Args:
-            topic: Conversation topic identifier
-            actions: List of actions to execute
-            downstream_mode: Mode to use after action processing
-            act_history: History of previous actions in this cycle
-            loop_id: Identifier for the action loop
-            generation_time: Time taken to generate the actions
-
-        Returns:
-            str: UUID of the enqueued output
-        """
-        _channel = channel or topic
-        actions = actions or []
-        act_history = act_history or []
-        output_id = str(uuid.uuid4())
-        output = {
-            "id": output_id,
-            "type": "ACT",
-            "topic": _channel,
-            "created_at": utc_now().isoformat(),
-            "metadata": {
-                "actions": actions,
-                "downstream_mode": downstream_mode,
-                "act_history": act_history,
-                "loop_id": loop_id,
-                "generation_time": generation_time
-            }
-        }
-
-        # Store with 1-hour TTL
-        self.store.setex(f"output:{output_id}", 3600, json.dumps(output))
-
-        # Add to queue
-        self.store.lpush(self.queue_name, output_id)
-        self.store.expire(self.queue_name, 3600)
-
-        logger.info(
-            f"Enqueued ACT output {output_id} for topic '{_channel}' "
-            f"(loop_id={loop_id}, actions={len(actions)})"
-        )
-
-        return output_id
-
-    def dequeue(self, output_type: Optional[str] = None, timeout: int = 0) -> Optional[Dict[str, Any]]:
-        """
-        Dequeue an output from the queue with optional type filtering.
-
-        Args:
-            output_type: Optional filter for output type (TEXT, ACT)
-            timeout: BRPOP timeout in seconds (0 = block indefinitely)
-
-        Returns:
-            Dict containing the output data, or None if timeout
-        """
-        while True:
-            result = self.store.brpop(self.queue_name, timeout)
-
-            if not result:
-                return None
-
-            _, output_id = result
-
-            # Handle both bytes and str
-            if isinstance(output_id, bytes):
-                output_id = output_id.decode()
-
-            output_data = self.store.get(f"output:{output_id}")
-
-            if not output_data:
-                logger.warning(f"Output {output_id} expired or deleted, skipping")
-                continue
-
-            output = json.loads(output_data)
-
-            # Filter by type if specified
-            if output_type and output.get('type') != output_type:
-                logger.debug(f"Re-queuing output {output_id} (type={output.get('type')}, want={output_type})")
-                self.store.lpush(self.queue_name, output_id)
-                self.store.expire(self.queue_name, 3600)
-                continue
-
-            logger.info(f"Dequeued {output.get('type')} output {output_id}")
-            return output
-
-    def delete_output(self, output_id: str) -> None:
-        """
-        Delete an output from storage.
-
-        Args:
-            output_id: UUID of the output to delete
-        """
-        deleted = self.store.delete(f"output:{output_id}")
-
-        if deleted:
-            logger.info(f"Deleted output {output_id}")
-        else:
-            logger.warning(f"Output {output_id} not found for deletion")
 

--- a/backend/tests/test_memorystore_ttl.py
+++ b/backend/tests/test_memorystore_ttl.py
@@ -14,7 +14,6 @@ Pattern used throughout:
   A non-None expiry confirms the TTL was set.
 """
 
-import json
 import pytest
 from unittest.mock import patch
 
@@ -37,61 +36,6 @@ def _has_ttl(store: MemoryStore, key: str) -> bool:
             _, expiry = keyspace[key]
             return expiry is not None
     return False
-
-
-# ---------------------------------------------------------------------------
-# 1. output_service — enqueue path + re-queue path
-# ---------------------------------------------------------------------------
-
-@pytest.mark.unit
-class TestOutputServiceQueueTTL:
-    """After every lpush to output-queue, expire(output-queue, 3600) must fire.
-
-    The output-queue is written by enqueue_act (primary path) and by the
-    re-queue branch inside dequeue() when a type-mismatch is detected.
-    enqueue_text does NOT touch output-queue; it uses setex on the output key
-    and rpush/expire on notifications:recent.
-    """
-
-    @pytest.fixture
-    def svc(self):
-        store = MemoryStore()
-        connections = {"memory": {"topics": {"output_queue": "output-queue"}}}
-        with patch("services.memory_client.MemoryClientService.create_connection",
-                   return_value=store), \
-             patch("services.config_service.ConfigService.connections",
-                   return_value=connections):
-            from services.output_service import OutputService
-            return OutputService(), store
-
-    def test_enqueue_act_sets_ttl_on_output_queue(self, svc):
-        """enqueue_act calls lpush then expire(output-queue, 3600)."""
-        service, store = svc
-        service.enqueue_act(topic="t", actions=["search"], channel="web:default:1")
-        assert _has_ttl(store, "output-queue"), "output-queue must have a TTL after enqueue_act lpush"
-
-    def test_requeue_sets_ttl_on_output_queue(self, svc):
-        """dequeue re-queue path (type mismatch) calls expire on output-queue."""
-        service, store = svc
-
-        # Push a TEXT output and an ACT output so that dequeue finds ACT on second pop.
-        # brpop pops from the right, so ACT is at the right (last) position.
-        text_output = {"id": "out-text", "type": "TEXT", "topic": "t", "metadata": {}}
-        act_output = {"id": "out-act", "type": "ACT", "topic": "t",
-                      "metadata": {"actions": [], "downstream_mode": "ACT",
-                                   "act_history": [], "loop_id": "", "generation_time": 0.0}}
-        store.set("output:out-text", json.dumps(text_output))
-        store.set("output:out-act", json.dumps(act_output))
-        # rpush appends to the right; brpop pops from the right.
-        # Push ACT first (left), then TEXT (rightmost) so TEXT is popped first.
-        store.rpush("output-queue", "out-act")
-        store.rpush("output-queue", "out-text")
-
-        # dequeue asks for ACT: pops out-text (type mismatch) → re-queues it → pops out-act → returns
-        result = service.dequeue(output_type="ACT", timeout=2)
-
-        assert result is not None and result["type"] == "ACT"
-        assert _has_ttl(store, "output-queue"), "output-queue must have a TTL after re-queue lpush"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_output_service.py
+++ b/backend/tests/test_output_service.py
@@ -46,7 +46,7 @@ class TestOutputService:
     @pytest.fixture
     def service(self, mock_store):
         """
-        Create OutputService with a real MemoryStore and stubbed config.
+        Create OutputService with a real MemoryStore.
 
         Args:
             mock_store: Real MemoryStore (with publish spy) injected by fixture.
@@ -54,15 +54,8 @@ class TestOutputService:
         Returns:
             OutputService: Fully initialised service instance.
         """
-        connections = {
-            "memory": {
-                "topics": {"output_queue": "output-queue"},
-            }
-        }
         with patch('services.memory_client.MemoryClientService.create_connection',
-                    return_value=mock_store), \
-             patch('services.config_service.ConfigService.connections',
-                   return_value=connections):
+                    return_value=mock_store):
             svc = OutputService()
         return svc
 
@@ -160,62 +153,6 @@ class TestOutputService:
 
         recent = mock_store.lrange("notifications:recent", 0, -1)
         assert len(recent) > 0
-
-    # ------------------------------------------------------------------ #
-    # dequeue
-    # ------------------------------------------------------------------ #
-
-    def test_dequeue_returns_output_from_queue(self, service, mock_store):
-        """Successful dequeue returns the parsed output dict."""
-        output_data = {
-            "id": "out-1",
-            "type": "ACT",
-            "topic": "t",
-            "metadata": {"actions": ["search"]},
-        }
-        mock_store.set("output:out-1", json.dumps(output_data))
-        mock_store.rpush("output-queue", "out-1")
-
-        result = service.dequeue(output_type="ACT", timeout=1)
-
-        assert result is not None
-        assert result["id"] == "out-1"
-        assert result["type"] == "ACT"
-
-    def test_dequeue_requeues_mismatched_type(self, service, mock_store):
-        """When dequeued output type does not match, it is re-queued via lpush."""
-        text_output = {"id": "out-2", "type": "TEXT", "topic": "t", "metadata": {}}
-        act_output = {"id": "out-3", "type": "ACT", "topic": "t", "metadata": {}}
-
-        # rpush appends to the right; brpop pops from the right.
-        # Push out-3 first so out-2 sits at the right end and is popped first.
-        mock_store.set("output:out-2", json.dumps(text_output))
-        mock_store.set("output:out-3", json.dumps(act_output))
-        mock_store.rpush("output-queue", "out-3")
-        mock_store.rpush("output-queue", "out-2")
-
-        result = service.dequeue(output_type="ACT", timeout=1)
-
-        assert result["type"] == "ACT"
-        # out-2 (TEXT) must have been re-queued back onto the list
-        queued = mock_store.lrange("output-queue", 0, -1)
-        assert "out-2" in queued
-
-    def test_dequeue_returns_none_on_timeout(self, service, mock_store):
-        """When brpop times out (returns None), dequeue returns None."""
-        # Empty queue — brpop will exhaust the timeout and return None
-        result = service.dequeue(output_type="ACT", timeout=1)
-        assert result is None
-
-    # ------------------------------------------------------------------ #
-    # delete_output
-    # ------------------------------------------------------------------ #
-
-    def test_delete_output_calls_store_delete(self, service, mock_store):
-        """delete_output removes the output key from the store."""
-        mock_store.set("output:dead-uuid-42", json.dumps({"id": "dead-uuid-42"}))
-        service.delete_output("dead-uuid-42")
-        assert mock_store.get("output:dead-uuid-42") is None
 
     # ------------------------------------------------------------------ #
     # notifications:recent trimming


### PR DESCRIPTION
## Summary

Drop three zero-caller public methods on `OutputService` plus their dead supporting state and matching tests.

- `OutputService.enqueue_act` — no live callers (live ACT path is `notifications:recent` rpush + `output:<id>` setex inside `enqueue_text`)
- `OutputService.dequeue` — no live callers
- `OutputService.delete_output` — no live callers
- `self.queue_name` attribute + `ConfigService.connections()` lookup — only fed the three removed methods
- `Dict/Any/Optional/List` typing imports + `ConfigService` import — all unused after rip
- `TestOutputServiceQueueTTL` class in `test_memorystore_ttl.py` — exercises only the dead path
- 4 tests in `test_output_service.py` (`test_dequeue_*`, `test_delete_output_*`) — exercise only the dead path

Live paths preserved: `enqueue_text` (used by `/chat` SSE delivery) and `enqueue_proactive` (used by background workers, subagent delivery, etc.) both write `output:<id>` setex + `notifications:recent` rpush, never `output-queue`.

Net: +4 / -239 across 3 files.

## Test plan

- [x] `pytest -m unit` — 2169 passed, 17 skipped
- [x] `vulture --confidence 60` — three target methods drop off, no new findings
- [x] Repo-wide grep for `enqueue_act`, `dequeue\(`, `delete_output\(`, `queue_name`, `output-queue` — no live references remain (api/system.py:192 reads `output-queue` depth as a health-check diagnostic, structurally valid, just always 0 now)
- [ ] Targeted nightly scenarios (030-skill-memory, 044-skill-invocation-determinism, 060-document-lifecycle) — harness is currently wedged; will run on merge

## Cycle metadata

Tracked: TKT-295 (Cycle 1, project Chalie). Approach: deductive. Same orthogonal probe set as cycles 228/230/232 which all held identical scores after similar dead-code rips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)