### PR TITLE
improve(drop-dead): rip ConfigService.load_text + PROMPTS_DIR

### DIFF
--- a/backend/services/config_service.py
+++ b/backend/services/config_service.py
@@ -2,8 +2,7 @@
 Config Service — Centralized configuration loading and provider resolution.
 
 Loads agent configs from JSON files, merges the globally selected provider
-into the resolved config, and exposes helpers for prompt text, connection
-settings, and registered agent names.
+into the resolved config, and exposes helpers for connection settings.
 """
 
 import json
@@ -15,10 +14,9 @@ logger = logging.getLogger(__name__)
 
 
 class ConfigService:
-    """Static configuration service for agents, providers, prompts, and connections."""
+    """Static configuration service for agents, providers, and connections."""
 
     CONFIGS_DIR         = Path(__file__).resolve().parent.parent / "configs"
-    PROMPTS_DIR         = Path(__file__).resolve().parent.parent / "prompts"
     CONNECTIONS_CONFIG  = str(CONFIGS_DIR / "connections.json")
     AGENTS_CONFIGS      = CONFIGS_DIR / "agents"
 
@@ -38,21 +36,6 @@ class ConfigService:
         """
         with open(file_path, 'r') as f:
             return json.load(f)
-
-    @staticmethod
-    def load_text(file_path: str) -> str:
-        """Load the text content of a file, returning empty string if missing.
-
-        Args:
-            file_path: Absolute or relative path to the text file.
-
-        Returns:
-            Stripped text content of the file, or empty string if it does not exist.
-        """
-        path = Path(file_path)
-        if not path.exists():
-            return ""
-        return path.read_text().strip()
 
     @staticmethod
     def connections() -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
Deductive cycle (TKT-300). Removes two zero-caller surfaces from `ConfigService` plus stale docstring text.

- `ConfigService.PROMPTS_DIR` — pointed to `backend/prompts/` which doesn't exist on disk
- `ConfigService.load_text(file_path)` — staticmethod with zero callers anywhere in repo
- Class + module docstrings synced to drop "prompts" from advertised responsibilities

Net: **−19 LOC** in one file (`backend/services/config_service.py`).

## Evidence
- Exhaustive grep across `*.py *.md *.sh *.json *.yaml *.yml *.html *.js` — zero matches for `PROMPTS_DIR` / `load_text` / `ConfigService.load_text` / `config_service.load_text`
- `backend/prompts/` directory does not exist on filesystem
- `python3 -m py_compile backend/services/config_service.py` — OK
- `ruff check backend/services/config_service.py` — All checks passed
- Full unit suite — **2175 passed**, 17 skipped, 0 failed (2:19)

## Baseline (run 572, branch rc-0.7.0, 2026-05-10)
| Scenario | Verdict | Score |
|---|---|---|
| 030-skill-memory | PASS | 1.000 |
| 044-skill-invocation-determinism | PASS | 1.000 |
| 060-document-lifecycle | WARN | 0.667 |

Aggregate: **0.9067**

## Improve-branch verification
Pipeline wedged at install phase (>25 status checks, never advanced past `Running install.sh`). Same harness wedge pattern as cycle 235 (PR #1747 / TKT-295), which shipped on static evidence and held.

This change cannot affect runtime behavior: the removed surfaces are unreachable (zero callers proven via exhaustive grep) and the unit suite is fully green. Pattern matches 6 prior held-score deletion cycles (230-234).

## Test plan
- [x] grep audit shows zero callers
- [x] py_compile clean
- [x] ruff clean
- [x] full unit suite green (2175 passed)
- [ ] nightly fingerprint (deferred — harness wedged; will validate on next clean nightly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)