### PR TITLE
chore(memory-store): drop dead lindex/lset/blpop/listen redis-api stubs

### DIFF
--- a/backend/services/memory_store.py
+++ b/backend/services/memory_store.py
@@ -329,49 +329,6 @@ class MemoryStore:
                 return None
             return lst.pop(0)
 
-    def lindex(self, key: str, index: int) -> Optional[str]:
-        """Return the element at ``index`` in the list at ``key``.
-
-        Supports negative indices.
-
-        Args:
-            key: List key.
-            index: Zero-based position (may be negative).
-
-        Returns:
-            The element at the given position, or ``None`` if out of range or key absent.
-        """
-        with self._list_lock:
-            lst = self._get_list(key)
-            if lst is None:
-                return None
-            try:
-                return lst[index]
-            except IndexError:
-                return None
-
-    def lset(self, key: str, index: int, value: str):
-        """Set the list element at ``index`` to ``value``.
-
-        Args:
-            key: List key.
-            index: Zero-based position to update (may be negative).
-            value: New value (coerced to ``str``).
-
-        Returns:
-            ``True`` on success.
-
-        Raises:
-            Exception: If the key does not exist.
-            IndexError: If ``index`` is out of range.
-        """
-        with self._list_lock:
-            lst = self._get_list(key)
-            if lst is None:
-                raise Exception("no such key")
-            lst[index] = str(value)
-            return True
-
     def brpop(self, key: str, timeout: int = 0) -> Optional[Tuple[str, str]]:
         """Blocking right-pop. Polls with sleep for simplicity."""
         deadline = time.time() + timeout if timeout > 0 else None
@@ -381,22 +338,6 @@ class MemoryStore:
                 if lst:
                     val = lst.pop()
                     return (key, val)
-            if deadline and time.time() >= deadline:
-                return None
-            time.sleep(0.1)
-
-    def blpop(self, keys, timeout: int = 0):
-        """Blocking left-pop from first non-empty key."""
-        if isinstance(keys, str):
-            keys = [keys]
-        deadline = time.time() + timeout if timeout > 0 else None
-        while True:
-            with self._list_lock:
-                for key in keys:
-                    lst = self._get_list(key)
-                    if lst:
-                        val = lst.pop(0)
-                        return (key, val)
             if deadline and time.time() >= deadline:
                 return None
             time.sleep(0.1)
@@ -839,13 +780,6 @@ class PubSubProxy:
                 return self._queue.get_nowait()
         except queue_module.Empty:
             return None
-
-    def listen(self):
-        """Generator that yields messages (blocking)."""
-        while True:
-            msg = self.get_message(timeout=1.0)
-            if msg:
-                yield msg
 
     def close(self):
         """Unsubscribe from all channels and release this proxy's queue from the store."""


### PR DESCRIPTION
## Summary
Continuation of cycle 233 (`a862b3f`) deductive dead-code rip pattern. Four zero-caller Redis-API methods removed from `backend/services/memory_store.py`:

- `MemoryStore.lindex` (list random-access by index)
- `MemoryStore.lset` (list element overwrite)
- `MemoryStore.blpop` (blocking left-pop)
- `PubSubProxy.listen` (blocking message generator)

`brpop` (line 375) is the only blocking list-pop in production use (rate limiter, queue daemons) and remains untouched.

## Verification

**Static evidence:**
- Grep across `backend/` for `lset|blpop|lindex|.listen()` → zero non-self callers
- 2175 unit tests pass on the improve worktree
- ruff clean, vulture clean

**Nightly pipeline (rc-0.7.0 baseline run 575 vs improve run 576, scenarios 030/044/060):**
| Scenario | Baseline | Improve |
|----------|----------|---------|
| 030 skill-memory | PASS 1.0 | PASS 1.0 |
| 044 skill-invocation-determinism | PASS 1.0 | PASS 1.0 |
| 060 document-lifecycle | WARN 0.72 | WARN 0.60 |
| **Total score** | 0.9066 | 0.8666 |

Score dipped 0.04 due to 060's documented orthogonal `tool_calls=0 for document` anomaly (file_tags injection bypassing document skill — known issue blocked by the HARD RULE on prompt edits, see cycles 232-236). PASS count held. **The four removed methods are zero-caller — there is no causal path from this diff to 060's behavior.** The dip is harness noise within 060's WARN range.

## Diff
- 1 file changed, 66 deletions(-)

## Test plan
- [x] Unit tests (2175 pass)
- [x] Linters (ruff)
- [x] Dead-code scan (vulture)
- [x] Nightly scenarios 030/044/060 (PASS count held)

## Tracking
TKT-302

🤖 Generated with [Claude Code](https://claude.com/claude-code)