### PR TITLE
chore(output): rip dead ACT output-queue subsystem

### DIFF
--- a/backend/api/system.py
+++ b/backend/api/system.py
@@ -154,7 +154,7 @@ def system_status():
         from services.database_service import get_shared_db_service
 
         store = MemoryClientService.create_connection()
-        result = {"status": "ok", "memory": {}, "storage": {}, "queues": {}}
+        result = {"status": "ok", "memory": {}, "storage": {}}
 
         # MemoryStore health
         try:
@@ -187,14 +187,6 @@ def system_status():
         except Exception as e:
             result["status"] = "degraded"
             result["database_error"] = str(e)
-
-        # Queue depths
-        for queue_name in ["output-queue"]:
-            try:
-                result["queues"][queue_name] = store.llen(queue_name)
-            except Exception as e:
-                logger.warning(f"[SYSTEM] Queue depth check failed for '{queue_name}': {e}")
-                result["queues"][queue_name] = -1
 
         return jsonify(result), 200
 

--- a/backend/configs/connections.json
+++ b/backend/configs/connections.json
@@ -1,8 +1,7 @@
 {
   "memory": {
     "topics": {
-      "episodic_memory": "episodic-memory-queue",
-      "output_queue": "output-queue"
+      "episodic_memory": "episodic-memory-queue"
     },
     "queues": {
       "act_queue": {

--- a/backend/services/output_service.py
+++ b/backend/services/output_service.py
@@ -1,10 +1,7 @@
 import json
 import logging
 import uuid
-from typing import Dict, Any, Optional, List
-
 from .memory_client import MemoryClientService
-from .config_service import ConfigService
 from .time_utils import utc_now
 from .markup import actions_to_xml, sanitize
 
@@ -17,13 +14,8 @@ class OutputService:
     """Service for managing output queue and storage with type-based routing."""
 
     def __init__(self):
-        """Initialize the OutputService with MemoryStore connection and config."""
+        """Initialize the OutputService with MemoryStore connection."""
         self.store = MemoryClientService.create_connection()
-        config = ConfigService.connections()
-        topics = config.get("memory", {}).get("topics", {})
-        self.queue_name = topics.get("output_queue", "output-queue")
-
-        logger.info(f"OutputService initialized with queue: {self.queue_name}")
 
     def enqueue_text(
         self,
@@ -191,114 +183,4 @@ class OutputService:
             metrics=metrics,
         )
 
-    def enqueue_act(
-        self,
-        topic: str = None,
-        actions: List[str] = None,
-        downstream_mode: str = 'ACT',
-        act_history: List[Dict[str, Any]] = None,
-        loop_id: str = '',
-        generation_time: float = 0.0,
-        channel: str = None,
-    ) -> str:
-        """
-        Enqueue an ACT output for action processing.
-
-        Args:
-            topic: Conversation topic identifier
-            actions: List of actions to execute
-            downstream_mode: Mode to use after action processing
-            act_history: History of previous actions in this cycle
-            loop_id: Identifier for the action loop
-            generation_time: Time taken to generate the actions
-
-        Returns:
-            str: UUID of the enqueued output
-        """
-        _channel = channel or topic
-        actions = actions or []
-        act_history = act_history or []
-        output_id = str(uuid.uuid4())
-        output = {
-            "id": output_id,
-            "type": "ACT",
-            "topic": _channel,
-            "created_at": utc_now().isoformat(),
-            "metadata": {
-                "actions": actions,
-                "downstream_mode": downstream_mode,
-                "act_history": act_history,
-                "loop_id": loop_id,
-                "generation_time": generation_time
-            }
-        }
-
-        # Store with 1-hour TTL
-        self.store.setex(f"output:{output_id}", 3600, json.dumps(output))
-
-        # Add to queue
-        self.store.lpush(self.queue_name, output_id)
-        self.store.expire(self.queue_name, 3600)
-
-        logger.info(
-            f"Enqueued ACT output {output_id} for topic '{_channel}' "
-            f"(loop_id={loop_id}, actions={len(actions)})"
-        )
-
-        return output_id
-
-    def dequeue(self, output_type: Optional[str] = None, timeout: int = 0) -> Optional[Dict[str, Any]]:
-        """
-        Dequeue an output from the queue with optional type filtering.
-
-        Args:
-            output_type: Optional filter for output type (TEXT, ACT)
-            timeout: BRPOP timeout in seconds (0 = block indefinitely)
-
-        Returns:
-            Dict containing the output data, or None if timeout
-        """
-        while True:
-            result = self.store.brpop(self.queue_name, timeout)
-
-            if not result:
-                return None
-
-            _, output_id = result
-
-            # Handle both bytes and str
-            if isinstance(output_id, bytes):
-                output_id = output_id.decode()
-
-            output_data = self.store.get(f"output:{output_id}")
-
-            if not output_data:
-                logger.warning(f"Output {output_id} expired or deleted, skipping")
-                continue
-
-            output = json.loads(output_data)
-
-            # Filter by type if specified
-            if output_type and output.get('type') != output_type:
-                logger.debug(f"Re-queuing output {output_id} (type={output.get('type')}, want={output_type})")
-                self.store.lpush(self.queue_name, output_id)
-                self.store.expire(self.queue_name, 3600)
-                continue
-
-            logger.info(f"Dequeued {output.get('type')} output {output_id}")
-            return output
-
-    def delete_output(self, output_id: str) -> None:
-        """
-        Delete an output from storage.
-
-        Args:
-            output_id: UUID of the output to delete
-        """
-        deleted = self.store.delete(f"output:{output_id}")
-
-        if deleted:
-            logger.info(f"Deleted output {output_id}")
-        else:
-            logger.warning(f"Output {output_id} not found for deletion")
 

--- a/backend/tests/test_api_system.py
+++ b/backend/tests/test_api_system.py
@@ -93,15 +93,12 @@ class TestSystemAPI:
     # GET /system/status
 
     def test_system_status_returns_expected_keys(self, client, db):
-        """GET /system/status returns status, memory, storage, queues top-level keys."""
+        """GET /system/status returns status, memory, storage top-level keys."""
         store = MemoryStore()
         # Seed 2 keys for each memory namespace so counts == 2.
         for ns in ('working_memory', 'gist_index', 'fact_index'):
             store.set(f'{ns}:a', 'x')
             store.set(f'{ns}:b', 'x')
-        # Seed output-queue with 5 items so llen == 5.
-        for _ in range(5):
-            store.rpush('output-queue', 'x')
         # Seed DMN delivery ZSET with a recent entry.
         store.zadd('dmn:deliveries', {'test-delivery': 1711500000.0})
 
@@ -113,14 +110,10 @@ class TestSystemAPI:
         assert data['status'] == 'ok'
         assert 'memory' in data
         assert 'storage' in data
-        assert 'queues' in data
         # Memory keys should reflect store.keys() calls (3 calls: working_memory, gist, fact)
         assert data['memory']['working_memory_keys'] == 2
         assert data['memory']['gist_keys'] == 2
         assert data['memory']['fact_keys'] == 2
-        # Queue depth
-        assert data['queues']['output-queue'] == 5
-        assert 'prompt-queue' not in data['queues']
 
     def test_system_status_degraded_when_store_fails(self, client, db):
         """GET /system/status reports 'degraded' when MemoryStore ping raises."""

--- a/backend/tests/test_memorystore_ttl.py
+++ b/backend/tests/test_memorystore_ttl.py
@@ -14,7 +14,6 @@ Pattern used throughout:
   A non-None expiry confirms the TTL was set.
 """
 
-import json
 import pytest
 from unittest.mock import patch
 
@@ -37,61 +36,6 @@ def _has_ttl(store: MemoryStore, key: str) -> bool:
             _, expiry = keyspace[key]
             return expiry is not None
     return False
-
-
-# ---------------------------------------------------------------------------
-# 1. output_service — enqueue path + re-queue path
-# ---------------------------------------------------------------------------
-
-@pytest.mark.unit
-class TestOutputServiceQueueTTL:
-    """After every lpush to output-queue, expire(output-queue, 3600) must fire.
-
-    The output-queue is written by enqueue_act (primary path) and by the
-    re-queue branch inside dequeue() when a type-mismatch is detected.
-    enqueue_text does NOT touch output-queue; it uses setex on the output key
-    and rpush/expire on notifications:recent.
-    """
-
-    @pytest.fixture
-    def svc(self):
-        store = MemoryStore()
-        connections = {"memory": {"topics": {"output_queue": "output-queue"}}}
-        with patch("services.memory_client.MemoryClientService.create_connection",
-                   return_value=store), \
-             patch("services.config_service.ConfigService.connections",
-                   return_value=connections):
-            from services.output_service import OutputService
-            return OutputService(), store
-
-    def test_enqueue_act_sets_ttl_on_output_queue(self, svc):
-        """enqueue_act calls lpush then expire(output-queue, 3600)."""
-        service, store = svc
-        service.enqueue_act(topic="t", actions=["search"], channel="web:default:1")
-        assert _has_ttl(store, "output-queue"), "output-queue must have a TTL after enqueue_act lpush"
-
-    def test_requeue_sets_ttl_on_output_queue(self, svc):
-        """dequeue re-queue path (type mismatch) calls expire on output-queue."""
-        service, store = svc
-
-        # Push a TEXT output and an ACT output so that dequeue finds ACT on second pop.
-        # brpop pops from the right, so ACT is at the right (last) position.
-        text_output = {"id": "out-text", "type": "TEXT", "topic": "t", "metadata": {}}
-        act_output = {"id": "out-act", "type": "ACT", "topic": "t",
-                      "metadata": {"actions": [], "downstream_mode": "ACT",
-                                   "act_history": [], "loop_id": "", "generation_time": 0.0}}
-        store.set("output:out-text", json.dumps(text_output))
-        store.set("output:out-act", json.dumps(act_output))
-        # rpush appends to the right; brpop pops from the right.
-        # Push ACT first (left), then TEXT (rightmost) so TEXT is popped first.
-        store.rpush("output-queue", "out-act")
-        store.rpush("output-queue", "out-text")
-
-        # dequeue asks for ACT: pops out-text (type mismatch) → re-queues it → pops out-act → returns
-        result = service.dequeue(output_type="ACT", timeout=2)
-
-        assert result is not None and result["type"] == "ACT"
-        assert _has_ttl(store, "output-queue"), "output-queue must have a TTL after re-queue lpush"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_output_service.py
+++ b/backend/tests/test_output_service.py
@@ -54,15 +54,8 @@ class TestOutputService:
         Returns:
             OutputService: Fully initialised service instance.
         """
-        connections = {
-            "memory": {
-                "topics": {"output_queue": "output-queue"},
-            }
-        }
         with patch('services.memory_client.MemoryClientService.create_connection',
-                    return_value=mock_store), \
-             patch('services.config_service.ConfigService.connections',
-                   return_value=connections):
+                    return_value=mock_store):
             svc = OutputService()
         return svc
 
@@ -160,62 +153,6 @@ class TestOutputService:
 
         recent = mock_store.lrange("notifications:recent", 0, -1)
         assert len(recent) > 0
-
-    # ------------------------------------------------------------------ #
-    # dequeue
-    # ------------------------------------------------------------------ #
-
-    def test_dequeue_returns_output_from_queue(self, service, mock_store):
-        """Successful dequeue returns the parsed output dict."""
-        output_data = {
-            "id": "out-1",
-            "type": "ACT",
-            "topic": "t",
-            "metadata": {"actions": ["search"]},
-        }
-        mock_store.set("output:out-1", json.dumps(output_data))
-        mock_store.rpush("output-queue", "out-1")
-
-        result = service.dequeue(output_type="ACT", timeout=1)
-
-        assert result is not None
-        assert result["id"] == "out-1"
-        assert result["type"] == "ACT"
-
-    def test_dequeue_requeues_mismatched_type(self, service, mock_store):
-        """When dequeued output type does not match, it is re-queued via lpush."""
-        text_output = {"id": "out-2", "type": "TEXT", "topic": "t", "metadata": {}}
-        act_output = {"id": "out-3", "type": "ACT", "topic": "t", "metadata": {}}
-
-        # rpush appends to the right; brpop pops from the right.
-        # Push out-3 first so out-2 sits at the right end and is popped first.
-        mock_store.set("output:out-2", json.dumps(text_output))
-        mock_store.set("output:out-3", json.dumps(act_output))
-        mock_store.rpush("output-queue", "out-3")
-        mock_store.rpush("output-queue", "out-2")
-
-        result = service.dequeue(output_type="ACT", timeout=1)
-
-        assert result["type"] == "ACT"
-        # out-2 (TEXT) must have been re-queued back onto the list
-        queued = mock_store.lrange("output-queue", 0, -1)
-        assert "out-2" in queued
-
-    def test_dequeue_returns_none_on_timeout(self, service, mock_store):
-        """When brpop times out (returns None), dequeue returns None."""
-        # Empty queue — brpop will exhaust the timeout and return None
-        result = service.dequeue(output_type="ACT", timeout=1)
-        assert result is None
-
-    # ------------------------------------------------------------------ #
-    # delete_output
-    # ------------------------------------------------------------------ #
-
-    def test_delete_output_calls_store_delete(self, service, mock_store):
-        """delete_output removes the output key from the store."""
-        mock_store.set("output:dead-uuid-42", json.dumps({"id": "dead-uuid-42"}))
-        service.delete_output("dead-uuid-42")
-        assert mock_store.get("output:dead-uuid-42") is None
 
     # ------------------------------------------------------------------ #
     # notifications:recent trimming

--- a/backend/tests/test_xml_wire_cutover.py
+++ b/backend/tests/test_xml_wire_cutover.py
@@ -78,11 +78,8 @@ class TestOutputServiceXmlWireFrame:
     @pytest.fixture
     def svc(self, store):
         from services.output_service import OutputService
-        from unittest.mock import patch
 
-        connections = {"memory": {"topics": {"output_queue": "output-queue"}}}
-        with patch("services.config_service.ConfigService.connections", return_value=connections):
-            yield OutputService()
+        yield OutputService()
 
     def test_plaintext_response_passes_through(self, svc, store):
         """Plain text without any tags is valid HTML — pass through, no wrapping."""


### PR DESCRIPTION
## Summary

Pure deductive rip of the dead ACT output-queue subsystem in `OutputService`. The methods `enqueue_act`, `dequeue`, and `delete_output` have zero production callers since the ACT loop refactor moved to `_act_iter`. Their backing config key (`memory.topics.output_queue`) and the empty queue-depth diagnostic in `/system/status` come along with them.

## Changes

| File | LOC | Notes |
|---|---|---|
| `backend/services/output_service.py` | -118 | Removes `enqueue_act` / `dequeue` / `delete_output` + `self.queue_name` init + ConfigService import + unused `Dict/Any/Optional/List` typing imports |
| `backend/api/system.py` | -8 | Removes `queues` slot in result dict + the `for queue_name in [\"output-queue\"]` llen loop |
| `backend/configs/connections.json` | -1 | Drops `memory.topics.output_queue` (no readers remain) |
| `backend/tests/test_output_service.py` | -64 | Removes `test_dequeue_*` and `test_delete_output_*` |
| `backend/tests/test_memorystore_ttl.py` | -55 | Removes `TestOutputServiceQueueTTL` (TTL on enqueue_act / requeue) |
| `backend/tests/test_api_system.py` | -8 | Drops `output-queue` seeding + `queues` assertions in `test_system_status_returns_expected_keys` |
| `backend/tests/test_xml_wire_cutover.py` | -3 | Drops dead `output_queue` patch in `svc` fixture (init no longer reads topics) |

**Net: 7 files, +6 / -262.**

## Verification

- `grep -rn 'enqueue_act\\|delete_output\\|output-queue\\|output_queue\\|self\\.queue_name'` in `backend/` → empty
- Frontend grep for `queues` and `/system/status` → zero consumers
- `pytest tests/test_output_service.py tests/test_memorystore_ttl.py tests/test_xml_wire_cutover.py tests/test_api_system.py -k system_status` → 25 passed
- `ruff check` on touched files → all checks passed
- `vulture` on `output_service.py` / `system.py` → no new findings
- Pre-existing ONNX/CoreML failures (`test_ready_*`) reproduce on `main` baseline (model file divergence, unrelated)

## Why deductive

`enqueue_act`'s ACT-queue path was the legacy pre-`_act_iter` ACT loop. The ACT loop refactor consumes turn state in-process now — there is no consumer reading from `output-queue`. Per cycle 233-239 precedent, zero-caller surface is removed wholesale rather than left as a backward-compat shim.

## Test plan

- [x] All touched test files pass locally
- [x] No production caller for any removed symbol
- [x] No frontend consumer of removed `/system/status` `queues` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)