### PR TITLE
drop-dead: CATEGORIES + search_sources (zero callers)

### DIFF
--- a/backend/services/news_sources.py
+++ b/backend/services/news_sources.py
@@ -6,11 +6,6 @@ from collections import namedtuple
 
 Source = namedtuple("Source", "id name category feed_url country")
 
-CATEGORIES = (
-    "international", "us", "uk", "tech",
-    "business", "science", "sports", "entertainment",
-)
-
 SOURCES = (
     # ── International (10) ────────────────────────────────────
     Source("bbc_world", "BBC World News", "international", "https://feeds.bbci.co.uk/news/world/rss.xml", "GB"),
@@ -99,11 +94,3 @@ def get_source_by_id(source_id: str):
 def get_sources_by_category(category: str) -> list:
     """Return all sources in a category."""
     return list(_BY_CATEGORY.get(category, []))
-
-
-def search_sources(query: str = "") -> list:
-    """Case-insensitive substring match on source name. Empty query returns all."""
-    if not query:
-        return list(SOURCES)
-    q = query.lower()
-    return [s for s in SOURCES if q in s.name.lower()]

--- a/backend/tests/test_news_sources.py
+++ b/backend/tests/test_news_sources.py
@@ -2,8 +2,8 @@
 
 import pytest
 from services.news_sources import (
-    SOURCES, CATEGORIES, Source,
-    get_source_by_id, get_sources_by_category, search_sources,
+    SOURCES, Source,
+    get_source_by_id, get_sources_by_category,
 )
 
 
@@ -13,15 +13,12 @@ class TestNewsSources:
     def test_total_source_count(self):
         assert len(SOURCES) == 56
 
-    def test_category_count(self):
-        assert len(CATEGORIES) == 8
-
     def test_all_sources_have_valid_fields(self):
         for s in SOURCES:
             assert isinstance(s, Source)
             assert len(s.id) >= 2
             assert len(s.name) >= 2
-            assert s.category in CATEGORIES
+            assert s.category in {"international", "us", "uk", "tech", "business", "science", "sports", "entertainment"}
             assert s.feed_url.startswith("https://")
             assert len(s.country) == 2
 
@@ -37,10 +34,6 @@ class TestNewsSources:
         for cat, count in expected.items():
             assert len(get_sources_by_category(cat)) == count, f"{cat} expected {count}"
 
-    def test_all_source_categories_in_categories(self):
-        for s in SOURCES:
-            assert s.category in CATEGORIES
-
     def test_get_source_by_id_found(self):
         src = get_source_by_id("bbc_world")
         assert src is not None
@@ -53,25 +46,3 @@ class TestNewsSources:
     def test_get_sources_by_category_unknown(self):
         assert get_sources_by_category("fictional") == []
 
-    def test_search_sources_empty_query(self):
-        result = search_sources("")
-        assert len(result) == 56
-
-    def test_search_sources_partial_match(self):
-        result = search_sources("BBC")
-        assert len(result) >= 3  # bbc_world, bbc_uk, bbc_sport
-        for s in result:
-            assert "BBC" in s.name
-
-    def test_search_sources_case_insensitive(self):
-        result = search_sources("bbc")
-        assert len(result) >= 3
-
-    def test_search_sources_no_match(self):
-        result = search_sources("zzzznonexistent")
-        assert result == []
-
-    def test_search_sources_single_match(self):
-        result = search_sources("TechCrunch")
-        assert len(result) == 1
-        assert result[0].id == "techcrunch"


### PR DESCRIPTION
## Opportunity (TKT-307)
`backend/services/news_sources.py` exported two symbols with zero non-test callers:
- `CATEGORIES` constant (8-tuple of category names)
- `search_sources()` substring-match helper

Outside imports only used `Source`, `get_source_by_id`, and `get_sources_by_category` — those stay.

## Approach
**Deductive** — pure subtraction. No production behavior change.

```
$ grep -rn "search_sources\|news_sources.CATEGORIES" --include="*.py" backend/ | grep -v test_news_sources
backend/services/news_sources.py:104:def search_sources(query: str = "") -> list:
```

## Diff
- \`backend/services/news_sources.py\`: -13 LOC
- \`backend/tests/test_news_sources.py\`: -32 LOC net (drop 7 tests, replace 1 \`CATEGORIES\` reference with inline set literal so coverage of category-validity is preserved)
- **Total: -45 LOC, +2 LOC**

## Verification
- Targeted suite (\`test_news_sources.py\` + \`test_news_service.py\`, \`-m unit\`): **67 passed in 1.97s**
- Full unit suite: **2168 passed, 17 skipped, 147 deselected**

## Nightly comparison (run 584 on main → run pending on branch)
| Composite | 030 | 044 | 060 |
|---|---|---|---|
| 0.9067 (main baseline) | PASS 1.0 | PASS 1.0 | WARN ~0.72 |

Branch pipeline run will be added as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)