### PR TITLE
chore(list): drop zero-caller get_lists_for_prompt helper

### DIFF
--- a/backend/services/list_service.py
+++ b/backend/services/list_service.py
@@ -12,7 +12,6 @@ import secrets
 from typing import Optional, List, Dict, Any
 
 from services.log_utils import safe
-from services.time_utils import utc_now, parse_utc
 from services.write_queue_service import get_write_queue
 
 logger = logging.getLogger(__name__)
@@ -426,49 +425,6 @@ class ListService:
         except Exception as e:
             logger.error(f"[LISTS] _set_checked failed: {e}")
             return 0
-
-    # Prompt context
-
-    def get_lists_for_prompt(self) -> str:
-        """
-        Format active lists summary for LLM prompt injection.
-
-        Format: ``- {id} · {name} ({count_str}) — updated {recency}``
-        """
-        lists = self.get_all_lists()
-        if not lists:
-            return ""
-
-        now = utc_now()
-        lines = ["## Active Lists"]
-
-        for lst in lists:
-            item_count = lst['item_count']
-            checked_count = lst['checked_count']
-            updated_at = lst['updated_at']
-
-            recency = "unknown"
-            if updated_at:
-                try:
-                    delta = now - parse_utc(updated_at)
-                    total_seconds = int(delta.total_seconds())
-                    if total_seconds < 3600:
-                        recency = f"{total_seconds // 60}m ago"
-                    elif total_seconds < 86400:
-                        recency = f"{total_seconds // 3600}h ago"
-                    else:
-                        recency = f"{delta.days} days ago"
-                except Exception as e:
-                    logger.debug(f"[LIST] recency calculation failed: {e}")
-
-            if checked_count > 0:
-                count_str = f"{item_count} items, {checked_count} checked"
-            else:
-                count_str = f"{item_count} items"
-
-            lines.append(f"- {lst['id']} · {lst['name']} ({count_str}) — updated {recency}")
-
-        return "\n".join(lines)
 
     # Internal helpers
 

--- a/backend/tests/test_list_service.py
+++ b/backend/tests/test_list_service.py
@@ -7,8 +7,6 @@ SQLite via the shared ``db`` fixture — no mocked database connections.
 """
 
 import pytest
-from datetime import timedelta
-
 from services.time_utils import utc_now
 
 
@@ -278,48 +276,3 @@ class TestGetListRow:
 
     def test_returns_none_for_empty(self, service):
         assert service._get_list_row('') is None
-
-
-# ─── get_lists_for_prompt ────────────────────────────────────────────────
-
-class TestGetListsForPrompt:
-    def test_returns_empty_when_no_lists(self, service):
-        assert service.get_lists_for_prompt() == ""
-
-    def test_includes_id_in_format(self, service, db):
-        _seed_list(db, list_id='abc12345', name='Groceries')
-        _seed_item(db, 'i1', 'abc12345', 'milk', position=0)
-        _seed_item(db, 'i2', 'abc12345', 'eggs', checked=1, position=1)
-
-        result = service.get_lists_for_prompt()
-
-        assert "## Active Lists" in result
-        assert "abc12345" in result
-        assert "Groceries" in result
-        assert "2 items" in result
-        assert "1 checked" in result
-
-    def test_no_checked_count_omitted_when_zero(self, service, db):
-        _seed_list(db, list_id='abc12345', name='Todo')
-        _seed_item(db, 'i1', 'abc12345', 'task', position=0)
-
-        result = service.get_lists_for_prompt()
-        assert "checked" not in result
-        assert "1 items" in result
-
-    def test_recency_format_minutes(self, service, db):
-        # updated_at defaults to datetime('now') → recency should read "0m ago"
-        _seed_list(db, list_id='abc12345', name='Fresh')
-        result = service.get_lists_for_prompt()
-        assert "m ago" in result
-
-    def test_recency_format_days_for_old_list(self, service, db):
-        old_iso = (utc_now() - timedelta(days=5)).isoformat()
-        db.execute(
-            "INSERT INTO lists (id, name, list_type, created_at, updated_at) "
-            "VALUES (?, ?, ?, ?, ?)",
-            ('old00001', 'Old List', 'checklist', old_iso, old_iso),
-        )
-        db.commit()
-        result = service.get_lists_for_prompt()
-        assert "5 days ago" in result


### PR DESCRIPTION
## Summary

Drop `ListService.get_lists_for_prompt()` (~42 LOC) plus the matching `TestGetListsForPrompt` class (5 tests). Method has zero production callers — only tests touched it. Net **−91 LOC, +0**.

## Evidence

- `grep -rn \"lists_for_prompt\"` matched only 1 production-file definition (`backend/services/list_service.py:432`) and 5 test references in `backend/tests/test_list_service.py:283-325`.
- `grep -rn \"get_all_lists\"` shows production callers (`backend/abilities/list.py:224`, `backend/api/lists.py:98`) all use `get_all_lists()` directly, not the prompt formatter.
- No `.j2`, `.txt`, `.md`, `.html`, `.js` template references.
- Both `utc_now` and `parse_utc` were exclusively consumed inside the deleted method, so the entire `from services.time_utils import …` line was dropped (ruff caught this on first pass).
- `timedelta` import in the test file was only used by the deleted `test_recency_format_days_for_old_list` — also dropped.

## Validation

- `python -m py_compile`: clean
- `ruff check`: clean
- `vulture`: no new findings
- `pytest -m unit -q tests/test_list_service.py` → 33 passed (was 38; 5 deleted tests gone)
- Full unit suite → 304 passed, 1 failed (pre-existing ONNX `InvalidProtobuf` flake on `test_ready_all_ok_returns_200_with_component_status`, documented in TKT-301 / cycle 239 — unrelated to this change)

## Targeted scenarios

`030-skill-memory.yaml` (PASS=1.0), `044-skill-invocation-determinism.yaml` (PASS=1.0), `060-document-lifecycle.yaml` (WARN=0.72) — same 3-scenario fingerprint cycles 233–241 used. Baseline pipeline 585 (main): 2 PASS / 1 WARN, aggregate ≈ 0.9067.

Branch pipeline wedged at \"Waiting for readiness... (10s)\" — same non-deterministic harness wedge documented in cycles 236, 240, 241 ([apps#1751](https://github.com/chalie-ai/chalie/pull/1751), [#1752](https://github.com/chalie-ai/chalie/pull/1752), [#1754](https://github.com/chalie-ai/chalie/pull/1754)). Cancelled and shipping on the cycle-236/240/241 precedent: pure deletion + zero production callers + green local CI + unit suite holds.

## Test plan

- [x] Unit suite (33 list-service tests, 304 total) passes
- [x] Lint clean
- [x] No new vulture findings
- [x] Zero production callers verified by grep across `*.py`, `*.j2`, `*.txt`, `*.md`, `*.html`, `*.js`

Targeted by [TKT-308](http://localhost:5555/tickets/308).

🤖 Generated with [Claude Code](https://claude.com/claude-code)