### PR TITLE
improve(news): drop redundant url from rich-media results payload

### DIFF
--- a/backend/abilities/news.py
+++ b/backend/abilities/news.py
@@ -137,16 +137,17 @@ def _serialise_rich(articles, ordinal: int) -> str:
     image_items: list[tuple[str, str]] = []
     needs_og: list[tuple[str, str]] = []
     for a in articles:
-        entry = {"title": a.title, "source": a.source, "url": getattr(a, "url", "")}
+        entry = {"title": a.title, "source": a.source}
         if a.description:
             entry["desc"] = a.description[:200]
         results.append(entry)
         img = getattr(a, "image_url", "") or ""
         title = a.title or ""
+        a_url = getattr(a, "url", "") or ""
         if img:
             image_items.append((img, title))
-        elif entry["url"]:
-            needs_og.append((entry["url"], title))
+        elif a_url:
+            needs_og.append((a_url, title))
 
     # og_meta maps image_url → {"image_url", "description"} for caption derivation
     og_meta: dict = {}


### PR DESCRIPTION
## Summary
- Drop `url` field from each entry in `NewsAbility._serialise_rich`'s `results` array (the data structure returned to the LLM in news tool output).
- The Google News redirect URLs (~250 chars × 10 articles per call ≈ 2500 chars / ~600 tokens) were never cited in synthesis (rich-media instruction example doesn't reference URLs) and never surfaced to the frontend (only `image_candidates[].url` flows to the FE card renderer). The `url` was only needed internally for og:image lookup, preserved via a local `a_url` variable.
- Targets recurring "Excessive Response Latency" / "LLM synthesis 30-50s+" anomaly on `053-tool-news.yaml` (WARN 0.88 across 7+ consecutive runs: 9921, 9884, 9882, 9775, 9709, 9707, 9664, 9555).

## Approach
**Deductive / subtractive** — net 4-line refactor in `_serialise_rich`. No prompt edits, no schema changes, no API contract changes.

## Verification
- 2175 unit tests pass (`pytest -m unit`).
- ruff clean. vulture clean (pre-existing `channel` unused at line 86 left out of scope).
- No tests assert on `url` in news rich payload (`grep` confirmed `test_rich_media_parser.py` only checks `image_url` for image-flow scenarios).
- No frontend consumer reads `results[].url` from news (only `image_candidates[].url`).
- og:image lookup pathway preserved: `needs_og` populated with article URL via local `a_url`; `og_map.get(article_url)` and `og_meta[img]` keying both unchanged.
- Scenario 054-tool-news-image (image-candidates flow) unaffected.

## Test plan
- [x] Local unit suite green
- [ ] CI checks green (CodeQL, SonarCloud, Analyze python+js, Lint+Unit Tests, ability DB drift)
- [ ] Nightly `053-tool-news.yaml` re-run on this branch — score holds or rises, latency anomaly drops or downgrades

## Notes
- TKT-331
- `/improve-chalie` cycle following TKT-291 (cycle 231) and TKT-307 (cycle 241), both deductive on news module on different paths.
- Nightly-test infra hit `[Errno 5] Input/output error` 3× on baseline run today; same pattern as TKT-328/TKT-330 yesterday. PR ships regardless and will re-run when infra recovers, matching prior cycle precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)