### PR TITLE
fix: port PR #1757 to rc-0.7.0 — voice collapse, Brain provider auto-fetch + 13 misc fixes

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -6,6 +6,7 @@ and static file serving (replaces nginx).
 import os
 import re
 import importlib
+import mimetypes
 import pkgutil
 import logging
 from pathlib import Path
@@ -17,6 +18,29 @@ from .auth import require_session as require_session
 
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# MIME type registration (cross-platform safety net)
+#
+# Python's `mimetypes` module reads the Windows registry on Windows, which is
+# frequently stale or missing the standard JS/CSS/JSON entries. When that
+# happens, Flask's `send_from_directory` ships `.js` files as `text/plain`,
+# and strict browsers (Chrome, Edge) refuse to execute them — breaking the
+# entire frontend.
+#
+# Registering these at import time, before any Flask app is constructed,
+# guarantees that `mimetypes.guess_type()` returns the correct value on every
+# OS. `mimetypes.add_type` overrides any pre-existing mapping for the given
+# extension, so it neutralises the bad registry entries on Windows without
+# affecting macOS/Linux (which already return the correct types).
+# ---------------------------------------------------------------------------
+
+mimetypes.add_type('application/javascript', '.js')
+mimetypes.add_type('application/javascript', '.mjs')
+mimetypes.add_type('application/json', '.json')
+mimetypes.add_type('text/css', '.css')
+mimetypes.add_type('text/html', '.html')
 
 # Resolve frontend directories relative to backend/
 _BACKEND_DIR = Path(__file__).resolve().parent.parent

--- a/backend/api/providers.py
+++ b/backend/api/providers.py
@@ -60,24 +60,37 @@ def _validate_ollama_host(host: str) -> tuple[str | None, str | None]:
     return safe, None
 
 
-def _fetch_ollama_models(host: str):
-    """Fetch the model list from an Ollama instance via GET /api/tags.
+# --- Live model-list fetch helpers -----------------------------------------
+#
+# Each helper returns ``(models, error)`` where ``models`` is a list of dicts
+# ``{"id": str, "display_name": str | None}`` and exactly one of the two is
+# non-None. All helpers cap upstream calls at 8s and never raise.
 
-    Returns ``(model_names, error_str)`` where exactly one is non-None.
-    """
+_LIST_MODELS_TIMEOUT = 8
+
+# OpenAI model IDs we accept: chat-capable text models only. Drop audio/realtime/
+# image/tts/whisper/embedding/moderation variants — none are useful for ACT.
+_OPENAI_PREFIX_OK = ('gpt-', 'o1', 'o3', 'o4', 'o5')
+_OPENAI_DENY_SUBSTR = (
+    'audio', 'realtime', 'image', 'tts', 'whisper', 'embedding', 'moderation',
+)
+
+
+def _fetch_ollama_models(host: str):
+    """Fetch the model list from an Ollama instance via GET /api/tags."""
     safe_host, err = _validate_ollama_host(host)
     if err is not None:
         return None, err
     try:
-        r = req.get(f"{safe_host}/api/tags", timeout=5)
+        r = req.get(f"{safe_host}/api/tags", timeout=_LIST_MODELS_TIMEOUT)
         r.raise_for_status()
         models_data = r.json()
-        names = [
-            m.get('name') or m.get('model', '')
-            for m in (models_data.get('models') or [])
-            if m.get('name') or m.get('model', '')
-        ]
-        return names, None
+        models = []
+        for m in (models_data.get('models') or []):
+            name = m.get('name') or m.get('model', '')
+            if name:
+                models.append({"id": name, "display_name": None})
+        return models, None
     except req.exceptions.ConnectionError:
         return None, f"Cannot connect to {safe_host} — is the service running?"
     except req.exceptions.Timeout:
@@ -85,6 +98,84 @@ def _fetch_ollama_models(host: str):
     except Exception as e:
         logger.warning(f"[REST API] Ollama model list failed: {type(e).__name__}: {e}")
         return None, "Failed to fetch Ollama models"
+
+
+def _fetch_openai_models(api_key: str):
+    """Fetch chat-capable model IDs from GET https://api.openai.com/v1/models."""
+    if not api_key:
+        return None, "API key is required"
+    try:
+        r = req.get(
+            'https://api.openai.com/v1/models',
+            headers={'Authorization': f'Bearer {api_key}'},
+            timeout=_LIST_MODELS_TIMEOUT,
+        )
+        if r.status_code in (401, 403):
+            return None, "Invalid API key"
+        if not r.ok:
+            return None, f"OpenAI API returned {r.status_code}"
+        data = r.json()
+        items = data.get('data') or []
+        # Filter to chat-capable text models, then sort newest first by 'created'.
+        kept = []
+        for m in items:
+            mid = m.get('id') or ''
+            if not mid or not mid.startswith(_OPENAI_PREFIX_OK):
+                continue
+            lid = mid.lower()
+            if any(bad in lid for bad in _OPENAI_DENY_SUBSTR):
+                continue
+            kept.append(m)
+        kept.sort(key=lambda m: m.get('created') or 0, reverse=True)
+        return [{"id": m['id'], "display_name": None} for m in kept], None
+    except req.exceptions.ConnectionError:
+        return None, "Cannot connect to OpenAI API"
+    except req.exceptions.Timeout:
+        return None, "OpenAI API request timed out"
+    except Exception as e:
+        logger.warning(f"[REST API] OpenAI model list failed: {type(e).__name__}: {e}")
+        return None, "OpenAI API request failed"
+
+
+def _fetch_anthropic_models(api_key: str):
+    """Fetch chat models from GET https://api.anthropic.com/v1/models."""
+    if not api_key:
+        return None, "API key is required"
+    try:
+        r = req.get(
+            'https://api.anthropic.com/v1/models',
+            params={'limit': 1000},
+            headers={
+                'x-api-key': api_key,
+                'anthropic-version': '2023-06-01',
+            },
+            timeout=_LIST_MODELS_TIMEOUT,
+        )
+        if r.status_code in (401, 403):
+            return None, "Invalid API key"
+        if not r.ok:
+            return None, f"Anthropic API returned {r.status_code}"
+        data = r.json()
+        items = list(data.get('data') or [])
+        # Sort by created_at desc when available; falsy values sink to the end.
+        items.sort(key=lambda m: m.get('created_at') or '', reverse=True)
+        models = []
+        for m in items:
+            mid = m.get('id')
+            if not mid:
+                continue
+            models.append({
+                "id": mid,
+                "display_name": m.get('display_name'),
+            })
+        return models, None
+    except req.exceptions.ConnectionError:
+        return None, "Cannot connect to Anthropic API"
+    except req.exceptions.Timeout:
+        return None, "Anthropic API request timed out"
+    except Exception as e:
+        logger.warning(f"[REST API] Anthropic model list failed: {type(e).__name__}: {e}")
+        return None, "Anthropic API request failed"
 
 
 def get_provider_service():
@@ -225,65 +316,39 @@ def delete_provider(provider_id):
         return jsonify({"error": "Failed to delete provider"}), 500
 
 
-@providers_bp.route('/ollama/models', methods=['GET'])
+@providers_bp.route('/list-models', methods=['POST'])
 @require_session
-def list_ollama_models():
-    """Proxy GET /api/tags on an Ollama host and return model names.
-
-    Query param:
-      host  — Ollama base URL (default: http://localhost:11434)
-
-    Response 200: {"models": ["name:tag", ...]}
-    Response 502: {"error": "..."}
-    """
-    host = request.args.get('host', 'http://localhost:11434')
-    names, err = _fetch_ollama_models(host)
-    if err is not None:
-        return jsonify({"error": err}), 502
-    return jsonify({"models": names}), 200
-
-
-@providers_bp.route('/anthropic/models', methods=['POST'])
-@require_session
-def list_anthropic_models():
-    """Proxy the Anthropic models list endpoint server-side.
+def list_models():
+    """Live model-list fetch for the brain provider form.
 
     Body JSON:
-      {"api_key": "sk-ant-..."}
+      {"platform": "ollama" | "openai" | "anthropic",
+       "api_key": "...",   # openai / anthropic
+       "host": "..."}      # ollama
 
-    The key is POSTed (not a query param) so it does not land in Flask access
-    logs, browser history, or reverse-proxy logs.
+    Always returns HTTP 200 — auth/network/parse failures land in the body's
+    ``error`` field so the UI can render them inline. Credentials are POSTed
+    (never a query param) to keep them out of Flask access logs and reverse-
+    proxy logs.
 
-    Response 200: {"models": ["claude-...", ...]}
-    Response 400: {"error": "api_key is required"}
-    Response 502: {"error": "..."}
+    Response 200: {"models": [{"id": "...", "display_name": "..."|null}, ...],
+                   "error": "..."|null}
+    Response 400: {"error": "..."}  (only for malformed/unsupported requests)
     """
     body = request.get_json(silent=True) or {}
-    api_key = (body.get('api_key') or '').strip()
-    if not api_key:
-        return jsonify({"error": "api_key is required"}), 400
+    platform = (body.get('platform') or '').strip().lower()
+    if platform == 'ollama':
+        models, err = _fetch_ollama_models(body.get('host') or '')
+    elif platform == 'openai':
+        models, err = _fetch_openai_models((body.get('api_key') or '').strip())
+    elif platform == 'anthropic':
+        models, err = _fetch_anthropic_models((body.get('api_key') or '').strip())
+    else:
+        return jsonify({"models": [], "error": f"Unsupported platform '{platform}'"}), 400
 
-    try:
-        r = req.get(
-            'https://api.anthropic.com/v1/models',
-            headers={
-                'x-api-key': api_key,
-                'anthropic-version': '2023-06-01',
-            },
-            timeout=10,
-        )
-        if not r.ok:
-            return jsonify({"error": f"Anthropic API returned {r.status_code}"}), 502
-        data = r.json()
-        model_ids = [m['id'] for m in (data.get('data') or []) if m.get('id')]
-        return jsonify({"models": model_ids}), 200
-    except req.exceptions.ConnectionError:
-        return jsonify({"error": "Cannot connect to Anthropic API"}), 502
-    except req.exceptions.Timeout:
-        return jsonify({"error": "Anthropic API request timed out"}), 502
-    except Exception as e:
-        logger.error(f"[REST API] Anthropic model list failed: {type(e).__name__}: {e}")
-        return jsonify({"error": "Anthropic API request failed"}), 502
+    if err is not None:
+        return jsonify({"models": [], "error": err}), 200
+    return jsonify({"models": models, "error": None}), 200
 
 
 @providers_bp.route('/test', methods=['POST'])
@@ -328,13 +393,14 @@ def test_provider():
             if err is not None:
                 return jsonify({"success": False, "error": err}), 200
 
+            available_names = [m['id'] for m in (available or [])]
             model_base = model.split(':')[0]
             model_found = any(
                 m == model or m.startswith(model + ':') or m.split(':')[0] == model_base
-                for m in available
+                for m in available_names
             )
 
-            if not model_found and not available:
+            if not model_found and not available_names:
                 return jsonify({
                     "success": True,
                     "model": model,
@@ -346,14 +412,14 @@ def test_provider():
                 return jsonify({
                     "success": False,
                     "error": f"Model '{model}' not found on this Ollama instance.",
-                    "hint": f"Run: ollama pull {model}  ·  Available: {', '.join(available[:5])}"
+                    "hint": f"Run: ollama pull {model}  ·  Available: {', '.join(available_names[:5])}"
                 }), 200
 
             return jsonify({
                 "success": True,
                 "model": model,
                 "latency_ms": latency_ms,
-                "message": f"Connected · {len(available)} model(s) available"
+                "message": f"Connected · {len(available_names)} model(s) available"
             }), 200
 
         else:

--- a/backend/api/voice.py
+++ b/backend/api/voice.py
@@ -269,7 +269,7 @@ def voice_health():
             "reason": "deps_missing",
             "missing": list(_VOICE_MISSING_MODULES),
             "hint": _VOICE_INSTALL_HINT,
-        }), 503
+        }), 200
     if _models_loaded:
         return jsonify({"status": "ok"}), 200
     if _models_loading:

--- a/backend/api/voice.py
+++ b/backend/api/voice.py
@@ -1,25 +1,20 @@
 """
-Voice blueprint — native STT (Moonshine Voice) + TTS (Kokoro).
+Voice blueprint — STT + TTS via the unified ``moonshine_voice`` package.
 
-Auto-detects voice dependencies at import time. If moonshine_voice or kokoro_onnx
-are not installed, all routes return {"status": "unavailable"} / 503.
-No Docker required — voice runs in-process.
+One pip dependency owns G2P, ONNX runtime wiring, voice asset download, and
+inference for both directions:
 
-Models are loaded lazily on first request (not at startup) to avoid blocking
-the Flask server while large models download.
+* STT  → ``moonshine_voice.Transcriber`` (Moonshine encoder/decoder)
+* TTS  → ``moonshine_voice.TextToSpeech`` (Kokoro voice "am_adam")
 
-TTS architecture: one Kokoro instance, one lock. ``Kokoro.create()`` already
-phonemizes, batches by ``MAX_PHONEME_LENGTH``, runs ORT inference, trims
-inter-batch silence, and concatenates — so this module is just the Flask
-glue (text cleanup → kokoro.create → WAV encode → NDJSON envelope). The
-single dtype patch in ``_patch_kokoro_speed_dtype`` works around an upstream
-``kokoro-onnx==0.5.0`` int32/float32 mismatch on the HF fp16 export. Drop
-the patch when upstream releases a fix.
+If the package is not installed, all routes return ``{"status":"unavailable"}``
+or 503. Models are loaded lazily on first request to avoid blocking Flask
+while assets download; ``run.py`` fires a daemon thread at boot to warm them
+ahead of the first user message.
 """
 
 import io
 import logging
-import os
 import re
 import struct
 import tempfile
@@ -27,7 +22,6 @@ import threading
 
 from flask import Blueprint, Response, request, jsonify
 
-import paths
 from services.markup import extract_plaintext
 
 logger = logging.getLogger(__name__)
@@ -37,22 +31,18 @@ voice_bp = Blueprint("voice", __name__)
 # ── Constants (hardcoded — no env vars) ─────────────────────────────────────
 
 MOONSHINE_LANG = "en"
-KOKORO_VOICE = "af_heart"
+TTS_LANG = "en-us"
+TTS_VOICE = "kokoro_am_adam"
 MAX_AUDIO_SECONDS = 660
-
-# Kokoro model files — downloaded lazily into data/models/kokoro/
-_KOKORO_MODEL_DIR = str(paths.MODELS_DIR / "kokoro")
-_KOKORO_MODEL_URL = "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/onnx/model_fp16.onnx"
-_KOKORO_VOICES_URL = "https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/voices-v1.0.bin"
 
 # ── Dependency detection ────────────────────────────────────────────────────
 #
 # We track _which_ voice package is missing so the UI can surface a precise
 # install hint instead of a generic "unavailable" — the fresh-install case.
-# The shipped requirements-voice.txt covers all four; if any are missing the
+# The shipped requirements-voice.txt covers all three; if any are missing the
 # user (or installer) skipped the voice pip step.
 
-_VOICE_REQUIRED_MODULES = ("moonshine_voice", "kokoro_onnx", "soundfile", "numpy")
+_VOICE_REQUIRED_MODULES = ("moonshine_voice", "soundfile", "numpy")
 _VOICE_MISSING_MODULES: tuple[str, ...] = ()
 
 
@@ -93,110 +83,11 @@ _tts_model = None
 _load_lock = threading.Lock()
 _models_loaded = False
 _models_loading = False
-# Moonshine STT is single-instance; one user clicks the mic at a time.
-# Kokoro is single-instance too — ``create()`` mutates the phonemizer's
-# stateful espeak backend and the ORT session is not safe for concurrent
-# ``run()`` calls on a shared Kokoro wrapper. Serialise both.
+# Both engines are single-instance: one user clicks the mic at a time, and
+# ``TextToSpeech.synthesize()`` is not documented as thread-safe (it shares
+# G2P + ORT state under the hood). Serialise both.
 _stt_lock = threading.Lock()
 _tts_lock = threading.Lock()
-
-
-def _download_kokoro_models():
-    """Download Kokoro model files if not present."""
-    import requests
-
-    os.makedirs(_KOKORO_MODEL_DIR, exist_ok=True)
-
-    model_path = os.path.join(_KOKORO_MODEL_DIR, "kokoro-v1.0-fp16.onnx")
-    voices_path = os.path.join(_KOKORO_MODEL_DIR, "voices-v1.0.bin")
-
-    for url, path in [(_KOKORO_MODEL_URL, model_path), (_KOKORO_VOICES_URL, voices_path)]:
-        if os.path.exists(path):
-            continue
-        fname = os.path.basename(path)
-        logger.info("[Voice] Downloading %s …", fname)
-        resp = requests.get(url, stream=True, timeout=120)
-        resp.raise_for_status()
-        tmp_path = path + ".tmp"
-        with open(tmp_path, "wb") as f:
-            for chunk in resp.iter_content(chunk_size=1 << 20):
-                f.write(chunk)
-        os.rename(tmp_path, path)
-        logger.info("[Voice] Downloaded %s (%.1f MB)", fname, os.path.getsize(path) / 1e6)
-
-    return model_path, voices_path
-
-
-def _patch_kokoro_speed_dtype(tts):
-    """Fix upstream ``kokoro-onnx==0.5.0`` dtype bug for the HF fp16 schema.
-
-    The library's ``_create_audio`` hardcodes ``speed: int32`` when the model
-    exposes an ``input_ids`` input (the newer
-    ``onnx-community/Kokoro-82M-v1.0-ONNX`` export), but the fp16 graph
-    actually expects ``speed: float32``. ONNXRuntime then rejects every
-    inference call with::
-
-        Unexpected input data type. Actual: (tensor(int32)),
-        expected: (tensor(float))
-
-    We override the bound method on the loaded instance with a corrected
-    version so we don't have to vendor or fork the library. Drop this once
-    upstream releases a fix.
-    """
-    import time
-    import types
-    import numpy as np
-    from kokoro_onnx.config import MAX_PHONEME_LENGTH, SAMPLE_RATE
-
-    def _create_audio_fixed(self, phonemes, voice, speed):
-        # The library's ``create()`` pre-batches phonemes via
-        # ``_split_phonemes()`` so each call here is already under budget.
-        # If something upstream ever skips that, fail loudly rather than
-        # silently truncating audio.
-        if len(phonemes) > MAX_PHONEME_LENGTH:
-            raise RuntimeError(
-                f"Kokoro phoneme overflow: {len(phonemes)} > {MAX_PHONEME_LENGTH}. "
-                "Library should have batched via _split_phonemes()."
-            )
-        start_t = time.time()
-        tokens = np.array(self.tokenizer.tokenize(phonemes), dtype=np.int64)
-        assert len(tokens) <= MAX_PHONEME_LENGTH
-        voice = voice[len(tokens)]
-        tokens = [[0, *tokens, 0]]
-        if "input_ids" in [i.name for i in self.sess.get_inputs()]:
-            inputs = {
-                "input_ids": tokens,
-                "style": np.array(voice, dtype=np.float32),
-                "speed": np.array([speed], dtype=np.float32),  # was int32 — upstream bug
-            }
-        else:
-            inputs = {
-                "tokens": tokens,
-                "style": voice,
-                "speed": np.ones(1, dtype=np.float32) * speed,
-            }
-        audio = self.sess.run(None, inputs)[0]
-        # The HF fp16 export returns shape (1, N) float16; kokoro-onnx's
-        # downstream concatenation + soundfile encoding both expect a 1-D
-        # float32 waveform (the legacy thewh1teagle fp32 model returned that
-        # natively).
-        audio = np.asarray(audio, dtype=np.float32).reshape(-1)
-        logger.debug("[Voice] kokoro batch %.2fs in %.2fs",
-                     len(audio) / SAMPLE_RATE, time.time() - start_t)
-        return audio, SAMPLE_RATE
-
-    tts._create_audio = types.MethodType(_create_audio_fixed, tts)
-
-
-def _build_kokoro_instance(model_file: str, voices_file: str):
-    """Construct one Kokoro instance with its own ONNX session and dtype patch."""
-    from kokoro_onnx import Kokoro
-    from services.onnx_session import build_session
-
-    sess = build_session(model_file, log_prefix="[Voice/Kokoro]")
-    inst = Kokoro.from_session(sess, voices_file)
-    _patch_kokoro_speed_dtype(inst)
-    return inst
 
 
 def _ensure_models():
@@ -222,9 +113,8 @@ def _ensure_models():
         model_path, model_arch = mv.get_model_for_language(MOONSHINE_LANG)
         stt = mv.Transcriber(model_path=model_path, model_arch=model_arch)
 
-        logger.info("[Voice] Loading TTS model (Kokoro, voice=%s)", KOKORO_VOICE)
-        model_file, voices_file = _download_kokoro_models()
-        tts = _build_kokoro_instance(model_file, voices_file)
+        logger.info("[Voice] Loading TTS model (lang=%s, voice=%s)", TTS_LANG, TTS_VOICE)
+        tts = mv.TextToSpeech(TTS_LANG, voice=TTS_VOICE)
 
         with _load_lock:
             _stt_model = stt
@@ -269,7 +159,7 @@ def _wav_duration_seconds(data: bytes) -> float:
 
 # ── Markdown strip patterns (compiled once) ─────────────────────────────────
 #
-# Kokoro pronounces literal punctuation, so ``*example*`` is spoken as
+# The TTS engine pronounces literal punctuation, so ``*example*`` is spoken as
 # "asterisk example asterisk". The LLM is supposed to emit our HTML subset,
 # but markdown leaks through legacy paths, fenced tool output, and quoted
 # user input. We strip it unconditionally — gating on "<" + ">" was the
@@ -297,7 +187,7 @@ _MD_HRULE_RE = re.compile(r"(?m)^\s*(?:[-*_]\s*){3,}\s*$")
 def _strip_markdown(text: str) -> str:
     """Strip markdown markers so they aren't pronounced literally.
 
-    Kokoro speaks raw punctuation. Without this, ``*example*`` becomes
+    The TTS engine speaks raw punctuation. Without this, ``*example*`` becomes
     "asterisk example asterisk" and ``[click](https://x)`` becomes
     "open bracket click close bracket open paren ...".
 
@@ -400,10 +290,9 @@ def voice_synthesize():
     ``{done:true, total:1}`` sentinel so the client can distinguish a
     complete response from a truncated one.
 
-    ``Kokoro.create()`` handles phonemization, batching by
-    ``MAX_PHONEME_LENGTH``, ORT inference, per-batch silence trimming, and
-    concatenation. We just clean the input text, lock around the call (the
-    instance is not thread-safe), and ship the WAV.
+    ``TextToSpeech.synthesize()`` handles G2P, batching, ORT inference, and
+    waveform concatenation. We just clean the input text, lock around the
+    call (the instance is not thread-safe), and ship the WAV.
     """
     if not _VOICE_AVAILABLE:
         return jsonify(_voice_unavailable_payload()), 503
@@ -426,9 +315,7 @@ def voice_synthesize():
     try:
         t0 = time.time()
         with _tts_lock:
-            samples, sample_rate = _tts_model.create(
-                text, voice=KOKORO_VOICE, speed=1.0, lang="en-us",
-            )
+            samples, sample_rate = _tts_model.synthesize(text)
         wav_bytes = _audio_to_wav_bytes(samples, sample_rate)
         logger.info(
             "[Voice] synthesized %d samples in %.2fs",

--- a/backend/api/voice.py
+++ b/backend/api/voice.py
@@ -46,16 +46,45 @@ _KOKORO_MODEL_URL = "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/
 _KOKORO_VOICES_URL = "https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/voices-v1.0.bin"
 
 # ── Dependency detection ────────────────────────────────────────────────────
+#
+# We track _which_ voice package is missing so the UI can surface a precise
+# install hint instead of a generic "unavailable" — the fresh-install case.
+# The shipped requirements-voice.txt covers all four; if any are missing the
+# user (or installer) skipped the voice pip step.
 
-_VOICE_AVAILABLE = False
-try:
-    import moonshine_voice  # noqa: F401
-    import kokoro_onnx  # noqa: F401
-    import soundfile  # noqa: F401
-    import numpy  # noqa: F401
-    _VOICE_AVAILABLE = True
-except ImportError:
-    pass
+_VOICE_REQUIRED_MODULES = ("moonshine_voice", "kokoro_onnx", "soundfile", "numpy")
+_VOICE_MISSING_MODULES: tuple[str, ...] = ()
+
+
+def _detect_voice_modules() -> tuple[str, ...]:
+    import importlib.util
+    missing = []
+    for name in _VOICE_REQUIRED_MODULES:
+        if importlib.util.find_spec(name) is None:
+            missing.append(name)
+    return tuple(missing)
+
+
+_VOICE_MISSING_MODULES = _detect_voice_modules()
+_VOICE_AVAILABLE = not _VOICE_MISSING_MODULES
+
+# Hint surfaced in /voice/health and route 503s. Same string in both places so
+# the frontend has a single canonical install instruction to render.
+_VOICE_INSTALL_HINT = (
+    "Voice dependencies are not installed. Run "
+    "`pip install -r backend/requirements-voice.txt` (or relaunch with "
+    "`./run.sh` — failed installs auto-retry on next launch)."
+)
+
+
+def _voice_unavailable_payload() -> dict:
+    """Canonical 503 envelope when voice deps are missing."""
+    return {
+        "error": "Voice dependencies not installed",
+        "reason": "deps_missing",
+        "missing": list(_VOICE_MISSING_MODULES),
+        "hint": _VOICE_INSTALL_HINT,
+    }
 
 # ── Lazy model state ────────────────────────────────────────────────────────
 
@@ -337,9 +366,20 @@ def _audio_to_wav_bytes(audio_array, sample_rate: int) -> bytes:
 
 @voice_bp.route("/voice/health", methods=["GET"])
 def voice_health():
-    """Voice service health check."""
+    """Voice service health check.
+
+    Returns ``status`` ∈ {``ok``, ``loading``, ``unavailable``} for backwards
+    compatibility with the existing frontend poller and integration tests.
+    When deps are missing we also include ``reason`` + ``missing`` + ``hint``
+    so the UI can show actionable install guidance instead of a silent hide.
+    """
     if not _VOICE_AVAILABLE:
-        return jsonify({"status": "unavailable"}), 503
+        return jsonify({
+            "status": "unavailable",
+            "reason": "deps_missing",
+            "missing": list(_VOICE_MISSING_MODULES),
+            "hint": _VOICE_INSTALL_HINT,
+        }), 503
     if _models_loaded:
         return jsonify({"status": "ok"}), 200
     if _models_loading:
@@ -366,7 +406,7 @@ def voice_synthesize():
     instance is not thread-safe), and ship the WAV.
     """
     if not _VOICE_AVAILABLE:
-        return jsonify({"error": "Voice dependencies not installed"}), 503
+        return jsonify(_voice_unavailable_payload()), 503
 
     if not _ensure_models():
         return jsonify({"error": "Models still loading"}), 503
@@ -422,7 +462,7 @@ def voice_synthesize():
 def voice_transcribe():
     """Transcribe uploaded audio (WAV). Returns {"text": "..."}."""
     if not _VOICE_AVAILABLE:
-        return jsonify({"error": "Voice dependencies not installed"}), 503
+        return jsonify(_voice_unavailable_payload()), 503
 
     if not _ensure_models():
         return jsonify({"error": "Models still loading"}), 503

--- a/backend/requirements-voice.txt
+++ b/backend/requirements-voice.txt
@@ -1,4 +1,3 @@
-moonshine-voice>=0.0.51
-kokoro-onnx>=0.5.0
+moonshine-voice>=0.0.59
 soundfile>=0.13.0
 numpy>=1.24.0

--- a/backend/run.py
+++ b/backend/run.py
@@ -331,6 +331,25 @@ def main():
     except Exception as e:
         logger.warning(f"[Startup] Concept LUT check failed: {e}")
 
+    # Warm up large ONNX models in background daemon threads. Each loader is
+    # already self-locking + idempotent — these calls just kick off the same
+    # download/init paths the first request would, so by the time the user
+    # sends a message the models are usually live. Failure is non-fatal: the
+    # lazy paths still cover it.
+    def _warmup():
+        import threading as _t
+        try:
+            from api.voice import _ensure_models as _voice_warm
+            _t.Thread(target=_voice_warm, name="voice-warmup", daemon=True).start()
+        except Exception as e:
+            logger.warning(f"[Startup] Voice warm-up skipped: {e}")
+        try:
+            from services.embedding_service import _get_session_and_tokenizer as _embed_warm
+            _t.Thread(target=_embed_warm, name="embed-warmup", daemon=True).start()
+        except Exception as e:
+            logger.warning(f"[Startup] Embedding warm-up skipped: {e}")
+    _warmup()
+
     # Register the Flask API worker (this is the main thread's HTTP server)
     def _flask_worker():
         from api import create_app

--- a/backend/services/provider_db_service.py
+++ b/backend/services/provider_db_service.py
@@ -265,6 +265,15 @@ class ProviderDbService:
                 new_id, exc,
             )
 
+        # Auto-activate this provider if none is currently selected. Atomic in
+        # the service layer so it cannot race with a concurrent UI selection.
+        # ``get_selected_provider`` returns ``None`` when the settings row is
+        # missing/empty OR when the previously-selected provider has been
+        # soft-deleted (is_active = 0) — in either case the new provider takes
+        # over the active slot.
+        if self.get_selected_provider() is None:
+            self.set_selected_provider(new_id)
+
         # Fetch the newly created row and return it
         return self.get_provider_by_id(new_id)
 

--- a/backend/tests/integration/test_voice_api.py
+++ b/backend/tests/integration/test_voice_api.py
@@ -48,7 +48,7 @@ def test_health_endpoint_shape(authed_client):
     client, _db, _store = authed_client
 
     resp = client.get('/voice/health')
-    assert resp.status_code in (200, 503)
+    assert resp.status_code == 200
 
     data = resp.get_json()
     assert data is not None

--- a/backend/utils/logger.py
+++ b/backend/utils/logger.py
@@ -113,6 +113,12 @@ class Logger:
         root.addHandler(file_handler)
         root.addHandler(stream_handler)
 
+        # Werkzeug logs every request at INFO. Frontend polling fires
+        # /health, /api/apps, /system/observability/tasks, /scheduler every
+        # 30–60s — that's per-request CPU + log noise for no value. WARNING
+        # keeps real errors (404/500) visible without the per-request stream.
+        logging.getLogger("werkzeug").setLevel(logging.WARNING)
+
     @staticmethod
     def info(message: str) -> None:
         logging.info(message)

--- a/docs/04-ARCHITECTURE.md
+++ b/docs/04-ARCHITECTURE.md
@@ -333,6 +333,8 @@ The system prompt forbids the LLM from emitting programmatic tags or `<a>`.
 
 **Asset versioning:** every static asset reference in served HTML has the version string injected into its filename at response time (e.g. `app.js` becomes `app-0.3.3.js`). Static routes strip the version suffix before the disk lookup, so nothing is renamed on disk. Versioned filenames are used instead of query strings because some service workers and proxies ignore query strings when keying caches. HTML responses themselves are never cached.
 
+**MIME registration:** `backend/api/__init__.py` calls `mimetypes.add_type()` at import time for `.js`, `.mjs`, `.json`, `.css`, and `.html`. Python's `mimetypes` module reads the Windows registry on Windows, which frequently returns `text/plain` (or `None`) for `.js` files due to stale or missing entries — strict browsers (Chrome, Edge) refuse to execute scripts served with the wrong MIME type. Registering the canonical types overrides any bad registry mapping, with no effect on macOS/Linux (where the defaults are already correct).
+
 See `docs/03-WEB-INTERFACE.md` for the full Radiant design system spec.
 
 ---

--- a/frontend/brain/app.js
+++ b/frontend/brain/app.js
@@ -253,12 +253,6 @@ function selectPlatform(platform, context) {
     // Show/hide api key field
     document.getElementById('editApiKeyGroup').style.display = config.hasApiKey ? '' : 'none';
 
-    // Show/hide Ollama model list panel
-    const ollamaListGroup = document.getElementById('ollamaModelListGroup');
-    if (ollamaListGroup) {
-        ollamaListGroup.style.display = platform === 'ollama' ? '' : 'none';
-    }
-
     // Update model select
     populateModelSelect();
 }
@@ -502,30 +496,8 @@ async function refreshOllamaModels() {
     try {
         const host = document.getElementById('editHost').value.trim();
         const names = await fetchOllamaModels(host, 'editConnectionStatus');
-        renderOllamaModelList(names);
-    } finally {
-        _ollamaRefreshInFlight = false;
-    }
-}
-
-function renderOllamaModelList(names) {
-    const container = document.getElementById('ollamaModelList');
-    if (!container) return;
-
-    const select = document.getElementById('editModel');
-
-    if (names.length === 0) {
-        container.innerHTML = '<span class="ollama-model-empty">No models found — is Ollama running?</span>';
-        return;
-    }
-
-    container.innerHTML = names.map(n => {
-        const selected = n === editModel;
-        return `<button type="button" class="ollama-model-chip${selected ? ' selected' : ''}" data-model="${escapeHtml(n)}">${escapeHtml(n)}</button>`;
-    }).join('');
-
-    // Populate the single model select with fetched names
-    if (select) {
+        const select = document.getElementById('editModel');
+        if (!select) return;
         const prev = select.value;
         select.innerHTML = '<option value="">Select model...</option>';
         names.forEach(n => {
@@ -535,18 +507,9 @@ function renderOllamaModelList(names) {
             if (n === prev || n === editModel) opt.selected = true;
             select.appendChild(opt);
         });
+    } finally {
+        _ollamaRefreshInFlight = false;
     }
-
-    container.querySelectorAll('.ollama-model-chip').forEach(chip => {
-        chip.addEventListener('click', () => {
-            const m = chip.dataset.model;
-            editModel = m;
-            if (select) select.value = m;
-            container.querySelectorAll('.ollama-model-chip').forEach(c => {
-                c.classList.toggle('selected', c.dataset.model === m);
-            });
-        });
-    });
 }
 
 // Refresh button click

--- a/frontend/brain/app.js
+++ b/frontend/brain/app.js
@@ -614,15 +614,23 @@ document.getElementById('providerForm').addEventListener('submit', async (e) => 
     }
 
     if (res.ok) {
-        const data = await res.json();
-        if (id) {
-            providers = providers.map(p => p.id === id ? data.provider : p);
-        } else {
-            providers.push(data.provider);
-        }
+        const wasFirstAdd = !id && providers.length === 0;
         document.getElementById('providerModal').classList.add('hidden');
-        renderProviders();
+        document.getElementById('providerForm').reset();
+        editModel = '';
         showToast(id ? 'Provider updated' : 'Provider added', 'success');
+
+        // First-ever provider unlocks the rest of the Brain UI (auth-gate
+        // sets providersOnly=!has_providers at page load). A full reload is
+        // the only way to re-run the gate and reveal the hidden tabs.
+        if (wasFirstAdd) {
+            window.location.reload();
+            return;
+        }
+
+        // Re-fetch from the server so the list reflects canonical state
+        // (handles api_key masking, server-side defaults, etc.) and re-render.
+        await loadData();
     } else {
         const err = await res.json();
         showToast(err.error || 'Failed to save provider', 'error');

--- a/frontend/brain/app.js
+++ b/frontend/brain/app.js
@@ -235,19 +235,15 @@ function selectPlatform(platform, context) {
     // Show/hide host field
     document.getElementById('editHostGroup').style.display = config.hasHost ? '' : 'none';
 
-    // Host field label + connection-test button are Ollama-specific helpers;
-    // for other OpenAI-compatible endpoints we expose a plain "Base URL" field
+    // Host field label differs by platform type
     const hostLabel = document.querySelector('#editHostGroup label');
     const hostInput = document.getElementById('editHost');
-    const ollamaTestBtn = document.getElementById('editTestConnectionBtn');
     if (platform === 'ollama') {
         if (hostLabel) hostLabel.textContent = 'Host';
         hostInput.placeholder = 'http://localhost:11434';
-        ollamaTestBtn.style.display = '';
     } else {
         if (hostLabel) hostLabel.textContent = 'Base URL';
         hostInput.placeholder = 'https://api.minimax.io/v1';
-        ollamaTestBtn.style.display = 'none';
     }
 
     // Show/hide api key field
@@ -255,32 +251,42 @@ function selectPlatform(platform, context) {
 
     // Update model select
     populateModelSelect();
+
+    // Auto-fetch models on tab switch if the relevant credential is already filled.
+    // Skip Gemini (hardcoded list) and OpenAI-compatible (no discovery endpoint).
+    // Skip if a fetch is already in-flight to avoid duplicate requests.
+    if (!_editModelsFetchInFlight) {
+        if (platform === 'ollama') {
+            const host = document.getElementById('editHost').value.trim();
+            if (host) refreshEditModels();
+        } else if (platform === 'openai' || platform === 'anthropic') {
+            const key = document.getElementById('editApiKey').value.trim();
+            if (key) refreshEditModels();
+        }
+    }
 }
 
-async function fetchOllamaModels(host, statusId) {
-    const statusEl = document.getElementById(statusId);
-    statusEl.textContent = 'Fetching models…';
-    statusEl.className = '';
+// Set the inline status under the model dropdown.
+//   tone ∈ {null, 'loading', 'ok', 'err'}
+function setModelStatus(text, tone) {
+    const el = document.getElementById('editModelStatus');
+    if (!el) return;
+    el.textContent = text || '';
+    el.className = 'model-status' + (tone ? ' status-' + tone : '');
+}
 
-    try {
-        const res = await apiFetch(`/providers/ollama/models?host=${encodeURIComponent(host || 'http://localhost:11434')}`);
-        if (res.ok) {
-            const data = await res.json();
-            const names = data.models || [];
-            statusEl.textContent = names.length > 0 ? `✓ ${names.length} model(s) found` : '✓ Connected (no models installed)';
-            statusEl.className = 'status-ok';
-            return names;
-        }
-        const err = await res.json().catch(() => ({}));
-        statusEl.textContent = `✗ ${err.error || 'Connection failed'}`;
-        statusEl.className = 'status-err';
-        return [];
-    } catch (e) {
-        console.warn('[brain/app] failed to reach backend for Ollama models:', e);
-        statusEl.textContent = '✗ Cannot reach backend';
-        statusEl.className = 'status-err';
-        return [];
+async function fetchProviderModels(platform, credentials) {
+    const body = { platform, ...credentials };
+    const res = await apiFetch('/providers/list-models', { method: 'POST', body: JSON.stringify(body) });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+        throw new Error(data.error || `Request failed (${res.status})`);
     }
+    if (data.error) {
+        throw new Error(data.error);
+    }
+    // Backend returns [{id, display_name}, ...]; collapse to plain ID strings.
+    return (data.models || []).map(m => (typeof m === 'string' ? m : (m && m.id) || '')).filter(Boolean);
 }
 
 
@@ -434,11 +440,11 @@ function openEditModal(id) {
     selectPlatform(editPlatform, 'edit');
     modal.classList.remove('hidden');
 
-    // Auto-load model list when editing an Ollama provider so the panel isn't
-    // empty until the user clicks Refresh. New-provider flow stays manual —
-    // the host field still has the default value and no key is needed.
-    if (id && editPlatform === 'ollama') {
-        refreshOllamaModels();
+    // Auto-load model list when editing an existing provider so the dropdown
+    // isn't empty on open. For new providers credential fields are blank so
+    // the tab-switch fetch inside selectPlatform won't fire (by design).
+    if (id) {
+        refreshEditModels();
     }
 }
 
@@ -486,40 +492,93 @@ document.getElementById('editPlatformTabs').addEventListener('click', (e) => {
     }
 });
 
-// Ollama refresh models — single code path used by button click and host blur.
-// Guarded so clicking the Refresh button (which blurs the host input) doesn't
-// fire two simultaneous requests.
-let _ollamaRefreshInFlight = false;
-async function refreshOllamaModels() {
-    if (_ollamaRefreshInFlight) return;
-    _ollamaRefreshInFlight = true;
-    try {
+// Live model fetch — single guarded code path for all platforms.
+// Guards against duplicate in-flight requests (tab-switch + keyup can both fire).
+let _editModelsFetchInFlight = false;
+async function refreshEditModels() {
+    if (_editModelsFetchInFlight) return;
+
+    const platform = editPlatform;
+
+    let credentials;
+    if (platform === 'ollama') {
         const host = document.getElementById('editHost').value.trim();
-        const names = await fetchOllamaModels(host, 'editConnectionStatus');
-        const select = document.getElementById('editModel');
-        if (!select) return;
-        const prev = select.value;
-        select.innerHTML = '<option value="">Select model...</option>';
-        names.forEach(n => {
-            const opt = document.createElement('option');
-            opt.value = n;
-            opt.textContent = n;
-            if (n === prev || n === editModel) opt.selected = true;
-            select.appendChild(opt);
-        });
+        credentials = { host: host || 'http://localhost:11434' };
+    } else if (platform === 'openai' || platform === 'anthropic') {
+        const key = document.getElementById('editApiKey').value.trim();
+        if (!key) return;
+        credentials = { api_key: key };
+    } else {
+        return;
+    }
+
+    const select = document.getElementById('editModel');
+    _editModelsFetchInFlight = true;
+    if (select) select.disabled = true;
+    setModelStatus('Loading models…', 'loading');
+
+    try {
+        const names = await fetchProviderModels(platform, credentials);
+        populateModelSelectFromFetch(names);
+        if (names.length === 0) {
+            setModelStatus(
+                platform === 'ollama'
+                    ? 'No models installed on this Ollama host'
+                    : 'No models returned',
+                'err',
+            );
+        } else {
+            setModelStatus(
+                `${names.length} model${names.length === 1 ? '' : 's'} available`,
+                'ok',
+            );
+        }
+    } catch (e) {
+        setModelStatus(e.message || 'Could not fetch models', 'err');
     } finally {
-        _ollamaRefreshInFlight = false;
+        if (select) select.disabled = false;
+        _editModelsFetchInFlight = false;
     }
 }
 
-// Refresh button click
-document.getElementById('editTestConnectionBtn').addEventListener('click', refreshOllamaModels);
-
-// Host blur → programmatically trigger the same refresh
-document.getElementById('editHost').addEventListener('blur', () => {
-    if (editPlatform === 'ollama') {
-        document.getElementById('editTestConnectionBtn').click();
+// Populate the dropdown from a freshly-fetched list. Preserves the user's
+// current selection if the model still exists in the new list; otherwise
+// appends it as a trailing option so the existing provider config isn't lost.
+function populateModelSelectFromFetch(names) {
+    const select = document.getElementById('editModel');
+    if (!select) return;
+    const prev = editModel || select.value;
+    select.innerHTML = '<option value="">Select model...</option>';
+    names.forEach(n => {
+        const opt = document.createElement('option');
+        opt.value = n;
+        opt.textContent = n;
+        if (n === prev) opt.selected = true;
+        select.appendChild(opt);
+    });
+    if (prev && !names.includes(prev)) {
+        const opt = document.createElement('option');
+        opt.value = prev;
+        opt.textContent = prev;
+        opt.selected = true;
+        select.appendChild(opt);
     }
+}
+
+// Debounced keyup on host (ollama) and api_key (openai/anthropic). 600 ms is
+// comfortably above typical inter-keystroke latency so a long paste collapses
+// to a single fetch while still feeling live.
+const _MODEL_FETCH_DEBOUNCE_MS = 600;
+let _modelFetchTimer = null;
+function debouncedRefreshModels() {
+    clearTimeout(_modelFetchTimer);
+    _modelFetchTimer = setTimeout(refreshEditModels, _MODEL_FETCH_DEBOUNCE_MS);
+}
+document.getElementById('editHost').addEventListener('keyup', () => {
+    if (editPlatform === 'ollama') debouncedRefreshModels();
+});
+document.getElementById('editApiKey').addEventListener('keyup', () => {
+    if (editPlatform === 'openai' || editPlatform === 'anthropic') debouncedRefreshModels();
 });
 
 // Full provider test (all platforms)

--- a/frontend/brain/app.js
+++ b/frontend/brain/app.js
@@ -58,7 +58,7 @@ const PLATFORM_CONFIG = {
         hasHost: false,
         hasApiKey: true,
         modelPlaceholder: 'e.g. gemini-2.5-flash',
-        models: ['gemini-2.5-flash', 'gemini-2.5-pro', 'gemini-2.0-flash-lite'],
+        models: ['gemini-3.1-pro-preview', 'gemini-3-flash-preview', 'gemini-3.1-flash-lite', 'gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.5-flash-lite'],
     },
     openai_compatible: {
         desc: 'Any OpenAI-compatible API — MiniMax, Groq, DeepSeek, Together, OpenRouter, LM Studio, vLLM. Supply the provider\'s base URL and API key.',

--- a/frontend/brain/index.html
+++ b/frontend/brain/index.html
@@ -449,12 +449,6 @@
                     <label for="editApiKey">API Key</label>
                     <input type="password" id="editApiKey" placeholder="Leave blank to keep existing key">
                 </div>
-                <div class="form-group" id="ollamaModelListGroup" style="display:none;">
-                    <label for="ollamaModelList">Available models <span class="label-hint">(click to select)</span></label>
-                    <div class="ollama-model-list" id="ollamaModelList">
-                        <span class="ollama-model-empty">Click &ldquo;Refresh models&rdquo; to load the list from your Ollama host.</span>
-                    </div>
-                </div>
                 <div class="form-group">
                     <label for="editModel">Model</label>
                     <select id="editModel">

--- a/frontend/brain/index.html
+++ b/frontend/brain/index.html
@@ -439,11 +439,7 @@
                 </div>
                 <div class="form-group" id="editHostGroup">
                     <label for="editHost">Host</label>
-                    <div class="host-input-row">
-                        <input type="text" id="editHost" value="http://localhost:11434">
-                        <button type="button" class="btn btn-secondary btn-sm" id="editTestConnectionBtn">Refresh models</button>
-                    </div>
-                    <span id="editConnectionStatus"></span>
+                    <input type="text" id="editHost" value="http://localhost:11434">
                 </div>
                 <div class="form-group" id="editApiKeyGroup">
                     <label for="editApiKey">API Key</label>
@@ -454,6 +450,7 @@
                     <select id="editModel">
                         <option value="">Select model...</option>
                     </select>
+                    <span id="editModelStatus" class="model-status"></span>
                 </div>
                 <div id="testResult" class="test-result hidden"></div>
                 <div class="form-actions">

--- a/frontend/brain/style.css
+++ b/frontend/brain/style.css
@@ -1512,49 +1512,6 @@ body::before {
     padding: 6px 12px;
     font-size: 0.8rem;
 }
-.label-hint {
-    font-size: 0.75rem;
-    color: var(--text-muted, #666);
-    font-weight: 400;
-}
-.ollama-model-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-    padding: 8px;
-    min-height: 36px;
-    background: var(--bg-input, #1a1a2e);
-    border: 1px solid var(--border, #2a2a3e);
-    border-radius: 6px;
-}
-.ollama-model-chip {
-    display: inline-flex;
-    align-items: center;
-    padding: 4px 10px;
-    border-radius: 4px;
-    font-size: 0.78rem;
-    font-weight: 500;
-    cursor: pointer;
-    background: var(--bg-surface, #16213e);
-    border: 1px solid var(--border, #2a2a3e);
-    color: var(--text-secondary, #aaa);
-    transition: border-color 150ms ease, background 150ms ease, color 150ms ease;
-}
-.ollama-model-chip:hover {
-    border-color: rgba(138, 92, 255, 0.4);
-    color: var(--text-primary, #e0e0e0);
-}
-.ollama-model-chip.selected {
-    background: rgba(138, 92, 255, 0.15);
-    border-color: rgba(138, 92, 255, 0.55);
-    color: var(--accent-primary, #8a5cff);
-}
-.ollama-model-empty {
-    font-size: 0.78rem;
-    color: var(--text-muted, #666);
-    padding: 4px 2px;
-}
-
 /* =====================================================
    Capability group cards
    ===================================================== */

--- a/frontend/interface/app.js
+++ b/frontend/interface/app.js
@@ -367,7 +367,17 @@ class ChalieApp {
     const MAX_POLL_MS = 60_000;
     const deadline = Date.now() + MAX_POLL_MS;
 
+    // Page loads with body.voice-loading set (see index.html). That class
+    // hides #voiceRecBtn and every .speech-form__speak-btn via style.css so
+    // mic + speaker icons never appear before voice is actually usable.
+    // We only clear it after /voice/health returns {status: "ok"}.
+    const reveal = () => {
+      document.body.classList.remove('voice-loading');
+    };
+
     const hide = () => {
+      // Keep voice-loading on so the icons stay hidden, and tag the body
+      // as unavailable for any additional CSS selectors.
       document.getElementById('voiceRecBtn')?.classList.add('hidden');
       document.body.classList.add('voice-unavailable');
     };
@@ -378,7 +388,7 @@ class ChalieApp {
         const resp = await fetch('/voice/health', { credentials: 'same-origin' });
         const data = resp.ok ? await resp.json().catch(() => ({})) : {};
         const status = data.status;
-        if (status === 'ok') return; // controls stay visible
+        if (status === 'ok') { reveal(); return; }
         if (status === 'unavailable') { hide(); return; }
         // 'loading' — re-poll until deadline
         if (Date.now() < deadline) {

--- a/frontend/interface/index.html
+++ b/frontend/interface/index.html
@@ -46,7 +46,7 @@
   <link rel="apple-touch-icon" href="/icons/icon.png">
   <link rel="icon" type="image/png" href="/icons/icon.png">
 </head>
-<body>
+<body class="voice-loading">
   <!-- Ambient background -->
   <canvas id="ambientCanvas"></canvas>
   <div id="ambientBloom"></div>

--- a/frontend/interface/style.css
+++ b/frontend/interface/style.css
@@ -1429,7 +1429,7 @@ body.voice-loading .speech-form__speak-btn { display: none; }
 
 .history-end-pill__label {
   font-size: 11px;
-  color: rgba(234, 230, 242, 0.3);
+  color: var(--text-muted);
   background: color-mix(in oklab, var(--text) 3%, transparent);
   border: 1px solid color-mix(in oklab, var(--text) 7%, transparent);
   border-radius: 20px;

--- a/frontend/interface/style.css
+++ b/frontend/interface/style.css
@@ -2203,22 +2203,30 @@ body.voice-unavailable .speech-form__speak-btn { display: none; }
   color: var(--accent-primary);
 }
 
+/* Dialog surface is hardcoded dark in both themes (rgba(12,14,24,0.96)),
+   so text must stay on the dark-theme light tokens — otherwise light theme
+   resolves --text-primary to #1A1626 and the copy goes dark-on-dark. */
+.pwa-dialog__content,
+.pwa-dialog__close {
+  color: #eae6f2;
+}
+
 .pwa-dialog__title {
   font-size: var(--font-size-xl);
   font-weight: 300;
   margin-bottom: var(--space-sm);
-  color: var(--text-primary);
+  color: #eae6f2;
 }
 
 .pwa-dialog__desc {
   font-size: var(--font-size-sm);
-  color: var(--text-secondary);
+  color: rgba(234, 230, 242, 0.78);
   margin-bottom: var(--space-lg);
   line-height: 1.6;
 }
 
 .pwa-dialog__desc strong {
-  color: var(--text-primary);
+  color: #eae6f2;
   font-weight: 500;
 }
 

--- a/frontend/interface/style.css
+++ b/frontend/interface/style.css
@@ -1236,6 +1236,14 @@ body.speaker-user   #ambientBloom {
 /* Hide all voice controls when the voice service is unavailable */
 body.voice-unavailable .speech-form__speak-btn { display: none; }
 
+/* Hide voice controls until the backend reports voice is fully loaded.
+   Default state on page load is .voice-loading; app.js removes the class
+   only after /voice/health returns {status: "ok"}. If voice is unavailable
+   or fails to initialise, the class stays and the controls remain hidden
+   instead of appearing and erroring on click. */
+body.voice-loading #voiceRecBtn,
+body.voice-loading .speech-form__speak-btn { display: none; }
+
 /* ACT cycle — chrome-less live tool loop UI.
    Layout:
      .act-cycle

--- a/frontend/interface/voice_player.js
+++ b/frontend/interface/voice_player.js
@@ -145,6 +145,13 @@ export class VoicePlayer {
       if (!resp.ok) {
         const err = await resp.json().catch(() => ({}));
         if (gen !== this._openGeneration) return;
+        // deps_missing → surface the install hint verbatim. The button SHOULD
+        // already be hidden by the /voice/health poller in app.js, but a stale
+        // page load (interface fetched before voice install completed) can still
+        // hit this path. Show the hint instead of a useless "HTTP 503".
+        if (err.reason === 'deps_missing') {
+          throw new Error(err.hint || err.error || 'Voice dependencies not installed');
+        }
         throw new Error(err.error || `HTTP ${resp.status}`);
       }
 

--- a/frontend/interface/voice_recorder.js
+++ b/frontend/interface/voice_recorder.js
@@ -134,7 +134,10 @@ export class VoiceRecorder {
       if (text) this._onTranscript(text);
     } catch (err) {
       console.error('[VoiceRecorder] STT error:', err);
-      this._showError('Transcription failed');
+      // Prefer the server-supplied hint when voice deps are missing — same
+      // rationale as VoicePlayer: the /voice/health poller usually hides the
+      // mic button first, but a stale page load can still race the install.
+      this._showError(err.userMessage || 'Transcription failed');
     } finally {
       this._setButtonState('idle');
     }
@@ -254,7 +257,16 @@ export class VoiceRecorder {
       credentials: 'same-origin',
     });
 
-    if (!response.ok) throw new Error(`STT error: ${response.status}`);
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({}));
+      const err = new Error(body.error || `STT error: ${response.status}`);
+      // deps_missing → attach the install hint as `userMessage` so the caller
+      // can render it verbatim. Other 4xx/5xx fall back to the generic message.
+      if (body.reason === 'deps_missing') {
+        err.userMessage = body.hint || body.error || 'Voice dependencies not installed';
+      }
+      throw err;
+    }
     const data = await response.json();
     return data.text || null;
   }

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -327,14 +327,15 @@ _install_voice_deps() {
   local os
   os="$(_detect_os)"
 
-  # Install system-level dependencies for soundfile/espeak
+  # Install system-level dependencies for soundfile + ffmpeg.
+  # moonshine_voice ships its own neural G2P, so espeak-ng is no longer needed.
   if [[ "$os" == "darwin" ]]; then
     if command -v brew >/dev/null 2>&1; then
-      _info "Installing libsndfile and espeak-ng via Homebrew…"
-      brew install libsndfile espeak-ng ffmpeg 2>/dev/null || true
+      _info "Installing libsndfile and ffmpeg via Homebrew…"
+      brew install libsndfile ffmpeg 2>/dev/null || true
     else
       _warn "Homebrew not found — voice system deps may need manual install"
-      _warn "  brew install libsndfile espeak-ng ffmpeg"
+      _warn "  brew install libsndfile ffmpeg"
     fi
   else
     local distro
@@ -342,14 +343,14 @@ _install_voice_deps() {
     _info "Installing voice system dependencies…"
     case "$distro" in
       *debian*|*ubuntu*)
-        _run_privileged apt-get install -y libsndfile1 espeak-ng ffmpeg 2>/dev/null || true
+        _run_privileged apt-get install -y libsndfile1 ffmpeg 2>/dev/null || true
         ;;
       *fedora*|*rhel*|*centos*)
-        _run_privileged dnf install -y libsndfile espeak-ng ffmpeg 2>/dev/null || true
+        _run_privileged dnf install -y libsndfile ffmpeg 2>/dev/null || true
         ;;
       *)
         _warn "Cannot auto-install voice deps on distro: $distro"
-        _warn "Install manually: libsndfile, espeak-ng, ffmpeg"
+        _warn "Install manually: libsndfile, ffmpeg"
         ;;
     esac
   fi

--- a/run.sh
+++ b/run.sh
@@ -92,9 +92,17 @@ if [[ "$_VOICE" == "true" ]]; then
   VOICE_STAMP="$_STAMP_DIR/.voice-deps-installed"
   if [[ -f "$VOICE_REQ" ]] && { [[ ! -f "$VOICE_STAMP" ]] || [[ "$VOICE_REQ" -nt "$VOICE_STAMP" ]]; }; then
     echo "→ Syncing voice dependencies …"
-    "$PIP" install -r "$VOICE_REQ" 2>/dev/null \
-      || echo "  ⚠ Voice dep install failed — voice will be unavailable"
-    touch "$VOICE_STAMP"
+    # Stamp ONLY on success. A failed install (no espeak-ng, no libsndfile,
+    # network blip) used to be papered over by an unconditional `touch`, which
+    # left voice permanently broken until requirements-voice.txt changed. Now
+    # the stamp is created only when pip exits 0, so the next launch retries
+    # automatically and the user sees the failure surface in the UI via
+    # /voice/health → status:"unavailable" + reason:"deps_missing".
+    if "$PIP" install -r "$VOICE_REQ"; then
+      touch "$VOICE_STAMP"
+    else
+      echo "  ⚠ Voice dep install failed — voice will be unavailable until next launch retries"
+    fi
   fi
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -92,7 +92,7 @@ if [[ "$_VOICE" == "true" ]]; then
   VOICE_STAMP="$_STAMP_DIR/.voice-deps-installed"
   if [[ -f "$VOICE_REQ" ]] && { [[ ! -f "$VOICE_STAMP" ]] || [[ "$VOICE_REQ" -nt "$VOICE_STAMP" ]]; }; then
     echo "→ Syncing voice dependencies …"
-    # Stamp ONLY on success. A failed install (no espeak-ng, no libsndfile,
+    # Stamp ONLY on success. A failed install (no libsndfile,
     # network blip) used to be papered over by an unconditional `touch`, which
     # left voice permanently broken until requirements-voice.txt changed. Now
     # the stamp is created only when pip exits 0, so the next launch retries


### PR DESCRIPTION
Duplicate of [#1757](https://github.com/chalie-ai/chalie/pull/1757) targeting `rc-0.7.0` instead of `main`.

All 15 commits cherry-picked from `fix/multi-issue-batch-20260509`. One commit (`fc8f8fa`) was dropped by git during cherry-pick (empty after merge) and re-applied manually — the change is identical.

## Included fixes

- `fix(brain)`: drop Available Models multi-select from Ollama provider form
- `fix(brain)`: refresh Gemini model list against current API
- `fix(pwa)`: make install dialog text white for legibility
- `feat(providers)`: auto-activate newly added provider when none is selected
- `fix(brain)`: refresh providers list after successful add
- `fix(voice)`: hide mic and speaker icons until voice is fully loaded
- `fix(voice)`: handle missing voice deps cleanly on fresh install
- `fix(static)`: force JS MIME type so Windows registry can't override it
- `docs(architecture)`: document static-asset MIME registration on Windows
- `feat(brain)`: live model fetch on provider form — drop Refresh button
- `feat(providers)`: live model fetch via keyup-debounced API call
- `fix(interface)`: theme-aware history-end-pill label (was invisible in light theme)
- `fix(voice)`: /voice/health returns 200 for unavailable state
- `logger`: silence werkzeug INFO request log
- `refactor(voice)`: collapse onto moonshine_voice package, drop kokoro-onnx + espeak-ng

🤖 Generated with [Claude Code](https://claude.com/claude-code)