### PR TITLE
fix(client-context): stop dropping heartbeats when cached location is null

### DIFF
--- a/backend/services/client_context_service.py
+++ b/backend/services/client_context_service.py
@@ -184,7 +184,11 @@ class ClientContextService:
 
         # Resolve location name if location changed significantly
         if location := ctx.get("location"):
-            cached_location = cached_ctx.get("location", {})
+            # ``cached_ctx.get("X", {})`` returns ``None`` when the key exists
+            # with value ``None`` — which it will, because ``_flatten`` JSON-
+            # encodes ``None`` as ``"null"`` and ``_unflatten`` decodes it back
+            # to ``None``. Coerce explicitly so ``.get()`` chaining is safe.
+            cached_location = cached_ctx.get("location") or {}
             lat_changed = abs(location.get("lat", 0) - cached_location.get("lat", 0)) > 0.05
             lon_changed = abs(location.get("lon", 0) - cached_location.get("lon", 0)) > 0.05
 
@@ -237,7 +241,7 @@ class ClientContextService:
         self._seed_demographic_traits(ctx)
 
         logging.debug(f"[CLIENT CONTEXT] Saved context with timezone={ctx.get('timezone')}, "
-                     f"device={ctx.get('device', {}).get('class')}")
+                     f"device={(ctx.get('device') or {}).get('class')}")
 
     def get(self) -> dict:
         """Retrieve client context from the telemetry table as a nested dict."""


### PR DESCRIPTION
## Summary
- `ClientContextService.save()` was silently dropping every heartbeat after the cached location went `null`
- Root cause: `cached_ctx.get('location', {})` returns `None` (not `{}`) when the key exists with value `None` — which it does after the JSON-roundtrip through the telemetry table
- Fix: `or {}` coercion (same pattern already used in `_mirror_telemetry_to_world_state`)

## Impact
On chalie-dev the warning `[HEALTH] Failed to save client context: 'NoneType' object has no attribute 'get'` was firing on every heartbeat (every ~60s). When it fires:
- ❌ telemetry table never written
- ❌ location history never appended
- ❌ session re-entry never detected
- ❌ demographic seeding skipped
- ❌ timezone never persisted to settings

## Test plan
- [ ] Restart chalie-dev, watch logs for ≥5 minutes — no more `[HEALTH] Failed to save client context` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)