### PR TITLE
refactor(schedule): collapse action.description to availability form

### DIFF
--- a/backend/abilities/schedule.py
+++ b/backend/abilities/schedule.py
@@ -54,13 +54,7 @@ class ScheduleAbility(Ability):
             "action": {
                 "type": "string",
                 "enum": ["create", "list", "search", "cancel"],
-                "description": (
-                    "The scheduler action to perform. If the user wants a short "
-                    "ephemeral countdown (e.g. 'set a 5 minute timer', 'start a "
-                    "25 minute focus block'), STOP — call the `timer` tool "
-                    "instead of `schedule`. `schedule` is for calendar-anchored "
-                    "reminders that persist across restarts."
-                ),
+                "description": "The scheduler action to perform.",
             },
             "message": {
                 "type": "string",


### PR DESCRIPTION
## Summary

Subtractive cleanup of `backend/abilities/schedule.py` — collapses the 5-line "STOP — call the \`timer\` tool instead" directive in INPUT_SCHEMA.action.description to the bare availability statement `"The scheduler action to perform."`.

## Why

- The SUMMARY already carries the schedule-vs-timer boundary in availability form (find_tools routes off SUMMARY + EXAMPLES).
- By the time the LLM reads action.description it has already committed to schedule's schema — the redirect-to-timer text fires too late to change routing.
- Matches TKT-349 convention: phrase ability schemas as **availability**, not directive.
- Saves ~220 chars / ~50 tokens per schedule schema injection.
- INPUT_SCHEMA is not part of the abilities SHA hash (`backend/utils/build_ability_db.py:79` covers SUMMARY + EXAMPLES only), so no sqlite rebuild needed.

## Targeted scenarios

- **064-tool-timer.yaml** — regression guard (currently PASS 1.0; must hold)
- **066-rich-media-schedule-card.yaml** — chronic step-1 WARN with latency/token anomaly (baseline #585: PASS 0.92, step 1 composite 0.76)

Linked Taskie: TKT-352

## Test plan
- [x] Self-review 8/8
- [x] Verification: `ScheduleAbility.INPUT_SCHEMA['properties']['action']['description']` prints `"The scheduler action to perform."`
- [ ] CI green
- [ ] Improve-pipeline ≥ baseline on 064 + 066

🤖 Generated with [Claude Code](https://claude.com/claude-code)