### PR TITLE
perf(ump): promote weather to ALWAYS_AVAILABLE — drop find_tools hop

### DIFF
--- a/backend/services/user_message_processor.py
+++ b/backend/services/user_message_processor.py
@@ -42,11 +42,14 @@ class UserMessageProcessor(MessageProcessor):
     JOB = 'frontal-cortex-unified'
     SYSTEM_PROMPT_CLASS = UnifiedSystemMessagePrompt
 
-    # 9 innate abilities — pre-injected on every ACT iteration. The 10 in
+    # 10 innate abilities — pre-injected on every ACT iteration. The 9 in
     # DISCOVERABLE are surfaced at runtime via find_tools and never
     # pre-injected. `subagent` lives in DISCOVERABLE so it competes with
-    # weather/search/news/browser via find_tools rather than appearing as
-    # an always-on fallback that biases routing for single-tool lookups.
+    # search/news/browser via find_tools rather than appearing as an always-on
+    # fallback that biases routing for single-tool lookups. `weather` is
+    # promoted to ALWAYS_AVAILABLE because the find_tools→weather hop costs an
+    # extra LLM iteration per weather query with no routing benefit — weather
+    # has a narrow, unambiguous trigger that does not need discovery gating.
     ALWAYS_AVAILABLE: list[str] = [
         "find_tools",
         "document",
@@ -57,6 +60,7 @@ class UserMessageProcessor(MessageProcessor):
         "review_transcript",
         "schedule",
         "timer",
+        "weather",
     ]
     DISCOVERABLE: list[str] = [
         "browser",
@@ -68,7 +72,6 @@ class UserMessageProcessor(MessageProcessor):
         "programming_docs_search",
         "search",
         "subagent",
-        "weather",
     ]
 
     # ── Constructor ───────────────────────────────────────────────────────────

--- a/backend/tests/test_phase4_invariants.py
+++ b/backend/tests/test_phase4_invariants.py
@@ -169,14 +169,15 @@ def test_abilities_directory_has_exactly_21_non_underscore_modules():
 #     for this processor.  find_tools filters its DB query by this list.
 #
 # The bug this test prevents: pre-injecting discoverable externals
-# (browser, code_eval, news, programming_docs_search, search, weather) into
-# a processor's ALWAYS_AVAILABLE that should not own them.  Pre-injection
+# (browser, code_eval, news, programming_docs_search, search) into a
+# processor's ALWAYS_AVAILABLE that should not own them.  Pre-injection
 # bloated tools arrays from ~5kB to ~12.8kB and produced Ollama 500 errors +
 # model hallucinations in nightly run 346.
 
 _DEFAULT_ALWAYS = frozenset({
     "document", "find_tools", "list", "memory",
     "read", "review_tool_calls", "review_transcript", "schedule", "timer",
+    "weather",
 })
 
 # `subagent` is discoverable in UMP only — DMN/Scheduled/Subagent processors
@@ -200,18 +201,20 @@ _CAPABILITY_TOOLS = frozenset({"email", "calendar", "contacts"})
 
 
 _EXPECTED_SCOPE: dict[str, tuple[frozenset[str], frozenset[str]]] = {
-    "UserMessageProcessor":      (_DEFAULT_ALWAYS, _DEFAULT_DISCOVERABLE),
+    # `weather` is promoted to ALWAYS_AVAILABLE — narrow unambiguous trigger,
+    # eliminates the find_tools→weather extra LLM iteration per query.
+    "UserMessageProcessor":      (_DEFAULT_ALWAYS, _DEFAULT_DISCOVERABLE - {"weather"}),
     # DMN has news, search, browser natively per masterplan §4 — no find_tools round-trip.
     # `timer` is dropped: DMN runs in the background without a user-channel
     # surface, so the rich-media card would never render. `subagent` is
     # excluded everywhere except UMP so background processes cannot spawn
     # nested subagents. email/calendar/contacts remain discoverable for DMN
     # — background reflection needs access to personal data context.
-    "DMNMessageProcessor":       ((_DEFAULT_ALWAYS - {"timer"}) | {"news", "search", "browser"},
+    "DMNMessageProcessor":       ((_DEFAULT_ALWAYS - {"timer", "weather"}) | {"news", "search", "browser"},
                                    _DEFAULT_DISCOVERABLE - {"news", "search", "browser", "subagent"}),
     # ScheduledPromptProcessor — same tool surface as UMP. Scheduled prompts
     # act on the user's behalf with full capabilities.
-    "ScheduledPromptProcessor": (_DEFAULT_ALWAYS, _DEFAULT_DISCOVERABLE),
+    "ScheduledPromptProcessor": (_DEFAULT_ALWAYS, _DEFAULT_DISCOVERABLE - {"weather"}),
     # SubagentProcessor ALWAYS_AVAILABLE is set per-instance (from agent_type);
     # the class-level attribute is [] (empty). The per-instance value is
     # verified separately in test_subagent_processor.py::test_per_instance_always_available_is_set_from_agent_type.
@@ -276,7 +279,15 @@ def test_per_processor_tool_scope_matches_spec():
 
         # DMNMessageProcessor has news/search/browser promoted to
         # ALWAYS_AVAILABLE per masterplan §4 — not a leak, by design.
-        approved_always_externals = {"news", "search", "browser"} if name == "DMNMessageProcessor" else set()
+        # UMP and ScheduledPromptProcessor have weather promoted to
+        # ALWAYS_AVAILABLE — narrow unambiguous trigger, no routing benefit
+        # from a find_tools round-trip.
+        if name == "DMNMessageProcessor":
+            approved_always_externals = {"news", "search", "browser"}
+        elif name in {"UserMessageProcessor", "ScheduledPromptProcessor"}:
+            approved_always_externals = {"weather"}
+        else:
+            approved_always_externals = set()
         leaked_externals = always & (_DEFAULT_DISCOVERABLE - approved_always_externals)
         assert not leaked_externals, (
             f"{name}.ALWAYS_AVAILABLE leaks discoverable externals "


### PR DESCRIPTION
## Summary

Move `weather` from `DISCOVERABLE` to `ALWAYS_AVAILABLE` in `UserMessageProcessor`. Weather queries currently take 3 LLM iterations (find_tools → weather → synthesis); with this change they collapse to 2 (weather → synthesis), eliminating an unnecessary discovery hop per weather query.

## Evidence

Nightly judge on pipeline #616 (rc-0.7.0, scenario 050-tool-weather, status WARN 0.88):

> "The model invoked 'find_tools' as a preliminary step before calling the 'weather' tool, adding an unnecessary iteration to the loop."

Verified again in baseline #619 metrics — even though 050 PASSed at 1.0 (judge variance on latency), the wiring still walks find_tools → weather → synthesis on 3 of 4 weather scenarios (044/050/083). The redundant LLM iteration is structural, not random.

## Why weather but not search/news/browser

The existing UMP comment justifies DISCOVERABLE placement to keep `subagent` competing fairly with weather/search/news/browser via find_tools. Weather is the safe case to promote because its trigger is narrow and unambiguous — an explicit weather query — so it does not compete with other tools at routing time. Search/news/browser remain in DISCOVERABLE because they contest broad knowledge queries with each other and with subagent.

## Test changes

`test_phase4_invariants.py` updated to reflect the new wiring:
- `_DEFAULT_ALWAYS` now includes `weather`
- UMP / ScheduledPromptProcessor expected discoverable = `_DEFAULT_DISCOVERABLE - {"weather"}`
- DMN expected always = `_DEFAULT_ALWAYS - {"timer", "weather"}` (DMN promotes news/search/browser instead, weather stays discoverable for DMN per masterplan §4)
- `approved_always_externals` extended to allow `weather` for UMP / ScheduledPromptProcessor in the leak check

Invariants are tightened to match the new design, not silenced.

## Test plan

- [ ] Backend unit tests pass (2156 passed locally; CI will re-run)
- [ ] Improve pipeline on 044/050/058/083 holds or improves baseline 0.985
- [ ] Total wall_ms on 044/050/083 should decrease by ~1-2s (eliminated iter-0 find_tools call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)