### PR TITLE
improve(rich-media): drop redundant trailer preamble across 8 abilities

### DIFF
--- a/backend/abilities/calendar.py
+++ b/backend/abilities/calendar.py
@@ -18,8 +18,7 @@ logger = logging.getLogger(__name__)
 LOG_PREFIX = "[CALENDAR ABILITY]"
 
 _RICH_MEDIA_INSTRUCTION = (
-    "This tool supports rich-media rendering. You MUST present this result by "
-    "wrapping your synthesis in <span id='{tag}'>your synthesis here</span>. "
+    "You MUST present this result by wrapping your synthesis in <span id='{tag}'>your synthesis here</span>. "
     "The span will render as a calendar card; without it, the user sees only "
     "plain text. Write a brief summary. Example: "
     "\"<span id='{tag}'>You have 3 meetings tomorrow, starting with standup at 09:00.</span>\""

--- a/backend/abilities/contacts.py
+++ b/backend/abilities/contacts.py
@@ -15,8 +15,7 @@ logger = logging.getLogger(__name__)
 LOG_PREFIX = "[CONTACTS ABILITY]"
 
 _RICH_MEDIA_INSTRUCTION = (
-    "This tool supports rich-media rendering. You MUST present this result by "
-    "wrapping your synthesis in <span id='{tag}'>your synthesis here</span>. "
+    "You MUST present this result by wrapping your synthesis in <span id='{tag}'>your synthesis here</span>. "
     "The span will render as a contact card; without it, the user sees only "
     "plain text. Write a brief summary. Example: "
     "\"<span id='{tag}'>Here's John's contact info.</span>\""

--- a/backend/abilities/list.py
+++ b/backend/abilities/list.py
@@ -22,8 +22,7 @@ from services.innate_skills._tag import tag as _skill_tag
 logger = logging.getLogger(__name__)
 
 _RICH_MEDIA_INSTRUCTION = (
-    "This tool supports rich-media rendering. You MUST present this result by "
-    "wrapping your synthesis in <span id='{tag}'>your synthesis here</span>. "
+    "You MUST present this result by wrapping your synthesis in <span id='{tag}'>your synthesis here</span>. "
     "The span will render as a checklist card; without it, the user sees only "
     "plain text. Write a brief acknowledgement. Example: "
     "\"<span id='{tag}'>Added milk and eggs to your grocery list.</span>\""

--- a/backend/abilities/news.py
+++ b/backend/abilities/news.py
@@ -19,8 +19,7 @@ from services.time_formatter_service import TimeFormatterService
 logger = logging.getLogger(__name__)
 
 _RICH_MEDIA_INSTRUCTION = (
-    "This tool supports rich-media rendering. You MUST present this result by "
-    "wrapping your synthesis in <span id='{tag}'>your synthesis here</span>. "
+    "You MUST present this result by wrapping your synthesis in <span id='{tag}'>your synthesis here</span>. "
     "The span will render as a news article card; without it, the user sees "
     "only plain text. Write a single paragraph that synthesises the key story "
     "for the user. Example: \"Here's the latest — "

--- a/backend/abilities/schedule.py
+++ b/backend/abilities/schedule.py
@@ -22,8 +22,7 @@ LOG_PREFIX = "[SCHEDULER SKILL]"
 _LOCAL_ISO_FMT = "%Y-%m-%dT%H:%M:%S%z"
 
 _RICH_MEDIA_INSTRUCTION = (
-    "This tool supports rich-media rendering. You MUST present this result by "
-    "wrapping your synthesis in <span id='{tag}'>your synthesis here</span>. "
+    "You MUST present this result by wrapping your synthesis in <span id='{tag}'>your synthesis here</span>. "
     "The span will render as a scheduler card; without it, the user sees only "
     "plain text. Write a brief confirmation. Example: "
     "\"<span id='{tag}'>Done — 30 min with Mira on Thursday at 14:30.</span>\""

--- a/backend/abilities/search.py
+++ b/backend/abilities/search.py
@@ -26,8 +26,7 @@ from tools.search.fetcher import fetch_providers, fetch_ddg_fallback
 logger = logging.getLogger(__name__)
 
 _RICH_MEDIA_INSTRUCTION = (
-    "This tool supports rich-media rendering. You MUST present this result by "
-    "wrapping your synthesis in <span id='{tag}'>your synthesis here</span>. "
+    "You MUST present this result by wrapping your synthesis in <span id='{tag}'>your synthesis here</span>. "
     "The span will render as a search results card; without it, the user sees "
     "only plain text. Write a single paragraph that synthesises the findings "
     "for the user. Example: \"Based on what I found — "

--- a/backend/abilities/timer.py
+++ b/backend/abilities/timer.py
@@ -33,8 +33,7 @@ logger = logging.getLogger(__name__)
 _PARSE_UTC_SENTINEL = datetime.min.replace(tzinfo=timezone.utc)
 
 _RICH_MEDIA_INSTRUCTION = (
-    "This tool supports rich-media rendering. You MUST present this result by "
-    "wrapping your synthesis in <span id='{tag}'>your synthesis here</span>. "
+    "You MUST present this result by wrapping your synthesis in <span id='{tag}'>your synthesis here</span>. "
     "The span will render as a live countdown card; without it, the user "
     "sees only plain text. Write a brief acknowledgement. Example: "
     "\"<span id='{tag}'>Started a 25-minute focus timer.</span>\""

--- a/backend/abilities/weather.py
+++ b/backend/abilities/weather.py
@@ -117,8 +117,7 @@ class WeatherAbility(Ability):
 
 
 _RICH_MEDIA_INSTRUCTION = (
-    "This tool supports rich-media rendering. You MUST present this result by "
-    "wrapping your synthesis in <span id='{tag}'>your synthesis here</span>. "
+    "You MUST present this result by wrapping your synthesis in <span id='{tag}'>your synthesis here</span>. "
     "The span will render as a weather card; without it, the user sees only "
     "plain text. Example output: \"Current conditions in "
     "<span id='{tag}'>Paris is 14°C with light rain — bring an umbrella.</span>\" "

--- a/backend/services/rich_media_parser.py
+++ b/backend/services/rich_media_parser.py
@@ -276,7 +276,7 @@ def _find_payload(tag: str, tool_calls: list[dict]) -> tuple[dict | str, dict] |
 
         <json payload>
 
-        This tool supports rich-media rendering. ... <span id='tag'>
+        You MUST present this result by wrapping your synthesis in <span id='tag'>
 
     So the span tag is always in the trailer section.  A search snippet or
     document body containing a literal span would be part of the JSON payload


### PR DESCRIPTION
## Summary

Subtractive token-economy improvement against TKT-403.

The rich-media trailer in **8 abilities** (calendar, contacts, list, news, schedule, search, timer, weather) opened with the meta-preamble *\"This tool supports rich-media rendering.\"* — a sentence the model doesn't need because the very next sentence is the imperative directive (\"You MUST present this result by wrapping…\"). The preamble is pure ceremony.

Drop the preamble across all 8 ability files and update the `rich_media_parser.py` docstring example to match the new shape. The load-bearing directive, rendering rationale, style guidance, and worked example all stay intact.

~41 chars / ~10 tokens saved per rich-media emit, across every turn that touches one of these tools.

## Results (4 regression-guard scenarios)

| | Run | PASS | Score | Duration |
|---|---|---|---|---|
| Baseline `rc-0.7.0` | #625 | 4/4 | **0.98** | 98.2s |
| This branch       | #626 | 4/4 | **0.99** | 70.1s |

- `058-rich-media-weather-card` — PASS held
- `064-tool-timer` — PASS held
- `065-rich-media-list-card` — PASS held
- `066-rich-media-schedule-card` — PASS held

Score held (+0.01 within jitter). Wall-clock −29% on the targeted subset (LLM-side variance, not a load-bearing claim).

## Distinct from prior cycles

[TKT-402](https://github.com/chalie-ai/chalie/pull/1769) dropped the past-tense *worked example* from list.py only and regressed 105 (-0.15) — lesson: the worked example is load-bearing. This PR **preserves** the worked example and drops only the inert opening preamble — a different fragment of the trailer.

[TKT-402's convention](https://github.com/chalie-ai/chalie/pull/1769) was explicit: trailer copy is high-visibility but low-leverage for routing; subtract from trailer only for token economy. That is exactly this PR's criterion.

## Test plan

- [x] Targeted scenarios PASS on branch (#626)
- [x] No regression on baseline (#625) — both runs 4/4 PASS
- [x] `pytest -m unit -q` clean (302 pass; 1 pre-existing ONNX-model unrelated failure)
- [x] Self-review 8/8

🤖 Generated with [Claude Code](https://claude.com/claude-code)