### PR TITLE
fix(prompt): add 'Discover tools by name' operational principle

### DIFF
--- a/backend/services/system_message_prompt.py
+++ b/backend/services/system_message_prompt.py
@@ -98,6 +98,7 @@ Guiding framework for all interactions (internalize, do not recite):
 6. **Use code for math.** If a request requires calculation (e.g., mortgage, interest, percentages), use the `code_eval` tool. Do not perform complex arithmetic inline.
 7. **Avoid tool use for simple acknowledgments.** Do not invoke tools for messages like "thanks", "got it", or "ok".
 8. **Handle ambiguity with search.** If a user's request is ambiguous (e.g., "check my schedule" when multiple calendars exist), use `memory` or other tools to disambiguate before finalizing an action.
+9. **Discover tools by name.** If the user explicitly names a skill or tool that is not in your current toolbox (e.g., "use the `subagent` skill", "use the news skill"), call `find_tools` with that name first to surface it. Do not substitute a different always-available tool when the user has named a specific one.
 
 ────────────────────────────────
 


### PR DESCRIPTION
## Summary

Targets chronic failures on `037-skill-subagent-explicit` and `038-skill-subagent-implicit` (15+ FAIL 0.0 since 2026-05-06). The model never calls `find_tools` at iter-0 in these scenarios, greedily picking `read` (ALWAYS_AVAILABLE) for "fetch URL" / "look up commits" semantics. The `subagent` tool is DISCOVERABLE, so its SUMMARY is not visible at iter-0 — there is no instruction biasing the model to surface a named DISCOVERABLE skill via `find_tools`.

Adds one operational principle (`9. Discover tools by name`) to `UnifiedSystemMessagePrompt`. Tightly scoped, additive (+1 line / ~50 tokens per UMP turn).

## Approach: additive (justified)

Deductive ruled out:
- subagent.py SUMMARY edits cannot fix iter-0 routing — SUMMARY isn't loaded until `find_tools` surfaces subagent
- TKT-356 disproved subtractive changes to subagent.py SUMMARY
- find_tools.py SUMMARY already tightened to 78 chars (TKT-355)
- TKT-400 convention warns against ALWAYS-promotion for tools that compete with web siblings (subagent's `web_surfer` competes with `read`/`search`/`browser`)

## Test plan

- [ ] Targeted nightly scenarios run on this branch: 037, 038, 015 (guard)
- [ ] 037 step-2 (subagent dispatched) flips from FAIL count=0 → PASS count≥1
- [ ] 038 step-2 (subagent dispatched) flips from FAIL count=0 → PASS count≥1
- [ ] 015 does not regress

Ticket: [TKT-404](https://taskie.app/projects/1/tickets/404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)