### PR TITLE
fix(subagent): flush _pending_steers on send exit to surface late returns

### DIFF
--- a/backend/services/message_processor.py
+++ b/backend/services/message_processor.py
@@ -117,6 +117,11 @@ def bind_current_processor(processor: "MessageProcessor"):
 
     Also sets/clears ``processor._turn_active`` so async subagent delivery
     threads can distinguish a live parent (mid-turn) from a finished one.
+
+    On exit, drains any leftover ``processor._pending_steers`` through Case B
+    (``_spawn_return_processor``). Closes the race where a subagent completes
+    during the parent's last ACT iteration and the envelope would otherwise
+    sit in ``_pending_steers`` with no further iteration to drain it.
     """
     token = _CURRENT_PROCESSOR.set(processor)
     processor._turn_active.set()
@@ -124,6 +129,23 @@ def bind_current_processor(processor: "MessageProcessor"):
         yield processor
     finally:
         processor._turn_active.clear()
+        pending = list(getattr(processor, '_pending_steers', []))
+        if hasattr(processor, '_pending_steers'):
+            processor._pending_steers.clear()
+        if pending:
+            try:
+                from abilities.subagent import _spawn_return_processor
+                for envelope in pending:
+                    try:
+                        _spawn_return_processor(envelope)
+                    except Exception as exc:
+                        logger.error(
+                            "bind_current_processor: failed to flush pending steer: %s", exc
+                        )
+            except Exception as exc:
+                logger.error(
+                    "bind_current_processor: could not import _spawn_return_processor: %s", exc
+                )
         _CURRENT_PROCESSOR.reset(token)
 
 

--- a/backend/tests/test_subagent_ability.py
+++ b/backend/tests/test_subagent_ability.py
@@ -349,6 +349,61 @@ class TestDeliverEnvelopeDiscriminator:
 
 
 # ---------------------------------------------------------------------------
+# AD1b. bind_current_processor flushes leftover _pending_steers on exit
+#
+# Regression for a race condition: when a subagent completes during the
+# parent's last ACT iteration, Case A appends the envelope to _pending_steers
+# (parent is still active). If the parent then produces its final response
+# without another iteration, the envelope is silently dropped — the drain
+# only runs at the top of each new iteration. Fix: bind_current_processor's
+# finally block flushes leftover steers via _spawn_return_processor (Case B).
+# ---------------------------------------------------------------------------
+
+
+class TestBindCurrentProcessorFlushesPendingSteers:
+    def test_pending_steers_flushed_via_spawn_on_context_exit(self):
+        """Leftover _pending_steers must be drained through _spawn_return_processor
+        when the bind_current_processor context exits."""
+        import threading
+        from unittest.mock import patch
+        from services.message_processor import bind_current_processor
+        from services.user_message_processor import UserMessageProcessor
+
+        envelope = "[subagent.complete(type=web_surfer)]\nLate result\n[end:subagent.complete]"
+
+        parent = UserMessageProcessor.__new__(UserMessageProcessor)
+        parent._pending_steers = []
+        parent._turn_active = threading.Event()
+
+        with patch('abilities.subagent._spawn_return_processor') as mock_spawn:
+            with bind_current_processor(parent):
+                # Subagent completes mid-turn — Case A path appends to _pending_steers
+                assert parent._turn_active.is_set()
+                parent._pending_steers.append(envelope)
+            # Parent ended turn without another ACT iteration — flush must fire
+
+        mock_spawn.assert_called_once_with(envelope)
+        assert parent._pending_steers == []
+
+    def test_no_flush_when_pending_steers_empty(self):
+        """Empty _pending_steers must not invoke _spawn_return_processor."""
+        import threading
+        from unittest.mock import patch
+        from services.message_processor import bind_current_processor
+        from services.user_message_processor import UserMessageProcessor
+
+        parent = UserMessageProcessor.__new__(UserMessageProcessor)
+        parent._pending_steers = []
+        parent._turn_active = threading.Event()
+
+        with patch('abilities.subagent._spawn_return_processor') as mock_spawn:
+            with bind_current_processor(parent):
+                pass
+
+        mock_spawn.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # AD2. _spawn_return_processor wires OutputService
 #
 # Regression: _spawn_return_processor used to call


### PR DESCRIPTION
## Summary

Closes the race where a subagent completes during the parent's last ACT iteration: envelope was appended to `_pending_steers` (Case A, parent live) but the parent produced its final response without another iteration, so the drain at the top of `getUserPrompt` never fired and the late result was silently dropped.

Visible in scenario **037-skill-subagent-explicit** step-5 — subagent dispatched and completes, but result never surfaces to user channel within the 10-minute step window.

## Fix

`bind_current_processor.finally` now drains any leftover envelopes from `_pending_steers` through Case B (`_spawn_return_processor`), guaranteeing async returns are delivered either inline within the current turn or as a fresh processor afterwards.

- `processor._turn_active.clear()` runs first, so any concurrent subagent thread now chooses Case B itself
- Uses lazy import to avoid the existing `message_processor` ↔ `abilities.subagent` import cycle
- `getattr` default tolerates `_StubProcessor` instances used in unit tests that bypass `MessageProcessor.__init__`

## Tests

Adds `TestBindCurrentProcessorFlushesPendingSteers` to `test_subagent_ability.py` with two cases:
- Pending envelope appended inside the context manager is flushed via `_spawn_return_processor` on exit
- No flush call when `_pending_steers` is empty

Verified the first test FAILS on rc-0.7.0 without the fix (proving the bug).

## Test plan

- [x] New tests pass
- [x] Full unit test suite green (modulo 3 pre-existing failures unrelated to this change — 2 ONNX model load, 1 daemon-thread leak flake)
- [ ] Targeted nightly scenarios 037 + 038 (regression guard)

Refs: TKT-405