### PR TITLE
feat: Quick Tip cards + User Guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ backend/.build_baseline.json
 backend/.simplify_baseline.json*
 backend/.simplify_test_results.xml*
 .sonar_issues_p*.json
+.worktrees/

--- a/backend/api/tips.py
+++ b/backend/api/tips.py
@@ -1,0 +1,56 @@
+"""
+Tips blueprint — Quick Tip dismiss/mute endpoints.
+"""
+
+import logging
+
+from flask import Blueprint, jsonify, request
+
+from .auth import require_session
+
+logger = logging.getLogger(__name__)
+
+tips_bp = Blueprint('tips', __name__, url_prefix='/api/tips')
+
+
+@tips_bp.route('/dismiss', methods=['POST'])
+@require_session
+def dismiss_tip():
+    """Dismiss a specific tip so it won't be shown again.
+
+    Request body::
+        {"tip_id": "weather"}
+
+    Response 204 on success.
+    """
+    try:
+        data = request.get_json(silent=True) or {}
+        tip_id = data.get('tip_id')
+        if not tip_id:
+            return jsonify({"error": "tip_id required"}), 400
+
+        from services.quick_tip_service import QuickTipService
+        svc = QuickTipService()
+        svc.dismiss_tip(tip_id)
+        return '', 204
+    except Exception as exc:
+        logger.error("[TIPS API] dismiss failed: %s", exc)
+        return jsonify({"error": "Failed to dismiss tip"}), 500
+
+
+@tips_bp.route('/mute', methods=['POST'])
+@require_session
+def mute_tips():
+    """Disable all quick tips.
+
+    Sets the quick_tips_enabled setting to false.
+    Response 204 on success.
+    """
+    try:
+        from services.quick_tip_service import QuickTipService
+        svc = QuickTipService()
+        svc.mute_tips()
+        return '', 204
+    except Exception as exc:
+        logger.error("[TIPS API] mute failed: %s", exc)
+        return jsonify({"error": "Failed to mute tips"}), 500

--- a/backend/api/websocket.py
+++ b/backend/api/websocket.py
@@ -864,6 +864,23 @@ def _handle_chat(ws, store, msg, active_request=None):
                 )
                 _buffer_event(message_evt)
                 _send_json(ws, message_evt)
+
+                # -- Quick tip check (fire-and-forget in a daemon thread) --
+                # Runs after the response is delivered to avoid blocking
+                # done_evt if chalie-web is slow or unreachable.
+                def _check_quick_tip():
+                    try:
+                        from services.quick_tip_service import QuickTipService
+                        tip = QuickTipService().maybe_show_tip()
+                        if tip:
+                            store.publish("output:events", json.dumps({
+                                "type": "quick_tip",
+                                **tip,
+                            }))
+                    except Exception as _tip_err:
+                        logger.debug("[WS] quick tip check failed: %s", _tip_err)
+                threading.Thread(target=_check_quick_tip, daemon=True, name="quick-tip").start()
+
                 message_received = True
 
                 # Clear active request when response is delivered

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -682,3 +682,16 @@ CREATE TABLE IF NOT EXISTS telemetry (
     key   TEXT PRIMARY KEY,
     value TEXT
 );
+
+-- ────────────────────────────────────────────────────────────────
+-- QUICK TIP STATE — tracks per-tip display/dismiss/retire state
+-- ────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS quick_tip_state (
+    tip_id        TEXT    NOT NULL,
+    shown_count   INTEGER NOT NULL DEFAULT 0,
+    dismissed     INTEGER NOT NULL DEFAULT 0,
+    retired       INTEGER NOT NULL DEFAULT 0,
+    last_shown_at TEXT,
+    created_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    PRIMARY KEY (tip_id)
+);

--- a/backend/services/quick_tip_service.py
+++ b/backend/services/quick_tip_service.py
@@ -1,0 +1,253 @@
+"""
+Quick Tip Service — periodic feature discovery tips for the chat interface.
+
+Fetches tip content from chalie-web's /guide/tips.json manifest, tracks
+per-tip state (shown/dismissed/retired) in the quick_tip_state table,
+and publishes eligible tips to the frontend via WebSocket drift events.
+
+Cooldown: 3h (first 2 weeks) → 24h (mature accounts).
+Max shows per tip: 2. Auto-retire when user demonstrates feature knowledge
+(≥2 successful non-ephemeral tool_calls for the tip's ability names).
+"""
+
+import json
+import logging
+import random
+from datetime import timedelta
+from typing import Optional
+
+import requests
+
+from services.database_service import get_shared_db_service
+from services.settings_service import SettingsService
+from services.time_utils import utc_now, parse_utc
+
+logger = logging.getLogger(__name__)
+
+# Default URL for the tips manifest built by chalie-web
+_DEFAULT_TIPS_URL = 'https://chalie.me/guide/tips.json'
+
+# Cooldown between tips
+_COOLDOWN_NEW = timedelta(hours=3)
+_COOLDOWN_MATURE = timedelta(hours=24)
+_MATURE_ACCOUNT_AGE = timedelta(days=14)
+
+# Max times a single tip can be shown before it's retired
+_MAX_SHOWS = 2
+
+# Min successful tool_calls to auto-retire a tip (user knows the feature)
+_MIN_TOOL_CALLS_FOR_RETIRE = 2
+
+
+class QuickTipService:
+    """Manages quick tip lifecycle: eligibility, display, dismiss, retire."""
+
+    def __init__(self, db=None, tips_url: str = None):
+        self._db = db or get_shared_db_service()
+        self._tips_url = tips_url or _DEFAULT_TIPS_URL
+
+    def maybe_show_tip(self) -> Optional[dict]:
+        """Check eligibility and return a tip dict to show, or None.
+
+        Returns dict with keys: tip_id, title, body, example, icon_svg, ability_names
+        or None if no tip should be shown.
+        """
+        # 1. Check if tips are enabled
+        if not self._tips_enabled():
+            return None
+
+        # 2. Check cooldown
+        if not self._cooldown_elapsed():
+            return None
+
+        # 3. Fetch tips manifest
+        tips = self._fetch_tips_json()
+        if not tips:
+            return None
+
+        # 4. Load all tip state from DB
+        state_map = self._load_all_tip_state()
+
+        # 5. Auto-retire tips for features the user already knows
+        self._auto_retire_known_features(tips, state_map)
+        # Reload after retirements
+        state_map = self._load_all_tip_state()
+
+        # 6. Filter to eligible tips
+        eligible = []
+        for tip in tips:
+            tip_id = tip.get('tip_id')
+            if not tip_id:
+                continue
+            state = state_map.get(tip_id, {})
+            if state.get('dismissed'):
+                continue
+            if state.get('retired'):
+                continue
+            if state.get('shown_count', 0) >= _MAX_SHOWS:
+                continue
+            eligible.append(tip)
+
+        if not eligible:
+            return None
+
+        # 7. Pick a random eligible tip
+        chosen = random.choice(eligible)
+        tip_id = chosen['tip_id']
+
+        # 8. Record the show
+        self._record_show(tip_id)
+
+        return chosen
+
+    def dismiss_tip(self, tip_id: str) -> None:
+        """Mark a tip as dismissed by the user."""
+        if not tip_id:
+            return
+        self._db.execute(
+            """INSERT INTO quick_tip_state (tip_id, dismissed)
+               VALUES (?, 1)
+               ON CONFLICT(tip_id) DO UPDATE SET dismissed = 1""",
+            (tip_id,),
+        )
+
+    def mute_tips(self) -> None:
+        """Disable all quick tips by setting the quick_tips_enabled setting."""
+        svc = SettingsService(self._db)
+        svc.set('quick_tips_enabled', 'false')
+
+    # ── Internal ──────────────────────────────────────────────────
+
+    def _tips_enabled(self) -> bool:
+        """Check the quick_tips_enabled setting. Default is true (enabled)."""
+        svc = SettingsService(self._db)
+        val = svc.get('quick_tips_enabled')
+        # Not set or any truthy value = enabled
+        if val is None or val == '':
+            return True
+        return val.lower() not in ('false', '0', 'no', 'off')
+
+    def _cooldown_elapsed(self) -> bool:
+        """Check if enough time has passed since the last tip was shown."""
+        now = utc_now()
+
+        # Determine cooldown based on account age
+        cooldown = self._get_cooldown()
+
+        # Find the most recent show across ALL tips
+        with self._db.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT MAX(last_shown_at) as last FROM quick_tip_state WHERE last_shown_at IS NOT NULL"
+            )
+            row = cursor.fetchone()
+
+        if not row or not row['last']:
+            return True  # Never shown any tip
+
+        last_shown = parse_utc(row['last'])
+        return (now - last_shown) >= cooldown
+
+    def _get_cooldown(self) -> timedelta:
+        """Return the appropriate cooldown based on account age."""
+        with self._db.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT created_at FROM master_account LIMIT 1")
+            row = cursor.fetchone()
+
+        if not row or not row['created_at']:
+            return _COOLDOWN_NEW
+
+        try:
+            created_at = parse_utc(row['created_at'])
+        except (ValueError, TypeError):
+            return _COOLDOWN_NEW
+
+        account_age = utc_now() - created_at
+        if account_age >= _MATURE_ACCOUNT_AGE:
+            return _COOLDOWN_MATURE
+        return _COOLDOWN_NEW
+
+    def _fetch_tips_json(self) -> list:
+        """Fetch the tips manifest from chalie-web. Returns list of tip dicts."""
+        try:
+            resp = requests.get(self._tips_url, timeout=5)
+            resp.raise_for_status()
+            data = resp.json()
+            # Expect {"tips": [...]} or just [...]
+            if isinstance(data, list):
+                return data
+            if isinstance(data, dict):
+                return data.get('tips', [])
+            return []
+        except Exception as e:
+            logger.warning("[QuickTip] Failed to fetch tips.json: %s", e)
+            return []
+
+    def _load_all_tip_state(self) -> dict:
+        """Load all tip states from DB. Returns {tip_id: {shown_count, dismissed, retired, last_shown_at}}."""
+        rows = self._db.fetch_all("SELECT * FROM quick_tip_state")
+        result = {}
+        for row in rows:
+            result[row['tip_id']] = {
+                'shown_count': row['shown_count'],
+                'dismissed': bool(row['dismissed']),
+                'retired': bool(row['retired']),
+                'last_shown_at': row['last_shown_at'],
+            }
+        return result
+
+    def _auto_retire_known_features(self, tips: list, state_map: dict) -> None:
+        """Auto-retire tips for features the user already demonstrates knowledge of."""
+        for tip in tips:
+            tip_id = tip.get('tip_id')
+            if not tip_id:
+                continue
+            state = state_map.get(tip_id, {})
+            if state.get('retired') or state.get('dismissed'):
+                continue
+
+            ability_names = tip.get('ability_names', [])
+            if not ability_names:
+                continue
+
+            # Check tool_calls for these abilities
+            if self._check_usage(ability_names):
+                self._retire_tip(tip_id, 'auto_usage')
+
+    def _check_usage(self, ability_names: list) -> bool:
+        """Return True if user has >= _MIN_TOOL_CALLS_FOR_RETIRE successful calls for any listed ability."""
+        if not ability_names:
+            return False
+        placeholders = ','.join('?' * len(ability_names))
+        rows = self._db.fetch_all(
+            f"""SELECT COUNT(*) as cnt FROM tool_calls
+                WHERE tool_name IN ({placeholders})
+                AND ephemeral = 0""",
+            ability_names,
+        )
+        if not rows:
+            return False
+        return rows[0].get('cnt', 0) >= _MIN_TOOL_CALLS_FOR_RETIRE
+
+    def _record_show(self, tip_id: str) -> None:
+        """Record that a tip was shown. Increments shown_count, updates last_shown_at."""
+        now_str = utc_now().strftime('%Y-%m-%dT%H:%M:%SZ')
+        self._db.execute(
+            """INSERT INTO quick_tip_state (tip_id, shown_count, last_shown_at)
+               VALUES (?, 1, ?)
+               ON CONFLICT(tip_id) DO UPDATE SET
+                   shown_count = shown_count + 1,
+                   last_shown_at = ?""",
+            (tip_id, now_str, now_str),
+        )
+
+    def _retire_tip(self, tip_id: str, reason: str = '') -> None:
+        """Mark a tip as retired."""
+        self._db.execute(
+            """INSERT INTO quick_tip_state (tip_id, retired)
+               VALUES (?, 1)
+               ON CONFLICT(tip_id) DO UPDATE SET retired = 1""",
+            (tip_id,),
+        )
+        logger.debug("[QuickTip] Retired tip %s (reason: %s)", tip_id, reason)

--- a/docs/03-WEB-INTERFACE.md
+++ b/docs/03-WEB-INTERFACE.md
@@ -91,6 +91,12 @@ Structured responses render as typed cards rather than prose. All cards share th
 - **Goal** — title, progress bar, target date, status (active/completed/abandoned), update actions
 - **Knowledge** — concept name and strength, related concepts, last accessed
 
+## Quick Tips
+
+Slide-up informational cards for feature discovery. Surface above the input dock after the assistant responds when a cooldown has elapsed (3 h for new accounts, 24 h after 2 weeks). Each card shows an icon, body text, a "Try saying" example prompt, a dismiss ✕, and a "Don't show more tips" mute button. Tips are fetched from `chalie-web /guide/tips.json` (built by Eleventy from guide doc frontmatter). State tracked in `quick_tip_state` table: max 2 shows per tip, auto-retire on ≥2 non-ephemeral `tool_calls` for the tip's ability. Dismiss sends `POST /api/tips/dismiss`, mute sends `POST /api/tips/mute` (sets `quick_tips_enabled` setting to false). WebSocket drift event type: `quick_tip`. Brain exposes a toggle in the Capabilities tab.
+
+CSS: `.tip` at z-index 190 (below `.perm-stack` at 200). Violet top-edge accent, frosted glass backdrop, 300 ms slide-up animation matching the permission card pattern.
+
 ## Rich-Media Cards
 
 Rich-media cards are tool-driven structured renders that appear inline with text bubbles in the chat surface. They follow the same Radiant conventions (near-black surface, 1 px violet/cyan accent edge, hover glow) and are the only component class that may use entrance animation.
@@ -163,6 +169,8 @@ The cognitive dashboard. Tabs expose episodic memory with decay visualization, s
 The **Personality** subtab (under Cognition) exposes five sliders — warmth, mood, expressiveness, curiosity, humor — each ranging from −2 to +2. The selected combination maps to a voice paragraph prepended to the system prompt for user-facing conversations. Background processors (memory encoding, goal pursuit, scheduled tasks) are unaffected.
 
 The **Errors** subtab (under Cognition) shows the most recent ERROR and CRITICAL log entries from `/tmp/chalie.log`, newest first, capped at 200 entries. Served by `GET /system/observability/errors` (`@require_session`). Reads only the last ~256 KB of the log file. Returns an empty list on a missing file rather than a 500.
+
+The **Capabilities** tab lists capability plugins (email, calendar, contacts) with connect/disconnect management. A Quick Tips toggle at the top controls whether feature-discovery tip cards appear in the chat interface (`quick_tips_enabled` setting via `GET/PUT /system/settings/quick_tips_enabled`).
 
 The **Policies** tab provides per-action permission control (allow / ask / deny) across three independent contexts: Chat, Subagent, and Background (subconscious). Each action has a three-state segmented toggle. Three presets are available: Careful (reads allowed, writes ask), Balanced (restore defaults), and Autonomous (all allowed). A collapsible Blocked Actions Log section shows recent policy denials. Served by `GET/PUT /api/policies`, `POST /api/policies/reset`, `GET/DELETE /api/policies/blocked`.
 

--- a/frontend/brain/app.js
+++ b/frontend/brain/app.js
@@ -325,6 +325,7 @@ document.getElementById('mainTabs').addEventListener('click', (e) => {
         loadDocuments();
     } else if (tabName === 'capabilities') {
         loadCapabilities();
+        loadQuickTipsSetting();
     } else if (tabName === 'policies') {
         loadPolicies();
     }
@@ -3104,6 +3105,43 @@ function renderCapabilities() {
         btn.addEventListener('click', () => disconnectCapability(btn.dataset.capDisconnect));
     });
 }
+
+// ── Quick Tips toggle ──────────────────────────────────────────
+async function loadQuickTipsSetting() {
+    try {
+        const res = await apiFetch('/system/settings/quick_tips_enabled');
+        if (!res.ok) return;
+        const data = await res.json();
+        const enabled = !data.value || data.value === 'true' || data.value === '';
+        const cb = document.getElementById('quickTipsCheckbox');
+        const dot = document.getElementById('quickTipsDot');
+        if (cb) cb.checked = enabled;
+        if (dot) {
+            dot.classList.toggle('cap-status-connected', enabled);
+            dot.classList.toggle('cap-status-disconnected', !enabled);
+        }
+    } catch (e) {
+        console.warn('[brain] failed to load quick tips setting:', e);
+    }
+}
+
+document.getElementById('quickTipsCheckbox')?.addEventListener('change', async (e) => {
+    const enabled = e.target.checked;
+    const dot = document.getElementById('quickTipsDot');
+    if (dot) {
+        dot.classList.toggle('cap-status-connected', enabled);
+        dot.classList.toggle('cap-status-disconnected', !enabled);
+    }
+    try {
+        await apiFetch('/system/settings/quick_tips_enabled', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ value: enabled ? 'true' : 'false' }),
+        });
+    } catch (e) {
+        console.warn('[brain] failed to save quick tips setting:', e);
+    }
+});
 
 function openCapSetup(capId) {
     document.getElementById('capSetupForm').reset();

--- a/frontend/brain/index.html
+++ b/frontend/brain/index.html
@@ -303,6 +303,22 @@
             <div class="panel-header">
                 <h2>Capabilities</h2>
             </div>
+            <!-- Quick Tips toggle -->
+            <div class="cap-card" id="quickTipsToggle" style="margin-bottom: 16px;">
+                <div class="cap-info">
+                    <div class="cap-name-row">
+                        <span class="cap-status-dot cap-status-connected" id="quickTipsDot"></span>
+                        <span class="cap-name">Quick Tips</span>
+                    </div>
+                    <div class="cap-meta">Show periodic feature discovery tips in the chat interface</div>
+                </div>
+                <div class="cap-actions">
+                    <label class="toggle-switch" title="Toggle quick tips">
+                        <input type="checkbox" id="quickTipsCheckbox">
+                        <span class="slider"></span>
+                    </label>
+                </div>
+            </div>
             <div id="capabilitiesList">
                 <div class="loading">Loading capabilities...</div>
             </div>

--- a/frontend/interface/quick_tip_card.js
+++ b/frontend/interface/quick_tip_card.js
@@ -101,7 +101,8 @@ export class QuickTipCard {
     const bodyEl = this._el.querySelector('.tip__body');
     const promptEl = this._el.querySelector('.tip__example-prompt');
 
-    // Icon — use SVG from data.icon_svg if provided, else fallback to lightbulb
+    // Icon — use SVG from data.icon_svg if provided, else fallback to lightbulb.
+    // TRUST: icon_svg originates from chalie-web guide frontmatter (first-party).
     iconEl.innerHTML = data.icon_svg || this._fallbackIcon();
     bodyEl.textContent = data.body || '';
     promptEl.textContent = data.example || '';
@@ -124,7 +125,7 @@ export class QuickTipCard {
       fetch(`${base}/api/tips/dismiss`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-
+        credentials: 'same-origin',
         body: JSON.stringify({ tip_id: tipId }),
       }).catch((e) => console.warn('[QuickTip] dismiss failed:', e));
     }

--- a/frontend/interface/style.css
+++ b/frontend/interface/style.css
@@ -4099,3 +4099,177 @@ details.block-section[open] > summary.block-section__title::before {
     0 8px 32px rgba(0, 0, 0, 0.12);
 }
 
+
+/* ==========================================================================
+   Quick Tip — slide-up informational card (feature discovery)
+   Design source: Claude Design prototype, section 10 (Tool Widgets v2)
+   ========================================================================== */
+
+.tip {
+  position: fixed;
+  left: 50%;
+  bottom: calc(var(--input-dock-height, 80px) + var(--space-md, 16px));
+  transform: translateX(-50%) translateY(20px);
+  width: min(480px, calc(100vw - 32px));
+  z-index: 190;
+  padding: 18px 20px 16px;
+  border-radius: var(--radius-md, 16px);
+  background: color-mix(in oklab, var(--bg-2, #0d0f18) 95%, transparent);
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.07));
+  border-top: 1px solid color-mix(in oklab, var(--accent-primary, #8A5CFF) 55%, transparent);
+  backdrop-filter: blur(16px) saturate(140%);
+  -webkit-backdrop-filter: blur(16px) saturate(140%);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.04) inset,
+    0 2px 8px rgba(0, 0, 0, 0.20),
+    0 8px 32px rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 300ms cubic-bezier(0.16, 1, 0.3, 1),
+              transform 300ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.tip--visible {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+  pointer-events: auto;
+}
+
+.tip--leaving {
+  opacity: 0;
+  transform: translateX(-50%) translateY(-12px);
+  pointer-events: none;
+}
+
+/* Dismiss button — top right */
+.tip__dismiss {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--text-tertiary, rgba(234, 230, 242, 0.30));
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 160ms ease;
+}
+
+.tip__dismiss:hover {
+  color: var(--text-primary, #eae6f2);
+  background: var(--bg-surface, rgba(255, 255, 255, 0.03));
+}
+
+.tip__dismiss svg {
+  width: 12px;
+  height: 12px;
+}
+
+/* Header — icon + label */
+.tip__head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.tip__icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background: color-mix(in oklab, var(--accent-primary, #8A5CFF) 14%, transparent);
+  border: 1px solid color-mix(in oklab, var(--accent-primary, #8A5CFF) 28%, transparent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #B07CFF;
+  flex-shrink: 0;
+}
+
+.tip__icon svg {
+  width: 14px;
+  height: 14px;
+}
+
+.tip__label {
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 0.62rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-tertiary, rgba(234, 230, 242, 0.30));
+}
+
+/* Body text */
+.tip__body {
+  font-size: 0.92rem;
+  color: var(--text-primary, #eae6f2);
+  line-height: 1.5;
+  margin: 0 0 12px;
+  letter-spacing: -0.005em;
+}
+
+/* "Try saying" example block */
+.tip__example {
+  padding: 10px 12px;
+  border-radius: var(--radius-sm, 8px);
+  background: color-mix(in oklab, var(--accent-primary, #8A5CFF) 8%, transparent);
+  border: 1px solid color-mix(in oklab, var(--accent-primary, #8A5CFF) 20%, transparent);
+  margin-bottom: 12px;
+}
+
+.tip__example-label {
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-tertiary, rgba(234, 230, 242, 0.30));
+  margin-bottom: 3px;
+}
+
+.tip__example-prompt {
+  font-size: 0.88rem;
+  color: #B07CFF;
+  font-style: italic;
+  letter-spacing: -0.005em;
+}
+
+.tip__example-prompt::before { content: '\201C'; }
+.tip__example-prompt::after  { content: '\201D'; }
+
+/* Footer — mute button */
+.tip__foot {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  margin-top: 4px;
+}
+
+.tip__mute {
+  background: transparent;
+  border: none;
+  padding: 4px 0;
+  font-family: var(--font-sans, 'Inter', system-ui, sans-serif);
+  font-size: 0.78rem;
+  color: var(--text-tertiary, rgba(234, 230, 242, 0.30));
+  cursor: pointer;
+  transition: color 160ms ease;
+  letter-spacing: -0.005em;
+}
+
+.tip__mute:hover {
+  color: var(--text-secondary, rgba(234, 230, 242, 0.58));
+}
+
+/* Light theme overrides */
+[data-theme="light"] .tip {
+  background: color-mix(in oklab, var(--bg-2, #f5f3f0) 95%, transparent);
+  box-shadow:
+    0 1px 0 rgba(0, 0, 0, 0.04) inset,
+    0 2px 8px rgba(0, 0, 0, 0.08),
+    0 8px 32px rgba(0, 0, 0, 0.12);
+}
+


### PR DESCRIPTION
## Summary
- **Backend**: `QuickTipService` with 3h/24h cooldown, max 2 shows per tip, auto-retire on ≥2 tool_calls. REST endpoints `POST /api/tips/dismiss` and `/mute`. Fire-and-forget websocket hook after message delivery. New `quick_tip_state` table.
- **Frontend**: `QuickTipCard` slide-up component (z-index 190, violet accent, frosted glass). Wired via `EventRouter` quick_tip event. Brain Capabilities tab toggle for `quick_tips_enabled`.
- **chalie-web** (separate commit on main): `/docs/` → `/guide/` with 15 feature pages. `tips.11ty.js` generates `/guide/tips.json` manifest from frontmatter.

## Test plan
- [ ] Send a chat message → Quick Tip card slides up above input dock
- [ ] Dismiss tip (✕ button) → card slides away, backend records dismiss
- [ ] Send another message within 3h → no tip appears (cooldown)
- [ ] "Don't show more tips" → mutes all tips, verify in Brain toggle
- [ ] Brain > Capabilities > Quick Tips toggle → disable/enable works
- [ ] Visit https://chalie.me/guide/ → guide pages render correctly
- [ ] Verify https://chalie.me/guide/tips.json → valid JSON with 12 tips

🤖 Generated with [Claude Code](https://claude.com/claude-code)