### PR TITLE
fix(imap): post-filter sender name when IMAP FROM returns 0

### DIFF
--- a/backend/capabilities/mail_capability/imap_handler.py
+++ b/backend/capabilities/mail_capability/imap_handler.py
@@ -263,11 +263,65 @@ class ImapHandler:
                 since = (utc_now() - timedelta(days=7)).strftime(_IMAP_DATE_FMT)
                 criteria.extend(["SINCE", since])
             uids = client.search(criteria)
+
+            # IMAP FROM "<name>" substring-matches the raw From: header literal, so
+            # "Alice" never matches "alice@example.com" when there is no display name.
+            # When the initial search returns nothing and the caller supplied a name
+            # (no "@"), fetch by date range only and post-filter in Python.
+            prefetched: dict | None = None
+            if not uids and sender and "@" not in sender:
+                fallback_criteria: list = []
+                if date_from:
+                    fallback_criteria.extend(["SINCE", _imap_date(date_from)])
+                else:
+                    fallback_criteria.extend(
+                        ["SINCE", (utc_now() - timedelta(days=14)).strftime(_IMAP_DATE_FMT)]
+                    )
+                if date_to:
+                    fallback_criteria.extend(["BEFORE", _imap_date(date_to)])
+                if params.get("unanswered"):
+                    fallback_criteria.append("UNANSWERED")
+                fallback_uids = client.search(fallback_criteria)
+                logger.info(
+                    "[imap_handler] search empty; name-fallback for %r: %d candidates",
+                    sender, len(fallback_uids),
+                )
+                if fallback_uids:
+                    raw_all = client.fetch(fallback_uids, [_IMAP_FETCH_HEADER])
+                    sender_lower = sender.lower()
+                    matched: list[int] = []
+                    for uid_fb, data_fb in raw_all.items():
+                        h = parse_headers(uid_fb, data_fb[_IMAP_FETCH_HEADER])
+                        from_name_l = h.get("from_name", "").lower()
+                        from_addr_l = h.get("from_addr", "").lower()
+                        local_part = from_addr_l.split("@")[0] if "@" in from_addr_l else from_addr_l
+                        sender_match = (
+                            sender_lower in from_name_l
+                            or sender_lower in from_addr_l
+                            or sender_lower in local_part
+                        )
+                        if not sender_match:
+                            continue
+                        if subject and subject.lower() not in h.get("subject", "").lower():
+                            continue
+                        if keyword and keyword.lower() not in h.get("subject", "").lower():
+                            continue
+                        matched.append(uid_fb)
+                    uids = sorted(matched)
+                    prefetched = {uid_fb: raw_all[uid_fb] for uid_fb in uids}
+                    logger.info(
+                        "[imap_handler] name-fallback matched %d/%d for sender=%r",
+                        len(uids), len(fallback_uids), sender,
+                    )
+
             limit = int(params.get("limit", 20))
             uids = uids[-limit:] if len(uids) > limit else uids
             if not uids:
                 return {"emails": [], "count": 0}
-            raw = client.fetch(uids, [_IMAP_FETCH_HEADER])
+            if prefetched is not None:
+                raw = {u: prefetched[u] for u in uids}
+            else:
+                raw = client.fetch(uids, [_IMAP_FETCH_HEADER])
             triage_filter = (params.get("triage") or "").lower()
             results = []
             for u in sorted(raw.keys(), reverse=True):

--- a/backend/tests/test_imap_handler_search_fallback.py
+++ b/backend/tests/test_imap_handler_search_fallback.py
@@ -1,0 +1,257 @@
+"""Unit tests for ImapHandler.search name-based fallback.
+
+When IMAP FROM-criteria search returns 0 UIDs and the caller supplied a bare
+display name (no "@"), the handler falls back to a date-windowed fetch and
+post-filters in Python against From-name, From-addr, and the local-part of
+the address.  These tests verify that path without a live IMAP server.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from capabilities.mail_capability.imap_handler import ImapHandler, _IMAP_FETCH_HEADER
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _header_bytes(
+    subject: str = "Hello",
+    from_addr: str = "alice@example.com",
+    date: str = "Mon, 01 Jan 2024 12:00:00 +0000",
+    message_id: str = "<uid1@mail.example.com>",
+) -> bytes:
+    """Build minimal raw From-only header bytes (no display name)."""
+    lines = [
+        f"Subject: {subject}",
+        f"From: {from_addr}",
+        f"To: bob@example.com",
+        f"Date: {date}",
+        f"Message-ID: {message_id}",
+    ]
+    return "\r\n".join(lines).encode()
+
+
+def _make_client(
+    *,
+    initial_uids: list[int],
+    fallback_uids: list[int] | None = None,
+    raw_map: dict | None = None,
+) -> MagicMock:
+    """Build a fake IMAPClient with controlled search/fetch responses.
+
+    search() returns initial_uids on the first call, then fallback_uids on the
+    second call (if provided).  fetch() always returns raw_map.
+    """
+    client = MagicMock()
+    search_responses: list[list[int]] = [initial_uids]
+    if fallback_uids is not None:
+        search_responses.append(fallback_uids)
+    client.search.side_effect = search_responses
+    client.fetch.return_value = raw_map or {}
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestSearchNameFallback:
+    """Verify the name post-filter fallback behaves correctly."""
+
+    @pytest.fixture()
+    def handler(self) -> ImapHandler:
+        return ImapHandler()
+
+    @pytest.fixture(autouse=True)
+    def _stub_triage(self):
+        """Stub classify_email so tests don't need the full ML stack."""
+        with patch(
+            "capabilities.mail_capability.email_triage.classify_email",
+            return_value="actionable",
+        ):
+            yield
+
+    # ------------------------------------------------------------------
+    # Case 1: fallback fires and returns the bare-address message
+    # ------------------------------------------------------------------
+
+    def test_bare_address_matched_via_fallback(self, handler):
+        uid = 7
+        raw = _header_bytes(from_addr="alice@example.com", subject="Budget review")
+        client = _make_client(
+            initial_uids=[],
+            fallback_uids=[uid],
+            raw_map={uid: {_IMAP_FETCH_HEADER: raw}},
+        )
+
+        result = handler.search(client, {"sender": "Alice"})
+
+        assert result["count"] == 1
+        assert result["emails"][0]["uid"] == uid
+        assert result["emails"][0]["from_addr"] == "alice@example.com"
+        # Two search calls: initial (FROM Alice) + fallback (SINCE …)
+        assert client.search.call_count == 2
+
+    # ------------------------------------------------------------------
+    # Case 2: initial criteria search returns hits → fallback NOT taken
+    # ------------------------------------------------------------------
+
+    def test_no_fallback_when_initial_returns_results(self, handler):
+        uid = 3
+        raw = _header_bytes(from_addr="Alice <alice@example.com>")
+        client = _make_client(
+            initial_uids=[uid],
+            raw_map={uid: {_IMAP_FETCH_HEADER: raw}},
+        )
+
+        result = handler.search(client, {"sender": "Alice"})
+
+        assert result["count"] == 1
+        # Only one search call — fallback was NOT triggered
+        assert client.search.call_count == 1
+
+    # ------------------------------------------------------------------
+    # Case 3: sender contains "@" → fallback NOT taken even on 0 UIDs
+    # ------------------------------------------------------------------
+
+    def test_email_address_sender_skips_fallback(self, handler):
+        client = _make_client(initial_uids=[])
+
+        result = handler.search(client, {"sender": "alice@example.com"})
+
+        assert result == {"emails": [], "count": 0}
+        # Only one search call — no fallback for address-based senders
+        assert client.search.call_count == 1
+
+    # ------------------------------------------------------------------
+    # Case 4: fallback + subject filter — only matching subject returned
+    # ------------------------------------------------------------------
+
+    def test_fallback_subject_filter_applied(self, handler):
+        uid_match = 10
+        uid_other = 11
+        raw_match = _header_bytes(from_addr="alice@example.com", subject="Budget Q1", message_id="<m1@x>")
+        raw_other = _header_bytes(from_addr="alice@example.com", subject="Unrelated topic", message_id="<m2@x>")
+        client = _make_client(
+            initial_uids=[],
+            fallback_uids=[uid_match, uid_other],
+            raw_map={
+                uid_match: {_IMAP_FETCH_HEADER: raw_match},
+                uid_other: {_IMAP_FETCH_HEADER: raw_other},
+            },
+        )
+
+        result = handler.search(client, {"sender": "Alice", "subject": "Budget"})
+
+        assert result["count"] == 1
+        assert result["emails"][0]["uid"] == uid_match
+
+    # ------------------------------------------------------------------
+    # Case 5: fallback candidate does NOT contain the sender substring
+    # ------------------------------------------------------------------
+
+    def test_fallback_filters_out_non_matching_sender(self, handler):
+        uid = 20
+        # From address has no part of "Alice" in it
+        raw = _header_bytes(from_addr="bob@example.com", subject="Hello")
+        client = _make_client(
+            initial_uids=[],
+            fallback_uids=[uid],
+            raw_map={uid: {_IMAP_FETCH_HEADER: raw}},
+        )
+
+        result = handler.search(client, {"sender": "Alice"})
+
+        assert result == {"emails": [], "count": 0}
+
+    # ------------------------------------------------------------------
+    # Supplementary: local-part match (e.g. "alice" in "alice@company.com")
+    # ------------------------------------------------------------------
+
+    def test_local_part_match(self, handler):
+        uid = 30
+        raw = _header_bytes(from_addr="alice@company.com", subject="Proposal")
+        client = _make_client(
+            initial_uids=[],
+            fallback_uids=[uid],
+            raw_map={uid: {_IMAP_FETCH_HEADER: raw}},
+        )
+
+        result = handler.search(client, {"sender": "alice"})
+
+        assert result["count"] == 1
+        assert result["emails"][0]["uid"] == uid
+
+    # ------------------------------------------------------------------
+    # Supplementary: keyword filter applied in fallback (subject match)
+    # ------------------------------------------------------------------
+
+    def test_fallback_keyword_filter_applied(self, handler):
+        uid_match = 40
+        uid_other = 41
+        raw_match = _header_bytes(from_addr="supplier@supplierco.com", subject="Invoice Q2", message_id="<m3@x>")
+        raw_other = _header_bytes(from_addr="supplier@supplierco.com", subject="Meeting notes", message_id="<m4@x>")
+        client = _make_client(
+            initial_uids=[],
+            fallback_uids=[uid_match, uid_other],
+            raw_map={
+                uid_match: {_IMAP_FETCH_HEADER: raw_match},
+                uid_other: {_IMAP_FETCH_HEADER: raw_other},
+            },
+        )
+
+        result = handler.search(client, {"sender": "SupplierCo", "keyword": "Invoice"})
+
+        assert result["count"] == 1
+        assert result["emails"][0]["uid"] == uid_match
+
+    # ------------------------------------------------------------------
+    # Supplementary: fetch is NOT called twice when fallback fires
+    # ------------------------------------------------------------------
+
+    def test_prefetched_raw_reused_no_double_fetch(self, handler):
+        uid = 50
+        raw = _header_bytes(from_addr="alice@example.com")
+        client = _make_client(
+            initial_uids=[],
+            fallback_uids=[uid],
+            raw_map={uid: {_IMAP_FETCH_HEADER: raw}},
+        )
+
+        handler.search(client, {"sender": "Alice"})
+
+        # fetch() should be called exactly once (the fallback fetch is reused)
+        assert client.fetch.call_count == 1
+
+    # ------------------------------------------------------------------
+    # Supplementary: limit clamp must apply on the prefetched path too.
+    # Without this, fallback would silently exceed the caller's limit
+    # because prefetched is built before the slice.
+    # ------------------------------------------------------------------
+
+    def test_fallback_respects_limit_clamp(self, handler):
+        # 5 alice@example.com candidates, limit=2 → only 2 returned
+        uids = [100, 101, 102, 103, 104]
+        raw_map = {
+            u: {_IMAP_FETCH_HEADER: _header_bytes(
+                from_addr="alice@example.com",
+                subject=f"msg-{u}",
+                message_id=f"<m{u}@x>",
+            )}
+            for u in uids
+        }
+        client = _make_client(
+            initial_uids=[],
+            fallback_uids=uids,
+            raw_map=raw_map,
+        )
+
+        result = handler.search(client, {"sender": "Alice", "limit": 2})
+
+        assert result["count"] == 2

--- a/backend/tests/test_imap_handler_search_fallback.py
+++ b/backend/tests/test_imap_handler_search_fallback.py
@@ -8,7 +8,7 @@ the address.  These tests verify that path without a live IMAP server.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -29,7 +29,7 @@ def _header_bytes(
     lines = [
         f"Subject: {subject}",
         f"From: {from_addr}",
-        f"To: bob@example.com",
+        "To: bob@example.com",
         f"Date: {date}",
         f"Message-ID: {message_id}",
     ]

--- a/backend/tests/test_policy_service.py
+++ b/backend/tests/test_policy_service.py
@@ -1,13 +1,11 @@
 """Unit tests for PolicyService — per-action permission control."""
 
-import json
 import sqlite3
 import pytest
 
 from services.policy_service import (
     PolicyService,
     get_defaults,
-    reset_defaults_cache,
     VALID_STATES,
     VALID_CONTEXTS,
     USAGE_CLASS_TO_CONTEXT,


### PR DESCRIPTION
## Why

Scenarios 134 (email reply) and 135 (email forward) were burning 4-5 `email.search` iterations before succeeding. The model would search by sender name (e.g. `Alice`, `SupplierCo`), IMAP would return 0 UIDs, and the model would re-issue the search with subtle variations until it gave up or guessed.

Root cause: IMAP `FROM "<name>"` substring-matches the *raw* `From:` header literal. GreenMail-injected fixtures have no display name (`From: alice@example.com`), so `FROM "Alice"` returns nothing. Production mailboxes usually have `From: Alice <alice@example.com>`, so the bug is masked there — but the model has no way to recover when the header lacks a display name.

This is the post-filter angle from earlier "next angles" recommendations after pure-IMAP retry was disproved.

## What

When `email.search` initial criteria returns 0 UIDs **and** caller supplied a bare name (no `@`), fall back to a date-windowed fetch (last 14 days by default, or honoring `date_from`/`date_to`) and post-filter in Python against `from_name`, `from_addr`, and the local-part of the address. Subject and keyword filters are applied to the same pass.

Limit clamp is preserved on the prefetched path (re-keyed after the slice).

## Evidence

Baseline #669 vs improve #672 — all 4 scenarios PASS in both:

| Metric | 134 baseline | 134 improve | 135 baseline | 135 improve |
|---|---|---|---|---|
| email calls | 4 | **3** (−25%) | 5 | **3** (−40%) |
| ACT iters | 5 | **3** (−40%) | 6 | **4** (−33%) |
| LLM calls | 6 | **4** (−33%) | 7 | **5** (−29%) |
| tokens | 37,981 | **23,867** (−37%) | 45,850 | **31,232** (−32%) |

Wall-time on improve runs is dominated by LLM inference jitter (one 303s LLM stall on 135 iter-3 alone) — pre-LLM, post-tool, and embedding stages are all normal. The fix itself eliminates redundant search round-trips.

130 (search/read, no name fallback) and 133 (send) PASS unchanged — non-name-based searches take the original path.

## Test plan
- [x] `pytest -m unit -q tests/test_imap_handler_search_fallback.py` → 9 passed
- [x] Scenarios 130, 133, 134, 135 PASS on improve branch (#672)
- [x] Email-call counts and tokens drop materially on 134/135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
