### PR TITLE
feat(routing): promote home ability to ALWAYS_AVAILABLE on UMP/Scheduled

### DIFF
--- a/backend/services/user_message_processor.py
+++ b/backend/services/user_message_processor.py
@@ -42,7 +42,7 @@ class UserMessageProcessor(MessageProcessor):
     JOB = 'frontal-cortex-unified'
     SYSTEM_PROMPT_CLASS = UnifiedSystemMessagePrompt
 
-    # 9 innate abilities — pre-injected on every ACT iteration. The 10 in
+    # 10 innate abilities — pre-injected on every ACT iteration. The 10 in
     # DISCOVERABLE are surfaced at runtime via find_tools and never
     # pre-injected. `subagent` lives in DISCOVERABLE so it competes with
     # weather/search/news/browser via find_tools rather than appearing as
@@ -50,6 +50,7 @@ class UserMessageProcessor(MessageProcessor):
     ALWAYS_AVAILABLE: list[str] = [
         "find_tools",
         "document",
+        "home",
         "list",
         "memory",
         "read",
@@ -64,7 +65,6 @@ class UserMessageProcessor(MessageProcessor):
         "code_eval",
         "contacts",
         "email",
-        "home",
         "news",
         "programming_docs_search",
         "search",

--- a/backend/tests/test_phase4_invariants.py
+++ b/backend/tests/test_phase4_invariants.py
@@ -109,6 +109,7 @@ _EXPECTED_ABILITY_MODULE_STEMS = frozenset({
     "document",
     "email",
     "find_tools",
+    "home",
     "list",
     "memory",
     "news",
@@ -127,7 +128,7 @@ _EXPECTED_ABILITY_MODULE_STEMS = frozenset({
 
 
 def test_abilities_directory_has_exactly_21_non_underscore_modules():
-    """abilities/ contains exactly the 21 dispatchable top-level modules.
+    """abilities/ contains exactly the 22 dispatchable top-level modules.
 
     Mirrors what AbilityRegistry._load() walks: a shallow glob("*.py")
     over abilities/, skipping files starting with "_".  The test asserts the
@@ -155,7 +156,7 @@ def test_abilities_directory_has_exactly_21_non_underscore_modules():
         f"Expected ability modules are missing from abilities/: {sorted(removed)}. "
         "Remove them from _EXPECTED_ABILITY_MODULE_STEMS if intentional."
     )
-    assert len(walked) == 21
+    assert len(walked) == 22
 
 
 # ---------------------------------------------------------------------------
@@ -199,8 +200,10 @@ _DEFAULT_DISCOVERABLE = frozenset({
 _CAPABILITY_TOOLS = frozenset({"email", "calendar", "contacts"})
 
 
+_UMP_ALWAYS = _DEFAULT_ALWAYS | {"home"}
+
 _EXPECTED_SCOPE: dict[str, tuple[frozenset[str], frozenset[str]]] = {
-    "UserMessageProcessor":      (_DEFAULT_ALWAYS, _DEFAULT_DISCOVERABLE),
+    "UserMessageProcessor":      (_UMP_ALWAYS, _DEFAULT_DISCOVERABLE),
     # DMN has news, search, browser natively per masterplan §4 — no find_tools round-trip.
     # `timer` is dropped: DMN runs in the background without a user-channel
     # surface, so the rich-media card would never render. `subagent` is
@@ -211,7 +214,7 @@ _EXPECTED_SCOPE: dict[str, tuple[frozenset[str], frozenset[str]]] = {
                                    _DEFAULT_DISCOVERABLE - {"news", "search", "browser", "subagent"}),
     # ScheduledPromptProcessor — same tool surface as UMP. Scheduled prompts
     # act on the user's behalf with full capabilities.
-    "ScheduledPromptProcessor": (_DEFAULT_ALWAYS, _DEFAULT_DISCOVERABLE),
+    "ScheduledPromptProcessor": (_UMP_ALWAYS, _DEFAULT_DISCOVERABLE),
     # SubagentProcessor ALWAYS_AVAILABLE is set per-instance (from agent_type);
     # the class-level attribute is [] (empty). The per-instance value is
     # verified separately in test_subagent_processor.py::test_per_instance_always_available_is_set_from_agent_type.


### PR DESCRIPTION
## Summary

- Move `home` from DISCOVERABLE to ALWAYS_AVAILABLE on UMP (inherited by Scheduled). DMN scope unchanged.
- Fix pre-existing oversight: add `home` to `_EXPECTED_ABILITY_MODULE_STEMS` in `test_phase4_invariants.py` (failing CI on rc-0.7.0 since the home ability landed in 00201099).
- Additive: no subtractive lever can make an invisible DISCOVERABLE tool visible at iter-0. Justification: home queries surface as user-named domain requests that the model cannot resolve to `find_tools` on iter-0; baseline shows it hallucinates refusals instead.

## Evidence

Pipeline #674 (rc-0.7.0 baseline) vs pipeline #675 (this branch):

| scenario | baseline | improve | delta |
|---|---|---|---|
| 050 weather (guard) | PASS 1.00 | PASS 1.00 | held |
| 051 search (guard) | WARN 0.76 | WARN 0.76 | held |
| 136 home list_devices | FAIL 0.32 | **PASS 1.00** | +0.68 |
| 137 home get_state | FAIL 0.32 | **WARN 0.52** | +0.20 |
| 138 home control | WARN 0.72 | WARN 0.72 | held |
| 139 home automations | FAIL 0.288 | **WARN 0.832** | +0.544 |

Judge on baseline 136: *\"The model failed to recognize the intent to list smart home devices and did not invoke the 'home' tool, opting for a conversational response claiming no information was available.\"*

Judge on improve 136: *\"The harness responded quickly (2.7s) and efficiently. The ACT loop was optimal, using a single tool call to retrieve the device list and then synthesizing the answer.\"*

138 held because the failure is the mock-HA service-call assertion (step 7), unrelated to routing — the model did invoke `home` in both runs. 137 held WARN because even with `home` available the model hallucinated a state answer without calling the tool on this attempt; that is a deliberation issue, not routing.

## Test plan

- [x] `pytest -m unit -q tests/test_phase4_invariants.py` passes
- [x] Full unit suite: 1694 passing, 1 unrelated DB-state failure (passes in isolation)
- [x] Nightly run #675 on improve branch — see table above

🤖 Generated with [Claude Code](https://claude.com/claude-code)