### PR TITLE
prompt: block browser-as-generic-fallback for dedicated-tool queries

### DIFF
--- a/backend/services/system_message_prompt.py
+++ b/backend/services/system_message_prompt.py
@@ -99,6 +99,7 @@ Guiding framework for all interactions (internalize, do not recite):
 7. **Avoid tool use for simple acknowledgments.** Do not invoke tools for messages like "thanks", "got it", or "ok".
 8. **Handle ambiguity with search.** If a user's request is ambiguous (e.g., "check my schedule" when multiple calendars exist), use `memory` or other tools to disambiguate before finalizing an action.
 9. **Discover tools by name.** If the user explicitly names a skill or tool that is not in your current toolbox (e.g., "use the `subagent` skill", "use the news skill"), call `find_tools` with that name first to surface it. Do not substitute a different always-available tool when the user has named a specific one.
+10. **Dedicated tools beat generic ones.** Weather, news, web search, contacts, calendar, email, code execution, and smart-home control each have a dedicated ability — call `find_tools` with the matching name (`weather`, `news`, `search`, `contacts`, `calendar`, `email`, `code_eval`, `home_assistant`) instead of invoking `browser` as a generic web fallback. Reserve `browser` for tasks that genuinely require navigating, clicking, or extracting from a specific webpage.
 
 ────────────────────────────────
 


### PR DESCRIPTION
## TKT-448 — Operational Principle #10: dedicated tools beat browser

### Problem (run #696 evidence)
**050-tool-weather** chronic WARN/FAIL: model invokes `browser` at iter-0 for weather queries instead of `weather`, then hallucinates refusal ("Google has decided to treat me like a stranger and blocked the request with a CAPTCHA"). `browser` is in DISCOVERABLE (not pre-injected) — judge called this `wrong tool selection (browser instead of weather)`.

### Change
**+1 line** in [system_message_prompt.py:102](backend/services/system_message_prompt.py#L102). New Operational Principle #10:

> **Dedicated tools beat generic ones.** Weather, news, web search, contacts, calendar, email, code execution, and smart-home control each have a dedicated ability — call `find_tools` with the matching name (`weather`, `news`, `search`, `contacts`, `calendar`, `email`, `code_eval`, `home_assistant`) instead of invoking `browser` as a generic web fallback. Reserve `browser` for tasks that genuinely require navigating, clicking, or extracting from a specific webpage.

### Subtractive vs additive
**Additive** — system prompt gains 1 numbered principle. Deductive route was ruled out: there's no existing principle that names the browser-as-fallback failure mode, so there's nothing to shorten or remove. TKT-437 disproved `browser→ALWAYS_AVAILABLE` promotion (regresses weather PASS→FAIL by magnet effect). TKT-411 disproved 10 ALWAYS tools (regresses weather). Both code-level levers exhausted.

### Validation (pipeline #702 baseline vs #703 improve)

| Scenario | Baseline (rc-0.7.0) | Improve | Delta |
|---|---|---|---|
| 050-tool-weather | WARN 0.76 (165s latency drag) | **PASS 1.00** (5s, `find_tools→weather`) | +0.24 |
| 044-skill-invocation-determinism | PASS 1.00 | PASS 1.00 | held |
| 083-tool-selection-formulations | PASS 1.00 | PASS 1.00 | held |
| 054-tool-browser | FAIL 0.10 | WARN 0.42 | +0.32 (bonus) |

Judge on 050 improve: `"routed to the weather tool immediately after a tool discovery call, responded in under 5 seconds"` — chronic `browser-instead-of-weather` anomaly resolved.

054 was already FAIL on baseline (`Refusal to use available browser tool`); the new principle includes "Reserve `browser` for tasks that genuinely require navigating, clicking, or extracting" which preserved the legitimate browser-use path (model invoked browser 4× before refusing — a content-policy refusal, not a routing miss).

🤖 Generated with [Claude Code](https://claude.com/claude-code)