### PR TITLE
feat(ump): emit contacts tool_calls row from memory auto-seed

### DIFF
--- a/backend/services/user_message_processor.py
+++ b/backend/services/user_message_processor.py
@@ -325,6 +325,15 @@ class UserMessageProcessor(MessageProcessor):
             transcript_id=self._uid,
         ).renderAndRecord()
 
+        if block and '[id:contact:' in block:
+            ToolRenderAndRecordService(
+                tool_name='contacts',
+                params={'action': 'list', 'via': 'memory_auto_seed', 'query': query},
+                result=block,
+                ephemeral=False,
+                transcript_id=self._uid,
+            ).renderAndRecord()
+
     def _emit_narration(self, text: str, iteration: int) -> None:
         """Push mid-loop narration text to the per-request SSE channel.
 


### PR DESCRIPTION
## Summary

Closes the telemetry gap for the contacts capability: when `pre_act`'s memory auto-seed surfaces `contact:*` data_graph rows into the prompt (so the LLM answers contact lookups in iter-0 with 0 ACT-loop tool calls), no `tool_calls` row was emitted to reflect that the contacts read genuinely happened. Scenarios asserting on contact telemetry couldn't see it.

Adds one durable `tool_calls` row with `tool_name='contacts'`, `params={'action':'list','via':'memory_auto_seed','query':...}` immediately after the existing `memory` audit row, guarded by `'[id:contact:' in block`. Mirrors the pattern that closed the same gap for `document` (commit 85bd1813).

## Evidence

**Baseline pipeline #728 on rc-0.7.0:**
- 025-memory-recall: **PASS**
- 132-capability-contacts-sync-lookup: **WARN** — step-7 `SELECT COUNT(*) FROM tool_calls WHERE tool_name='contacts'` returned 0, expected ≥1

**Improve pipeline #729 on this branch:**
- 025-memory-recall: **PASS** (held)
- 132-capability-contacts-sync-lookup: **PASS** — step-7 count=1

Step-6 behavior identical in both runs: iter-0, 0 ACT-loop tools, ~1.7s wall, correct answer including `+35699887766` and `maria.rossi@example.com`. The fix is pure telemetry — no behavior change beyond audit emission.

## Test plan

- [x] `pytest -m unit -q` — 1422 pass (one pre-existing `home.py` invariants failure, unrelated)
- [x] Pipeline #729 — both targeted scenarios PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
