### PR TITLE
fix(routing): surface document.view(name=…) shortcut to halve LLM iterations on document-by-name flows

### DIFF
--- a/backend/abilities/document.py
+++ b/backend/abilities/document.py
@@ -25,8 +25,8 @@ class DocumentAbility(Ability):
         "search my documents for information about coral bleaching",
         "what documents do I have uploaded",
         "show me the climate report",
+        "view the chicken tikka recipe by name",
         "create a note called project-ideas.md with my brainstorm",
-        "save this text as a document",
         "delete the old invoice document",
         "what did that report say about carbon emissions",
         "list all my documents",
@@ -49,13 +49,18 @@ class DocumentAbility(Ability):
             },
             "id": {
                 "type": "string",
-                "description": "Document ID for exact match (view, delete, restore).",
+                "description": (
+                    "Document ID for exact match (view, delete, restore). "
+                    "If you don't have an id, use `name` instead — do not call `search` first."
+                ),
             },
             "name": {
                 "type": "string",
                 "description": (
                     "Required for `create` and `upload`; use a filename like 'research-notes.md' "
-                    "if the user didn't give one. Optional fuzzy match for view/delete/restore."
+                    "if the user didn't give one. "
+                    "Preferred shortcut for view/delete/restore when you know the document name: "
+                    "pass `name` directly instead of calling `search` first to get an id."
                 ),
             },
             "content": {


### PR DESCRIPTION
## Summary

Surface the existing `name` fuzzy-match affordance on `DocumentAbility` so the model uses `document.view(name=...)` directly instead of `document.search` + `document.view`. `_resolve_document` already supports name fuzzy match for view/delete/restore — this is pure affordance surfacing in EXAMPLES + INPUT_SCHEMA.

Diff: **+8/-3 LOC** in `backend/abilities/document.py`.

## Targets

- Primary: 105 recipe-file-workflow — chronic FAIL/WARN on step-5 due to extra round-trips
- Guards: 060 doc-lifecycle, 063 PDF-upload, 092 doc-creation

## Results (baseline #736 vs improve #737)

| scenario | baseline | improve | delta |
|---|---|---|---|
| 060 doc-lifecycle (guard) | PASS | PASS | held |
| 063 PDF-upload (guard) | WARN | WARN | held (pre-existing doc.upload policy hang) |
| 092 doc-creation (guard) | PASS | PASS | held |
| **105 recipe-file-workflow** | **FAIL** (5 PASS / 6 FAIL) | **WARN** (12 PASS / 1 FAIL) | **+7 steps** |

### 105 step-5 — the chronic hang resolved

**Baseline #736 step-5 (909s timeout, FAIL):**
> 2× document calls → invokes \`code_eval\` for scaling → \`permission_request action_id=code_eval context=chat\` hangs 909s → cascades step-6/7/8/9/10 to FAIL

**Improve #737 step-5 (66s, PASS):**
> 3× document calls (view+update) + 1× list call → recipe scaled + shopping list created → no \`code_eval\`, no permission hang

The clearer affordance routes the model away from \`code_eval\` for arithmetic-on-document tasks: with \`document.view(name=...)\` surfaced as the preferred path, the model reads, scales, and rewrites within the \`document\` tool rather than reaching for code execution.

### Step-7 still FAIL (orthogonal)

105 step-7 asserts the original recipe document was deleted when the scaled version was created. Both baseline and improve fail this — separate issue, out of scope (document.delete prompting, not document.view routing).

## Convention

When an ability already supports a parameter that lets a single call replace a search→read sequence, EXAMPLES + INPUT_SCHEMA must explicitly surface the shortcut. Capability bloat without affordance surfacing leaves the model in search-first habits. Pattern: lead with the multi-purpose call in EXAMPLES, and put the routing guidance ("use \`name\` instead of calling \`search\` first") inside the \`id\` field's description so it's read at the moment of routing choice.

## Test plan

- [x] Targeted scenarios on improve branch (pipeline #737)
- [x] Guards held (060/063/092)
- [x] 105 improved FAIL→WARN
- [x] CI green (push-triggered checks passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
