### PR TITLE
fix(subagent): drop SubagentReturnProcessor + Case A — direct user-channel write

### DIFF
--- a/backend/abilities/subagent.py
+++ b/backend/abilities/subagent.py
@@ -7,8 +7,9 @@ Three types, each with its own tool surface, system prompt, and default timeout:
   general_purpose (30m): parallelise different long-running work.
 
 Default is fire-and-forget (wait=false). When the subagent finishes it steers
-the parent agent's ACT loop (Case A: parent mid-turn) or spawns a fresh
-user-channel turn via SubagentReturnProcessor (Case B: parent idle).
+the parent agent's ACT loop (Case A: parent mid-turn) or writes the extracted
+response text directly to the user-channel transcript and publishes via
+OutputService (Case B: parent idle) — no inner ACT loop.
 
 When wait=true the parent ACT iteration blocks until the subagent finishes,
 capped per-type by ``wait_cap``: web_surfer caps at 30 min (web research is
@@ -24,7 +25,9 @@ import uuid
 
 from abilities._base import Ability
 from services.innate_skills._tag import tag as _skill_tag
+from services.output_service import OutputService
 from services.rich_media_parser import strip_spans
+from services.transcript_service import write_assistant_row
 
 logger = logging.getLogger(__name__)
 LOG_PREFIX = "[SUBAGENT SKILL]"
@@ -170,9 +173,9 @@ def _deliver_envelope(envelope: str, parent_ref: object) -> None:
       getUserPrompt() drains _pending_steers into _act_trail.
 
     Case B — parent idle (turn finished, or non-UMP):
-      Spawn a daemon thread that runs SubagentReturnProcessor(envelope).send()
-      which produces a normal user-channel ACT turn and publishes via
-      OutputService.
+      Extract the response text from the envelope, write it synchronously to
+      the user-channel transcript, and publish via OutputService. No inner
+      ACT loop.
 
     The discriminator is ``parent_ref._turn_active.is_set()`` — a thread-safe
     Event that bind_current_processor sets on entry and clears on exit.
@@ -200,47 +203,72 @@ def _deliver_envelope(envelope: str, parent_ref: object) -> None:
             _spawn_return_processor(envelope)
         return
 
-    # Case B: parent idle — synthetic user-channel turn
+    # Case B: parent idle — direct write to user-channel transcript + WS publish
     _spawn_return_processor(envelope)
 
 
 def _spawn_return_processor(envelope: str) -> None:
-    """Spawn a daemon thread that runs SubagentReturnProcessor with the envelope.
+    """Extract the subagent response from the envelope and deliver it directly.
 
-    After the ACT loop completes, publishes the response to the WebSocket
-    via OutputService — the same pattern as scheduler_service.py.
+    Success envelopes: strips the header, introducer, and footer lines; delivers
+    the inner response text verbatim.
+    Failure envelopes: extracts the Reason line and emits a short user-facing
+    message — the retry/escalate hint is dropped (it was for an inner ACT loop
+    that no longer exists).
+    Falls back to a generic message if extraction yields empty text.
+
+    Writes the transcript row synchronously then publishes via OutputService.
+    No inner thread — caller is already executing inside a daemon thread (_run_async).
     """
+    def _extract(env: str) -> str:
+        lines = env.splitlines()
+        if not lines:
+            return ""
+        header = lines[0]
+        if "status=failure" in header:
+            for line in lines[1:]:
+                marker = "Reason: "
+                idx = line.find(marker)
+                if idx != -1:
+                    reason = line[idx + len(marker):].rstrip(".")
+                    return f"Subagent failed: {reason.strip()}"
+            return "Subagent failed."
+        # Success: strip header, "The subagent has completed..." line, blank, and footer
+        inner_lines = []
+        body_started = False
+        for line in lines[1:]:
+            if line.strip() == "[end:subagent.complete]":
+                break
+            if not body_started:
+                # Skip the introducer line and the blank line after it
+                if "Subagent's response:" in line:
+                    body_started = True
+                continue
+            inner_lines.append(line)
+        # Strip leading blank from body
+        while inner_lines and not inner_lines[0].strip():
+            inner_lines.pop(0)
+        return "\n".join(inner_lines).strip()
 
-    def _run():
-        from services.output_service import OutputService
+    response_text = _extract(envelope)
+    if not response_text:
+        response_text = "Subagent returned a result but produced no usable text."
 
-        try:
-            from services.user_message_processor import SubagentReturnProcessor
+    try:
+        write_assistant_row('user', response_text)
+        logger.info("%s Subagent return written to transcript", LOG_PREFIX)
+    except Exception as exc:
+        logger.error("%s Transcript write failed: %s", LOG_PREFIX, exc, exc_info=True)
 
-            response_text = SubagentReturnProcessor(raw_input=envelope).send()
-            response_text = (response_text or '').strip()
-            if not response_text:
-                response_text = "Subagent returned a result but synthesis produced no output."
-        except Exception as exc:
-            logger.error(
-                "%s SubagentReturnProcessor failed: %s", LOG_PREFIX, exc, exc_info=True
-            )
-            response_text = f"Subagent synthesis failed: {exc}"
-
-        try:
-            OutputService().enqueue_proactive(
-                topic='user',
-                response=response_text,
-                source='subagent_return',
-            )
-            logger.info("%s SubagentReturnProcessor completed and delivered", LOG_PREFIX)
-        except Exception as exc:
-            logger.error(
-                "%s SubagentReturnProcessor delivery failed: %s", LOG_PREFIX, exc, exc_info=True
-            )
-
-    t = threading.Thread(target=_run, daemon=True, name="subagent-return")
-    t.start()
+    try:
+        OutputService().enqueue_proactive(
+            topic='user',
+            response=response_text,
+            source='subagent_return',
+        )
+        logger.info("%s Subagent return delivered via OutputService", LOG_PREFIX)
+    except Exception as exc:
+        logger.error("%s OutputService delivery failed: %s", LOG_PREFIX, exc, exc_info=True)
 
 
 # ── Ability ───────────────────────────────────────────────────────────────────

--- a/backend/abilities/subagent.py
+++ b/backend/abilities/subagent.py
@@ -166,44 +166,22 @@ def _build_envelope(response_text: str, agent_type: str, status: str = "success"
 
 
 def _deliver_envelope(envelope: str, parent_ref: object) -> None:
-    """Deliver the subagent envelope to the parent agent.
+    """Deliver the subagent envelope to the user channel.
 
-    Case A — parent turn is still active (_turn_active Event is set):
-      Append the envelope to parent._pending_steers. The next iteration's
-      getUserPrompt() drains _pending_steers into _act_trail.
+    Fire-and-forget subagents (wait=false) always deliver as a separate
+    user-channel message — the parent already gave its final response after
+    dispatch (typically "Working on it, I'll notify you when done"), so there
+    is no iteration to fold the result into. Previously a "Case A" branch
+    appended the envelope to ``parent._pending_steers`` when the parent turn
+    was still active. This was racy: if the subagent finished after the parent
+    produced its final response but before ``_turn_active`` cleared, the steer
+    was stranded — nothing drained ``_pending_steers``. Always-direct-write
+    eliminates the race.
 
-    Case B — parent idle (turn finished, or non-UMP):
-      Extract the response text from the envelope, write it synchronously to
-      the user-channel transcript, and publish via OutputService. No inner
-      ACT loop.
-
-    The discriminator is ``parent_ref._turn_active.is_set()`` — a thread-safe
-    Event that bind_current_processor sets on entry and clears on exit.
-    Unlike isinstance() checks (which always return True for a valid Python
-    object), this correctly detects that the parent's send() has already
-    returned.
+    parent_ref is retained as a parameter for call-site compatibility but is
+    no longer consulted.
     """
-    from services.user_message_processor import UserMessageProcessor
-
-    if (
-        isinstance(parent_ref, UserMessageProcessor)
-        and parent_ref._turn_active.is_set()
-    ):
-        # Case A: mid-ACT injection via _pending_steers
-        try:
-            parent_ref._pending_steers.append(envelope)
-            logger.info(
-                "%s Delivered envelope to parent _pending_steers (iteration=%d)",
-                LOG_PREFIX, parent_ref._current_iteration,
-            )
-        except Exception as exc:
-            logger.error(
-                "%s Failed to append to parent _pending_steers: %s", LOG_PREFIX, exc
-            )
-            _spawn_return_processor(envelope)
-        return
-
-    # Case B: parent idle — direct write to user-channel transcript + WS publish
+    del parent_ref
     _spawn_return_processor(envelope)
 
 

--- a/backend/services/message_processor.py
+++ b/backend/services/message_processor.py
@@ -182,7 +182,7 @@ class MessageProcessor:
     # When True, send() skips write_input_row() but store() still writes
     # the assistant row.  self._uid stays None (tool calls get transcript_id
     # NULL — safe, all downstream code guards on _uid is not None).
-    # Used by SubagentReturnProcessor: the subagent envelope must never
+    # Used by ScheduledPromptProcessor: the raw scheduler prompt must never
     # appear in the user channel transcript, but the synthesized assistant
     # response must.
     SKIP_INPUT_ROW: bool = False
@@ -238,7 +238,7 @@ class MessageProcessor:
         # Thread-safe liveness flag: set while send() is on the call stack
         # (inside bind_current_processor). Async subagent delivery checks
         # this to distinguish a live parent (steer into _pending_steers)
-        # from a finished parent (spawn SubagentReturnProcessor).
+        # from a finished parent (write extracted response direct to user channel).
         self._turn_active = threading.Event()
         # Per-instance deadline (seconds from epoch) for processors that want a
         # hard wall-clock cap (e.g. SubagentProcessor). None means no deadline.
@@ -662,7 +662,7 @@ class MessageProcessor:
             # Skipped for internal processors (SKIP_TRANSCRIPT_WRITE=True) so
             # they leave no trace in the transcript table.
             # SKIP_INPUT_ROW suppresses only the input row — store() still
-            # writes the assistant row (SubagentReturnProcessor isolation).
+            # writes the assistant row (used by ScheduledPromptProcessor).
             if not self.SKIP_TRANSCRIPT_WRITE and not self.SKIP_INPUT_ROW:
                 self._uid = write_input_row(self.CHANNEL, self.ROLE, self._raw_input)
 

--- a/backend/services/user_message_processor.py
+++ b/backend/services/user_message_processor.py
@@ -528,32 +528,6 @@ class UserMessageProcessor(MessageProcessor):
         return self._mode_state_cached
 
 
-class SubagentReturnProcessor(UserMessageProcessor):
-    """Synthesize a subagent's result via a fresh user-channel ACT loop.
-
-    Flow (isolation contract):
-    1. SubagentProcessor (CHANNEL='subagent') does the work in its own
-       isolated transcript.
-    2. On completion, a daemon thread constructs this processor with the
-       subagent's result as ``raw_input`` and calls ``.send()``.
-    3. SKIP_INPUT_ROW=True — the raw subagent result is NEVER written to
-       the user transcript.  The user channel stays clean.
-    4. The ACT loop synthesizes the result.  The synthesized response is
-       written to transcript (``store()``) and delivered via WS — this is
-       what the user sees.
-    5. On subagent failure, the same flow runs — the ACT loop sees the
-       error envelope and synthesizes a user-friendly response.
-
-    Why CHANNEL='user': the output of this ACT loop is a normal
-    user-channel assistant message — fully visible, rich-media-capable.
-    Do NOT add a CHANNEL='subagent_return' constant — it would break
-    rich-media card injection for tool calls in this loop.
-    """
-
-    ROLE = 'subagent_return'
-    SKIP_INPUT_ROW = True
-
-
 class ScheduledPromptProcessor(UserMessageProcessor):
     """Scheduled prompt — UMP with hidden input and clean context window."""
 

--- a/backend/tests/test_subagent_ability.py
+++ b/backend/tests/test_subagent_ability.py
@@ -284,38 +284,40 @@ class TestHandleToolDispatchCollisionGuard:
 
 
 # ---------------------------------------------------------------------------
-# AD1. _deliver_envelope discriminator — turn_active Event
+# AD1. _deliver_envelope — always-direct delivery
 #
-# Regression for the fire-and-forget delivery bug: _deliver_envelope used to
-# check isinstance(parent_ref, UserMessageProcessor) which always returned True
-# even after the parent's turn was over (it's just a Python object reference).
-# The result was silently appended to a dead processor's _pending_steers and
-# never reached the user. Fix: check parent_ref._turn_active.is_set().
+# Regression for the stranded-steer bug: the previous "Case A" branch appended
+# the envelope to parent._pending_steers when the parent turn was still
+# active. If the subagent finished after the parent produced its final
+# response but before _turn_active cleared, the steer was never drained.
+# Fix: always route through _spawn_return_processor.
 # ---------------------------------------------------------------------------
 
 
 class TestDeliverEnvelopeDiscriminator:
-    def test_case_a_delivers_to_pending_steers_when_parent_active(self):
-        """When parent _turn_active is set, envelope goes to _pending_steers."""
+    def test_delivers_direct_when_parent_active(self):
+        """Even when parent _turn_active is set, envelope routes direct."""
         import threading
         from abilities.subagent import _deliver_envelope
         from services.user_message_processor import UserMessageProcessor
+        from unittest.mock import patch
 
         envelope = "[subagent.complete(type=web_surfer)]\nTest result\n[end:subagent.complete]"
 
-        # Build a real UMP instance (SKIP_TRANSCRIPT_WRITE avoids DB)
         parent = UserMessageProcessor.__new__(UserMessageProcessor)
         parent._pending_steers = []
         parent._turn_active = threading.Event()
         parent._turn_active.set()
         parent._current_iteration = 3
 
-        _deliver_envelope(envelope, parent)
+        with patch('abilities.subagent._spawn_return_processor') as mock_spawn:
+            _deliver_envelope(envelope, parent)
 
-        assert envelope in parent._pending_steers
+        mock_spawn.assert_called_once_with(envelope)
+        assert parent._pending_steers == []
 
-    def test_case_b_fires_when_parent_turn_finished(self):
-        """When parent _turn_active is cleared, envelope routes to Case B."""
+    def test_delivers_direct_when_parent_turn_finished(self):
+        """When parent _turn_active is cleared, envelope routes direct."""
         import threading
         from abilities.subagent import _deliver_envelope
         from services.user_message_processor import UserMessageProcessor
@@ -326,17 +328,17 @@ class TestDeliverEnvelopeDiscriminator:
         parent = UserMessageProcessor.__new__(UserMessageProcessor)
         parent._pending_steers = []
         parent._turn_active = threading.Event()
-        parent._turn_active.clear()  # turn is over
+        parent._turn_active.clear()
         parent._current_iteration = 5
 
         with patch('abilities.subagent._spawn_return_processor') as mock_spawn:
             _deliver_envelope(envelope, parent)
 
         mock_spawn.assert_called_once_with(envelope)
-        assert envelope not in parent._pending_steers
+        assert parent._pending_steers == []
 
-    def test_case_b_fires_when_parent_is_none(self):
-        """When parent_ref is None (no UMP), envelope routes to Case B."""
+    def test_delivers_direct_when_parent_is_none(self):
+        """When parent_ref is None (no UMP), envelope routes direct."""
         from abilities.subagent import _deliver_envelope
         from unittest.mock import patch
 

--- a/backend/tests/test_subagent_ability.py
+++ b/backend/tests/test_subagent_ability.py
@@ -349,134 +349,94 @@ class TestDeliverEnvelopeDiscriminator:
 
 
 # ---------------------------------------------------------------------------
-# AD2. _spawn_return_processor wires OutputService
+# AD2. _spawn_return_processor — direct envelope extraction + delivery
 #
-# Regression: _spawn_return_processor used to call
-# SubagentReturnProcessor.send() and discard the return value. The response
-# never reached the WebSocket. Fix: call OutputService.enqueue_proactive()
-# after send() — same pattern as scheduler_service.py.
+# _spawn_return_processor now extracts the inner text from the envelope
+# and delivers it via write_assistant_row + OutputService.enqueue_proactive
+# without a second ACT loop. These tests verify the extraction logic and
+# delivery calls for success, empty-body, and failure envelopes.
 # ---------------------------------------------------------------------------
 
 
 class TestSpawnReturnProcessorOutput:
-    def test_enqueue_proactive_called_with_response(self):
-        """_spawn_return_processor must call OutputService.enqueue_proactive()
-        with the response text after SubagentReturnProcessor.send() returns."""
+    def test_success_envelope_extracts_inner_text_and_delivers(self):
+        """Success envelope: inner text after 'Subagent's response:' is delivered
+        to both write_assistant_row and OutputService.enqueue_proactive."""
         from unittest.mock import patch, MagicMock
-        import threading
         from abilities.subagent import _spawn_return_processor
 
-        envelope = "[subagent.complete(type=web_surfer)]\nResult text\n[end:subagent.complete]"
+        inner = "Here is what I found from the subagent."
+        envelope = (
+            "[subagent.complete(type=web_surfer)]\n"
+            "The subagent has completed the task. Subagent's response:\n\n"
+            f"{inner}\n"
+            "[end:subagent.complete]"
+        )
 
         mock_output_svc = MagicMock()
-        mock_proc_instance = MagicMock()
-        mock_proc_instance.send.return_value = "Here is what I found from the subagent."
 
-        with patch(
-            'services.user_message_processor.SubagentReturnProcessor',
-            return_value=mock_proc_instance,
-        ), patch(
-            'services.output_service.OutputService',
-            return_value=mock_output_svc,
-        ):
+        with patch('abilities.subagent.write_assistant_row') as mock_write, \
+             patch('abilities.subagent.OutputService', return_value=mock_output_svc):
             _spawn_return_processor(envelope)
 
-            # Join inside the patch context so the thread resolves mocked imports
-            for t in threading.enumerate():
-                if t.name == "subagent-return":
-                    t.join(timeout=5)
+        mock_write.assert_called_once_with('user', inner)
+        mock_output_svc.enqueue_proactive.assert_called_once_with(
+            topic='user',
+            response=inner,
+            source='subagent_return',
+        )
 
-            mock_proc_instance.send.assert_called_once()
-            mock_output_svc.enqueue_proactive.assert_called_once_with(
-                topic='user',
-                response="Here is what I found from the subagent.",
-                source='subagent_return',
-            )
-
-    def test_enqueue_proactive_called_with_fallback_on_empty_response(self):
-        """If SubagentReturnProcessor.send() returns empty, deliver a fallback
-        message — never silently drop the result."""
+    def test_empty_body_delivers_fallback_to_both_outputs(self):
+        """Envelope with no text between introducer and footer delivers the
+        fallback message to write_assistant_row and enqueue_proactive."""
         from unittest.mock import patch, MagicMock
-        import threading
         from abilities.subagent import _spawn_return_processor
 
-        envelope = "[subagent.complete(type=web_surfer)]\n\n[end:subagent.complete]"
+        envelope = (
+            "[subagent.complete(type=web_surfer)]\n"
+            "The subagent has completed the task. Subagent's response:\n\n"
+            "[end:subagent.complete]"
+        )
 
         mock_output_svc = MagicMock()
-        mock_proc_instance = MagicMock()
-        mock_proc_instance.send.return_value = ""
 
-        # Drain leaked threads from TestAsyncDispatch before patching.
-        for t in threading.enumerate():
-            if t.name.startswith("subagent"):
-                t.join(timeout=5)
-
-        with patch(
-            'services.user_message_processor.SubagentReturnProcessor',
-            return_value=mock_proc_instance,
-        ), patch(
-            'services.output_service.OutputService',
-            return_value=mock_output_svc,
-        ):
+        with patch('abilities.subagent.write_assistant_row') as mock_write, \
+             patch('abilities.subagent.OutputService', return_value=mock_output_svc):
             _spawn_return_processor(envelope)
 
-            for t in threading.enumerate():
-                if t.name == "subagent-return":
-                    t.join(timeout=5)
+        mock_write.assert_called_once()
+        delivered = mock_write.call_args.args[1]
+        assert "no usable text" in delivered.lower()
 
-            mock_output_svc.enqueue_proactive.assert_called_once()
-            response = mock_output_svc.enqueue_proactive.call_args.kwargs['response']
-            assert "no output" in response.lower()
+        mock_output_svc.enqueue_proactive.assert_called_once()
+        response = mock_output_svc.enqueue_proactive.call_args.kwargs['response']
+        assert "no usable text" in response.lower()
 
-    def test_enqueue_proactive_called_with_error_on_send_exception(self):
-        """If SubagentReturnProcessor.send() raises, deliver the error — never
-        silently swallow it."""
+    def test_failure_envelope_delivers_reason_to_both_outputs(self):
+        """Failure envelope: extracted Reason string appears in both deliveries."""
         from unittest.mock import patch, MagicMock
-        import threading
         from abilities.subagent import _spawn_return_processor
 
-        envelope = "[subagent.complete(type=web_surfer)]\nResult\n[end:subagent.complete]"
+        reason = "Connection timed out after 3 attempts"
+        envelope = (
+            f"[subagent.complete(type=web_surfer, status=failure)]\n"
+            f"The subagent failed. Reason: {reason}.\n\n"
+            "Decide whether to retry, escalate to the user, or fall back.\n"
+            "[end:subagent.complete]"
+        )
 
         mock_output_svc = MagicMock()
-        mock_proc_instance = MagicMock()
-        mock_proc_instance.send.side_effect = RuntimeError("provider timeout")
 
-        for t in threading.enumerate():
-            if t.name.startswith("subagent"):
-                t.join(timeout=5)
-
-        with patch(
-            'services.user_message_processor.SubagentReturnProcessor',
-            return_value=mock_proc_instance,
-        ), patch(
-            'services.output_service.OutputService',
-            return_value=mock_output_svc,
-        ):
+        with patch('abilities.subagent.write_assistant_row') as mock_write, \
+             patch('abilities.subagent.OutputService', return_value=mock_output_svc):
             _spawn_return_processor(envelope)
 
-            for t in threading.enumerate():
-                if t.name == "subagent-return":
-                    t.join(timeout=5)
+        mock_write.assert_called_once()
+        delivered = mock_write.call_args.args[1]
+        assert "failed" in delivered.lower()
+        assert reason in delivered
 
-            mock_output_svc.enqueue_proactive.assert_called_once()
-            response = mock_output_svc.enqueue_proactive.call_args.kwargs['response']
-            assert "provider timeout" in response
-
-
-# ---------------------------------------------------------------------------
-# SubagentReturnProcessor isolation contract
-# ---------------------------------------------------------------------------
-
-
-class TestSubagentReturnProcessorIsolation:
-    def test_skip_input_row_is_true(self):
-        from services.user_message_processor import SubagentReturnProcessor
-        assert SubagentReturnProcessor.SKIP_INPUT_ROW is True
-
-    def test_channel_is_user(self):
-        from services.user_message_processor import SubagentReturnProcessor
-        assert SubagentReturnProcessor.CHANNEL == 'user'
-
-    def test_skip_transcript_write_is_false(self):
-        from services.user_message_processor import SubagentReturnProcessor
-        assert SubagentReturnProcessor.SKIP_TRANSCRIPT_WRITE is False
+        mock_output_svc.enqueue_proactive.assert_called_once()
+        response = mock_output_svc.enqueue_proactive.call_args.kwargs['response']
+        assert "failed" in response.lower()
+        assert reason in response


### PR DESCRIPTION
## Summary

Resolves the chronic **037-skill-subagent-explicit FAIL** that has held across **6+ prior improvement cycles** (TKT-427/430/440/440-drain/531/synthesis attempts), where the subagent fire-and-forget envelope completed on its own channel but never surfaced to the user-facing chat.

Two subtractive commits collapse the delivery path into a single, race-free direct write:

1. **3c396ba6** — `_spawn_return_processor` writes the envelope text synchronously to the user channel via `write_assistant_row('user', ...)` + `OutputService.enqueue_proactive(topic='user', ...)`. Deletes `SubagentReturnProcessor` entirely.
2. **a9ede95f** — `_deliver_envelope` drops Case A. Container log on baseline #739 showed `"Delivered envelope to parent _pending_steers (iteration=2)"` — the envelope took Case A then stranded because the parent had already produced its final response. For fire-and-forget the parent's post-dispatch reply is *always* terminal, so Case A had no upside.

Net: **−54 / +34 across 2 files** (`backend/abilities/subagent.py`, `backend/tests/test_subagent_ability.py`). Deletes the SubagentReturnProcessor class from `user_message_processor.py` and updates 3 stale comments in `message_processor.py`.

## Evidence

| Scenario | Baseline #738 (rc-0.7.0) | Improve #740 | Δ |
|---|---|---|---|
| 037-skill-subagent-explicit | FAIL 0.000 (gate fail step-5) | **PASS 0.952** | **+0.952** |
| 038-skill-subagent-implicit | PASS 0.920 | PASS 0.920 | held |

Judge on improve #740 step-5: *"The synthetic-turn/steer flow successfully surfaced the background findings back into the user-facing chat."* Quality 1.0 across steps 2–5.

## Test plan
- [x] `pytest tests/test_subagent_ability.py -q` — 15/15 pass
- [x] `pytest -m unit -q` — 2184 pass
- [x] `ruff` clean
- [x] Nightly: 037 PASS 0.952 / 038 PASS 0.920

🤖 Generated with [Claude Code](https://claude.com/claude-code)