### PR TITLE
feat(list): name-fallback on view action only

### DIFF
--- a/backend/abilities/list.py
+++ b/backend/abilities/list.py
@@ -39,6 +39,7 @@ class ListAbility(Ability):
         "check off milk on list abc12345",
         "rename list abc12345 to weekend chores",
         "delete list abc12345",
+        "view my grocery list",  # name-based lookup for view
     ]
     INPUT_SCHEMA = {
         "type": "object",
@@ -53,7 +54,7 @@ class ListAbility(Ability):
                 "description": (
                     "list_all: return all lists. "
                     "create: make a new list. "
-                    "view: read a list. "
+                    "view: read a list — pass id or name (name saves a separate list_all call). "
                     "add: append items. "
                     "check: toggle checked state per item. "
                     "remove: remove specific items. "
@@ -65,13 +66,18 @@ class ListAbility(Ability):
             "id": {
                 "type": "string",
                 "description": (
-                    "List id (8-char hex). Required for view/add/check/remove/clear/rename/delete. "
+                    "List id (8-char hex). Required for add/check/remove/clear/rename/delete. "
+                    "Optional for view — you may pass name instead. "
                     "Reuse the id returned by create or list_all."
                 ),
             },
             "name": {
                 "type": "string",
-                "description": "List name. Required for create and rename.",
+                "description": (
+                    "List name. Required for create and rename. "
+                    "For view: use name (case-insensitive fuzzy match) when you know the list's "
+                    "name but not its id — saves a separate list_all call."
+                ),
             },
             "items": {
                 "type": "array",
@@ -256,9 +262,15 @@ def _handle_create(service, params: dict) -> str:
 
 
 def _handle_view(service, params: dict) -> str:
-    list_id, err = _require_id(params)
-    if err:
-        return err
+    list_id = (params.get("id") or "").strip()
+    if not list_id:
+        name = (params.get("name") or "").strip()
+        if not name:
+            return _fail("'id' is required (or pass 'name' for view to resolve by list name).")
+        match = service._find_by_name(name)
+        if not match:
+            return _fail(f"List with name '{name}' not found.")
+        list_id = match["id"]
 
     lst_data = _list_json(service, list_id)
     if lst_data is None:

--- a/backend/tests/test_ability_list.py
+++ b/backend/tests/test_ability_list.py
@@ -132,6 +132,80 @@ class TestView:
         assert body['status'] == 'fail'
         assert 'not found' in body['message']
 
+    def test_view_by_name_happy_path(self, ability, service):
+        list_id = service.create_list("Groceries")
+        service.add_items(list_id, ["milk", "eggs"])
+
+        body = _payload(_exec(ability, {"action": "view", "name": "Groceries"}))
+        assert body['status'] == 'success'
+        assert body['list']['id'] == list_id
+        assert body['list']['name'] == 'Groceries'
+
+    def test_view_by_name_case_insensitive(self, ability, service):
+        list_id = service.create_list("Groceries")
+
+        body = _payload(_exec(ability, {"action": "view", "name": "groceries"}))
+        assert body['status'] == 'success'
+        assert body['list']['id'] == list_id
+
+    def test_view_by_name_not_found(self, ability):
+        body = _payload(_exec(ability, {"action": "view", "name": "nonexistent"}))
+        assert body['status'] == 'fail'
+        assert 'not found' in body['message']
+
+    def test_view_id_takes_precedence_over_name(self, ability, service):
+        real_id = service.create_list("RealList")
+        service.create_list("OtherList")
+
+        body = _payload(_exec(ability, {"action": "view", "id": real_id, "name": "OtherList"}))
+        assert body['status'] == 'success'
+        assert body['list']['id'] == real_id
+        assert body['list']['name'] == 'RealList'
+
+
+# ─── TKT-538 regression: id-only actions must not accept name alone ─────────
+
+class TestIdOnlyRegression:
+    """Mutation actions (add/check/remove/clear/rename/delete) remain id-only.
+
+    Passing only a name must return fail with 'id' in the message.
+    Guards against re-introducing the TKT-538 blanket name-fallback regression.
+    """
+
+    def test_add_name_only_fails(self, ability):
+        body = _payload(_exec(ability, {"action": "add", "name": "Groceries", "items": ["milk"]}))
+        assert body['status'] == 'fail'
+        assert 'id' in body['message']
+
+    def test_check_name_only_fails(self, ability):
+        body = _payload(_exec(ability, {
+            "action": "check",
+            "name": "Groceries",
+            "items": [{"content": "milk", "checked": True}],
+        }))
+        assert body['status'] == 'fail'
+        assert 'id' in body['message']
+
+    def test_remove_name_only_fails(self, ability):
+        body = _payload(_exec(ability, {"action": "remove", "name": "Groceries", "items": ["milk"]}))
+        assert body['status'] == 'fail'
+        assert 'id' in body['message']
+
+    def test_clear_name_only_fails(self, ability):
+        body = _payload(_exec(ability, {"action": "clear", "name": "Groceries"}))
+        assert body['status'] == 'fail'
+        assert 'id' in body['message']
+
+    def test_rename_name_only_fails(self, ability):
+        body = _payload(_exec(ability, {"action": "rename", "name": "Groceries"}))
+        assert body['status'] == 'fail'
+        assert 'id' in body['message']
+
+    def test_delete_name_only_fails(self, ability):
+        body = _payload(_exec(ability, {"action": "delete", "name": "Groceries"}))
+        assert body['status'] == 'fail'
+        assert 'id' in body['message']
+
 
 # ─── action: add ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Surface `ListService._find_by_name(name)` through the `list.view` action **only**. When a caller passes `name` but no `id`, resolve via case-insensitive name match (same lookup already used by create/rename collision checks). Mutation actions (`add`/`check`/`remove`/`clear`/`rename`/`delete`) remain id-only.

## Why this scope

Prior work proved that **blanket** name-fallback across all list actions regresses 036 (0.84 → 0.76) because behavior-mutating actions silently mis-target when widened. The exception was explicitly carved: **"For list.py only `view` qualifies"** for name-fallback — because `view` is the only behavior-pure read action where name collapses search→read.

Six regression-guard tests (`TestIdOnlyRegression`) prevent re-introducing the blanket pattern.

## Evidence

**Baseline #747 (rc-0.7.0)**: 036-skill-list → WARN 0.85
- step-1 (create): q=0.7, *"22.5s latency, 2 LLM calls"*
- step-3 (check): q=0.7, *"ACT loop inefficient, list tool twice in two iterations"*
- step-5 (rename): q=0.7, *"two tool calls across two iterations for single rename"*
- step-7 (delete): q=0.4, *"elapsed_ms 901288, harness stopped at permission request"* (chronic, blocked by unmerged PR #1792)
- Issues: `Extreme Latency on Delete`, `Inefficient ACT-Loop Iterations`

**Improve #748**: 036-skill-list → WARN **0.88** (+0.03)
- step-1: q=0.7, *"latency was high (10s)"* — **latency 22.5s → 10s**
- step-3: q=**1.0 PASS**, *"Efficient execution with a single tool call and fast response time"* — **WARN → PASS**
- step-5: q=0.7, *"high latency (10s) for a basic rename"* — still WARN
- step-7: q=0.4, *"902s permission request"* (unchanged — #1792 blocker)
- Issues: only `Severe Pipeline Latency` (chronic step-7). `Inefficient ACT-Loop Iterations` **CLEARED**.

## Convention

Pattern follows the established surfacing convention: wire the affordance in the handler, expose via INPUT_SCHEMA description + EXAMPLES so the model reads it at routing-choice moment. The clearer `id` description ("Optional for view — you may pass name instead") routed step-3 away from the redundant `list_all → check-by-id` pattern.

## Test plan

- [x] Unit tests pass: 48/48 in `test_ability_list.py` (10 new — 4 happy-path + 6 regression guards)
- [x] Targeted scenario 036-skill-list: 0.85 → 0.88 (step-3 WARN → PASS)
- [ ] CI: ruff / vulture / unit tests / SonarQube
- [ ] Verify no regression on full regression suite post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
