### PR TITLE
fix(client-context): restore settings.user_timezone write (TKT-540)

### DIFF
--- a/backend/services/client_context_service.py
+++ b/backend/services/client_context_service.py
@@ -207,6 +207,9 @@ class ClientContextService:
                 if "location_name" in cached_ctx:
                     ctx["location_name"] = cached_ctx["location_name"]
 
+        # Persist timezone to settings (survives restarts, enables CalDAV/scheduler)
+        if tz_name := ctx.get("timezone"):
+            self._persist_timezone(tz_name, cached_ctx.get("timezone"))
 
         # Persist the heartbeat to the telemetry table — replace-all so deleted
         # FE keys disappear from the next render.
@@ -284,6 +287,31 @@ class ClientContextService:
         except Exception as e:
             logging.debug(f"[CLIENT CONTEXT] Failed to push history: {e}")
 
+
+    def _persist_timezone(self, tz_name: str, previous_tz: str | None):
+        """Write user_timezone to settings if it changed.
+
+        Only writes on actual change to avoid unnecessary DB churn on every
+        heartbeat (sent every 5 minutes).
+        """
+        if tz_name == previous_tz:
+            return
+        try:
+            from zoneinfo import ZoneInfo
+            ZoneInfo(tz_name)  # validate IANA name
+        except Exception:
+            logging.debug(f"[CLIENT CONTEXT] Invalid timezone '{tz_name}', not persisting")
+            return
+        try:
+            from services.database_service import get_shared_db_service
+            from services.settings_service import SettingsService
+            SettingsService(get_shared_db_service()).set(
+                "user_timezone", tz_name, "string",
+                "User IANA timezone (auto-detected from client heartbeat)"
+            )
+            logging.debug(f"[CLIENT CONTEXT] Persisted user_timezone={tz_name}")
+        except Exception as e:
+            logging.debug(f"[CLIENT CONTEXT] Failed to persist timezone: {e}")
 
     # ── Demographic Trait Seeding ──────────────────────────────────────
 

--- a/backend/tests/unit/test_client_context_timezone.py
+++ b/backend/tests/unit/test_client_context_timezone.py
@@ -1,0 +1,94 @@
+"""
+Regression tests for ClientContextService._persist_timezone().
+
+Verifies that save() writes user_timezone to the settings table when the
+timezone changes, skips the write on a duplicate call, and silently ignores
+invalid IANA names — restoring the behaviour removed in commit 8088f09a.
+
+Uses the real SQLite DB via the `db` fixture (no mocks for the integration
+aspect) and a real MemoryStore via the `store` fixture (needed because
+ClientContextService.__init__ opens a MemoryClientService connection).
+"""
+
+import json
+import pytest
+
+
+def _read_timezone_setting(db):
+    """Return the stored user_timezone value, or None if absent."""
+    row = db.execute(
+        "SELECT value FROM settings WHERE key = 'user_timezone'"
+    ).fetchone()
+    return row[0] if row else None
+
+
+def _read_timezone_updated_at(db):
+    """Return the updated_at timestamp for user_timezone, or None."""
+    row = db.execute(
+        "SELECT updated_at FROM settings WHERE key = 'user_timezone'"
+    ).fetchone()
+    return row[0] if row else None
+
+
+def _seed_telemetry(db, **kwargs):
+    """Seed flat telemetry rows for the context get() call inside save()."""
+    db.execute("DELETE FROM telemetry")
+    for key, value in kwargs.items():
+        db.execute(
+            "INSERT INTO telemetry (key, value) VALUES (?, ?)",
+            (key, json.dumps(value)),
+        )
+    db.commit()
+
+
+@pytest.mark.unit
+class TestPersistTimezone:
+    """ClientContextService.save() writes timezone to settings table."""
+
+    def test_save_writes_timezone_to_settings(self, db, store):
+        """save() with a valid IANA timezone persists user_timezone to settings."""
+        _seed_telemetry(db)  # empty — no prior context
+        from services.client_context_service import ClientContextService
+        svc = ClientContextService()
+        svc.save({"timezone": "Asia/Tokyo"})
+        assert _read_timezone_setting(db) == "Asia/Tokyo"
+
+    def test_save_updates_timezone_when_changed(self, db, store):
+        """A second save() with a different timezone updates the settings row."""
+        _seed_telemetry(db)
+        from services.client_context_service import ClientContextService
+        svc = ClientContextService()
+        svc.save({"timezone": "Asia/Tokyo"})
+        assert _read_timezone_setting(db) == "Asia/Tokyo"
+
+        # Simulate the telemetry table now reflecting the first save so
+        # cached_ctx.get("timezone") returns "Asia/Tokyo" on the next call.
+        _seed_telemetry(db, timezone="Asia/Tokyo")
+
+        svc.save({"timezone": "Europe/Malta"})
+        assert _read_timezone_setting(db) == "Europe/Malta"
+
+    def test_invalid_timezone_not_written(self, db, store):
+        """An invalid IANA name must not write a row and must not raise."""
+        _seed_telemetry(db)
+        from services.client_context_service import ClientContextService
+        svc = ClientContextService()
+        svc.save({"timezone": "Not/A/Zone"})
+        assert _read_timezone_setting(db) is None
+
+    def test_same_timezone_does_not_rewrite(self, db, store):
+        """Calling save() twice with the same timezone skips the second write."""
+        _seed_telemetry(db)
+        from services.client_context_service import ClientContextService
+        svc = ClientContextService()
+        svc.save({"timezone": "Asia/Tokyo"})
+        first_updated_at = _read_timezone_updated_at(db)
+
+        # Reflect the saved timezone into telemetry so cached_ctx matches
+        _seed_telemetry(db, timezone="Asia/Tokyo")
+
+        svc.save({"timezone": "Asia/Tokyo"})
+        second_updated_at = _read_timezone_updated_at(db)
+
+        # updated_at must not have changed — no second write occurred
+        assert first_updated_at == second_updated_at


### PR DESCRIPTION
## Summary

Commit `8088f09a` (TKT-530) made `locale_service` the read chokepoint for all locale fields and deleted `ClientContextService._persist_timezone()` which used to UPSERT `settings.user_timezone` on every heartbeat. The deletion orphaned nightly scenario `004-heartbeat-timezone-honoured.yaml` step-2 — it asserts that row exists after a /health POST.

Restoring **only the write**. `locale_service` remains the sole reader — TKT-530's chokepoint intent is preserved.

## Evidence

Scenario 004 history:
- 2026-05-10/11: PASS 1.0 / 0.99 / 1.0 / 1.0
- 2026-05-17 (post-TKT-530): WARN 0.82 (step-2 deterministic count=0, judge: "lack of data is a state issue")

Net diff: +28 src LOC + new test file (4 tests).

## Test plan

- [x] Unit tests: 4/4 pass (`pytest tests/unit/test_client_context_timezone.py`)
- [x] Full unit suite: 1747 pass
- [ ] Nightly scenario 004 on this branch → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)