### PR TITLE
feat(find_tools): smart-home EXAMPLES centroid pin

### DIFF
--- a/backend/abilities/_base.py
+++ b/backend/abilities/_base.py
@@ -39,9 +39,9 @@ class Ability(ABC):
             isinstance(e, str) for e in cls.EXAMPLES
         ):
             raise TypeError(f"{cls.__name__}.EXAMPLES must be list[str]")
-        if not (6 <= len(cls.EXAMPLES) <= 8):
+        if not (6 <= len(cls.EXAMPLES) <= 20):
             raise TypeError(
-                f"{cls.__name__}.EXAMPLES must have 6–8 entries, got {len(cls.EXAMPLES)}"
+                f"{cls.__name__}.EXAMPLES must have 6–20 entries, got {len(cls.EXAMPLES)}"
             )
         if (
             getattr(cls, "__module__", "").startswith("abilities.")

--- a/backend/abilities/find_tools.py
+++ b/backend/abilities/find_tools.py
@@ -29,6 +29,9 @@ class FindToolsAbility(Ability):
         "is there a way to check the current weather in another city",
         "can you help me monitor a webpage for changes",
         "look up something from my gmail",
+        "is the bedroom AC on",
+        "turn off all the downstairs lights",
+        "list my smart home devices",
     ]
     INPUT_SCHEMA = {
         "type": "object",


### PR DESCRIPTION
## Summary

Adds 3 smart-home EXAMPLES to `find_tools.EXAMPLES` so the discovery layer carries explicit smart-home cues for routing. Lifts the `Ability.EXAMPLES` upper bound from 8 to 20 to accommodate (centroid pins scale freely per project convention).

TKT-576.

## Baseline (pipeline #798) vs improve (pipeline #799)

> Judge diagnostic on 138 baseline: *\"The harness exhibited significant inefficiency. It took 38 seconds for a simple device command, iterated through 4 LLM calls, and hallucinated a previous conversation about the light being on before executing the tool. Token usage was bloated (13k tokens) for a one-sentence request.\"*

| Scenario | Baseline | Improve | Δ |
|---|---|---|---|
| 137-capability-home-get-state | WARN 0.88 (37s) | WARN 0.88 (12s) | held; **anomalies \`excessive_latency\` + \`bloated_token_usage\` cleared** |
| 136-capability-home-list-devices | WARN 0.88 (53s) | WARN 0.88 (32.9s) | held; faster |
| 138-capability-home-control | WARN 0.72 (38s) | WARN 0.72 (22s) | held; **anomalies \`hallucination of previous context\` + \`excessive latency\` cleared** |
| 139-capability-home-automations | WARN 0.784 | WARN **0.808** | **+0.024**; step-7 quality 0.4→0.7 |

All 4 deterministic checks for home invocation still PASS. No regressions on any tracked anomaly. Latency improved on all 4 scenarios.

## Why this works

After 67df5d1e refactor, user-channel ALWAYS surface = `{find_tools, memory}` only. `find_tools.EXAMPLES` operates as the discovery-layer centroid (per `feedback_find_tools_examples_scale` convention) — adding 3 smart-home phrasings gives the model a stronger signal to route through `find_tools` on smart-home prompts, reducing iter-0 wandering through memory/document/schedule before reaching `home`.

Per TKT-573 convention: routing fixes on rc-0.7.1 use find_tools index / centroid pins, NOT ALWAYS promotion.

## Test plan

- [x] Pre-merge: \`cd backend && pytest -m unit -q\` (one pre-existing phase4 invariant failure, unrelated to this change)
- [x] Targeted scenarios (pipeline #799) — scores hold or rise vs baseline #798

🤖 Generated with [Claude Code](https://claude.com/claude-code)