### PR TITLE
improve(rich-media): trim image instruction, drop "(optional)" framing

### DIFF
--- a/backend/abilities/news.py
+++ b/backend/abilities/news.py
@@ -25,15 +25,11 @@ _RICH_MEDIA_INSTRUCTION = (
     "for the user. Example: \"Here's the latest — "
     "<span id='{tag}'>The EU opened its first audits under the AI Act today, "
     "targeting three major companies you've been tracking.</span>\""
-    "\n\nThumbnail (optional): if the data above includes an `image_candidates` "
-    "array, each entry has a `url`, `source_title` (the article it came from), "
-    "and `caption` (a short description derived from the image filename or "
-    "article metadata). Pick the candidate whose `caption` and `source_title` "
-    "together best match the topic of your synthesis. If no candidate is a "
-    "clear match, omit `data-image`. To attach a thumbnail, add "
-    "`data-image='<that url>'` to the span, e.g. "
-    "<span id='{tag}' data-image='https://example.com/pic.jpg'>your synthesis</span>. "
-    "Use a URL verbatim from `image_candidates`."
+    "\n\nIf the payload includes `image_candidates`, pick the entry whose "
+    "`caption` and `source_title` best fit your synthesis and add "
+    "`data-image='<that url>'` to the span. This is the only way to render "
+    "an inline image — raw <img> tags will not display. Use a URL verbatim "
+    "from `image_candidates`."
 )
 
 

--- a/backend/abilities/search.py
+++ b/backend/abilities/search.py
@@ -33,15 +33,11 @@ _RICH_MEDIA_INSTRUCTION = (
     "<span id='{tag}'>The Rust Foundation has cycled through three executive "
     "directors in four years, each departure hinging on the same question of "
     "how much a non-profit steward should do.</span>\""
-    "\n\nThumbnail (optional): if the data above includes an `image_candidates` "
-    "array, each entry has `url`, `source_title` (the result it came from), "
-    "and `caption` (a short description derived from the image filename or "
-    "article metadata). Pick the candidate whose `caption` and `source_title` "
-    "together best match the topic of your synthesis. If no candidate is a "
-    "clear match, omit `data-image`. To attach a thumbnail, add "
-    "`data-image='<that url>'` to the span, e.g. "
-    "<span id='{tag}' data-image='https://example.com/pic.jpg'>your synthesis</span>. "
-    "Use a URL verbatim from `image_candidates`."
+    "\n\nIf the payload includes `image_candidates`, pick the entry whose "
+    "`caption` and `source_title` best fit your synthesis and add "
+    "`data-image='<that url>'` to the span. This is the only way to render "
+    "an inline image — raw <img> tags will not display. Use a URL verbatim "
+    "from `image_candidates`."
 )
 
 


### PR DESCRIPTION
## Summary

Subtractive cleanup of `_RICH_MEDIA_INSTRUCTION` in `backend/abilities/news.py` and `backend/abilities/search.py`. Net **−8 LOC**.

The previous instruction framed `data-image` as **"Thumbnail (optional)"**, duplicated the payload schema in prose, and ended with the escape clause *"if no candidate is a clear match, omit `data-image`"* — three signals teaching the model to treat the image as decoration.

Replaced with a tight 5-line directive that keeps the load-bearing constraints:
- pick the entry whose caption + source_title best fit the synthesis
- add `data-image='<url>'` to the span
- raw `<img>` tags will not display
- use a URL verbatim from `image_candidates`

## Evidence

Baseline (#800 / rc-0.7.1) vs improve (#801):

| Scenario | Baseline | Improve | Δ |
|---|---|---|---|
| 052-tool-search-image | PASS 0.96 | PASS 0.96 | held (guard) |
| 054-tool-news-image | **FAIL 0.347** | **WARN 0.68** | **+0.333** |

054 step-3 (`assistant transcript carries a data-image attribute`): deterministic 0/1 → **1/1 PASS**. Judge quote: *"The model successfully selected an image and the rich_media_parser correctly emitted the data-image attribute in the final transcript."*

054 step-1 anomalies before: `redundant tool calls`, `excessive latency`. After: anomaly list empty (composite 0.16 → 0.76).

054 step-2 (image_candidates persistence) remains deterministic FAIL — orthogonal tool-side issue, not addressed by this PR.

## Test plan
- [x] `pytest -m unit -q` on rich_media_parser + image_candidate_service (21 passed)
- [x] Nightly scenario 052 (guard): PASS 0.96 held
- [x] Nightly scenario 054 (target): FAIL 0.347 → WARN 0.68, step-3 PASS, redundant-tool anomaly gone
- [ ] Full nightly post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)