### PR TITLE
fix(find_tools): drop schema enrichment leaking tool names to LLM

### DIFF
--- a/backend/services/message_processor.py
+++ b/backend/services/message_processor.py
@@ -383,14 +383,11 @@ class MessageProcessor:
             for tool_name in self.ALWAYS_AVAILABLE:
                 try:
                     ability = AbilityRegistry.get(tool_name)
-                    schema = {
+                    native.append({
                         'name': ability.NAME,
                         'description': ability.SUMMARY,
                         'input_schema': ability.INPUT_SCHEMA,
-                    }
-                    if ability.NAME == 'find_tools' and self.DISCOVERABLE:
-                        schema = self._enrich_find_tools_schema(schema)
-                    native.append(schema)
+                    })
                 except KeyError:
                     logger.warning(
                         "[MessageProcessor.get_tools] No ability registered for '%s'",
@@ -408,32 +405,6 @@ class MessageProcessor:
                 result.append(schema)
 
         return result
-
-    def _enrich_find_tools_schema(self, schema: dict) -> dict:
-        """Inject a discoverable-tools index into find_tools' query description."""
-        from abilities._registry import AbilityRegistry
-        import copy
-
-        index = {}
-        for name in self.DISCOVERABLE:
-            if name in self._BLOCKED:
-                continue
-            try:
-                ability = AbilityRegistry.get(name)
-                tooltip = getattr(ability, 'SEARCH_TOOLTIP', '') or ability.SUMMARY
-                index[name] = tooltip
-            except KeyError:
-                pass
-
-        if not index:
-            return schema
-
-        schema = copy.deepcopy(schema)
-        tools_index = ", ".join(f"`{k}` ({v})" for k, v in index.items())
-        schema['input_schema']['properties']['query']['description'] = (
-            f"Specify the tool name you need. Tools index: {tools_index}"
-        )
-        return schema
 
     def get_act_loop_trail(self) -> str:
         """Return the ACT loop trail as a single string for prompt injection.


### PR DESCRIPTION
## Summary

`_enrich_find_tools_schema` (introduced in 67df5d1e) mutated `find_tools.query.description` to embed the DISCOVERABLE tool index — e.g. \`\`browser\`\` (browse the web), \`\`search\`\` (live web lookup), \`\`weather\`\` (forecasts) ...

Ollama does not enforce a tool whitelist, so the model emitted those tool names directly and skipped \`find_tools\` entirely. The whole discovery tier was bypassed.

## Evidence

Scenario 041 regression PASS 1.0 → WARN 0.68 traced to 67df5d1e. Baseline pipeline #802 transcript shows \`search\` invoked at iter=0 (no \`find_tools\` call). Judge anomaly: \`find_tools skill not invoked\`.

## Targeted scenario results (baseline #802 vs improve #803)

| Scenario | Baseline | Improve | Δ |
|----------|----------|---------|---|
| 041-skill-find-tools | WARN 0.68 | **PASS** | **+0.32** |
| 050-tool-weather | WARN 0.76 | WARN 0.76 | held |
| 051-tool-search | WARN 0.88 | WARN 0.88 | held |
| **Pipeline score** | **0.7733** | **0.84** | **+0.067** |

Improve transcript #803 step-3 for 041: \`find_tools\` count=1 within 5min window (was 0 in baseline). Full chain on 041: find_tools → search + news → synthesised answer. The intended discovery path is restored.

## Test plan
- [x] Self-review 8/8 pass
- [x] Unit tests pass (727 passed, 1 pre-existing TKT-573 drift failure)
- [x] CI green on push
- [x] Targeted pipeline #803 shows 041 PASS and 050/051 held
- [ ] Manual: confirm \`find_tools.query.description\` is \`"Describe what you need."\` (clean) post-merge

Pure subtraction, -29/+2 LOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)