### PR TITLE
fix(code_eval): emit hint when user code has no print()

### DIFF
--- a/backend/abilities/code_eval.py
+++ b/backend/abilities/code_eval.py
@@ -80,12 +80,12 @@ class CodeEvalAbility(Ability):
         code = (params.get("code") or "").strip()
 
         if not code:
-            return {"error": "No code provided", "text": ""}
+            return {"text": "No code provided"}
 
         try:
             byte_code = compile_restricted(code, filename="<scratchpad>", mode="exec")
         except SyntaxError as exc:
-            return {"text": "", "error": f"Syntax error: {exc}"}
+            return {"text": f"Syntax error: {exc}"}
 
         # Fresh globals copy per call so state never leaks between executions.
         exec_globals = dict(self._RESTRICTED_GLOBALS)
@@ -98,8 +98,8 @@ class CodeEvalAbility(Ability):
             captured = collector() if collector is not None else ""
             error_msg = f"{type(exc).__name__}: {exc}"
             text = f"{captured}{error_msg}".strip() if captured else error_msg
-            return {"text": text, "error": error_msg}
+            return {"text": text}
 
         collector = exec_locals.get("_print")
         captured = collector() if collector is not None else ""
-        return {"text": captured, "error": ""}
+        return {"text": captured or "(no output — wrap your result in print() to emit it)"}

--- a/backend/tests/unit/test_code_eval_ability.py
+++ b/backend/tests/unit/test_code_eval_ability.py
@@ -1,0 +1,31 @@
+import pytest
+
+from abilities.code_eval import CodeEvalAbility
+
+
+def _run(code: str) -> dict:
+    return CodeEvalAbility().execute(channel="user", params={"code": code}, telemetry=None)
+
+
+@pytest.mark.unit
+class TestCodeEvalAbility:
+    def test_print_output_returned(self):
+        result = _run("print(2+2)")
+        assert "4" in result["text"]
+
+    def test_no_print_returns_hint(self):
+        result = _run("x = 42")
+        assert result["text"] == "(no output — wrap your result in print() to emit it)"
+
+    def test_syntax_error_message(self):
+        result = _run("def broken(")
+        assert "Syntax error" in result["text"]
+
+    def test_runtime_error_message(self):
+        result = _run("print('partial')\n1/0")
+        assert "ZeroDivisionError" in result["text"]
+        assert "partial" in result["text"]
+
+    def test_empty_code_returns_no_code_message(self):
+        result = _run("")
+        assert result["text"] == "No code provided"


### PR DESCRIPTION
## Why

Nightly scenario `052-tool-code-eval` regressed to WARN 0.82 in pipeline #789 with a 26-iteration `code_eval` ACT-loop (177s wall, 177k tokens) and a gibberish final message ("Got it, Kelly. Already had it locked in from earlier."). Judge diagnostic:

> The harness exhibited severe inefficiency, entering a massive ACT-loop with 26 iterations of the code_eval tool for a single mathematical calculation.

## Root cause

When user-supplied Python compiles + executes successfully but contains no `print()` call, `captured` is `""`. `code_eval.execute()` returned `{"text": "", "error": ""}`. `ActDispatcherService._build_success_result` (`act_dispatcher_service.py:400-403`) unwraps `text` to a bare empty string and discards every other key. The LLM sees a silent successful tool call producing no output, treats it as a no-op, and retries.

## Fix

`backend/abilities/code_eval.py` (+2/−3 LOC):
- Replace empty `captured` with `"(no output — wrap your result in print() to emit it)"` — gives the LLM an actionable signal.
- Drop the dead `error` key from every return dict — the dispatcher discards it.

`backend/tests/unit/test_code_eval_ability.py` (NEW, 5 tests): print output, no-print hint, syntax error, runtime error with partial captured output, empty code.

## Validation

| Scenario | Baseline #806 | Improve #807 | Δ |
|---|---|---|---|
| **052-tool-code-eval** | PASS 0.94 q=0.7 **27.5s** | PASS 0.94 q=0.7 **20.8s** | held; **−24% latency** |
| 050-tool-weather (variance) | WARN 0.88 q=0.7 | WARN 0.76 q=0.4 | within 0.24–1.00 band (#803 was 0.76); judge anomalies `context hallucination`+`synthesis latency` unrelated to code_eval |
| 051-tool-search (variance anchor) | WARN 0.76 | WARN 0.76 | held |

### Behavioral evidence — failure-mode collapsed

Both improve #807 and baseline #789 show the same Ollama `call_id` reuse pattern (`ollama_code_eval_0` repeated at 0ms execution). Without the hint (baseline #789): 26-iter spiral, 147s, gibberish final. With the hint (improve #807): recovers in **2 iterations**, 13s, correct answer `$2,212.24`. The model reads the hint, adds `print()`, gets the answer.

## Prior cycle context

TKT-447 (2026-05-16, rc-0.7.0) proposed the same fix but was CANCELLED untested due to harness instability — memory explicitly said "STILL UNTESTED — re-attempt in next cycle when harness is healthy". This PR is that re-attempt; the harness ran cleanly on rc-0.7.1.

## Test plan

- [x] `pytest -m unit -q backend/tests/unit/test_code_eval_ability.py` — 5/5 pass
- [x] `pytest -m unit -q` — 727 pass (1 pre-existing phase4 invariant fail, base-branch parity)
- [x] Baseline + improve targeted scenario runs (#806, #807) compared
- [ ] CI lint + unit + CodeQL + SonarCloud — to be verified after PR open

🤖 Generated with [Claude Code](https://claude.com/claude-code)