### PR TITLE
refactor(prompt): length-match synthesis instruction, drop comprehensive-synthesis directive

### DIFF
--- a/backend/services/system_message_prompt.py
+++ b/backend/services/system_message_prompt.py
@@ -112,9 +112,7 @@ Good: "Checked your TV and movie services — nothing matches your preferences. 
 Bad: "Running weather check."
 Bad: "<p>Checked your TV and movie services.</p>"
 
-When all tool calls are complete, your final response must be a comprehensive factual synthesis of everything found. Include key data points, numbers, names, dates, and findings from all tool results.
-
-Example: "Web searches showed Midea founded 1968 by He Xiangjian in Shunde, born 1942, revenue $50B in 2023, ~190K employees."
+When all tool calls are complete, respond with what you found. Match the response to the request: brief acknowledgment for simple commands ("Done", "Turned on the light"); full data points (numbers, names, dates) for research-style queries.
 
 ────────────────────────────────
 


### PR DESCRIPTION
## Summary

Trim the synthesis instruction in `UnifiedSystemMessagePrompt._SYSTEM_PROMPT` to length-match the response to the request. Removes the unconditional *comprehensive factual synthesis* directive + Midea example that was inflating responses to simple commands.

**Before:**
> When all tool calls are complete, your final response must be a comprehensive factual synthesis of everything found. Include key data points, numbers, names, dates, and findings from all tool results.
>
> Example: "Web searches showed Midea founded 1968 by He Xiangjian in Shunde, born 1942, revenue \$50B in 2023, ~190K employees."

**After:**
> When all tool calls are complete, respond with what you found. Match the response to the request: brief acknowledgment for simple commands ("Done", "Turned on the light"); full data points (numbers, names, dates) for research-style queries.

Net **−2 LOC**. Deductive / subtractive.

## Evidence

Baseline pipeline #808 (rc-0.7.1) vs improve #809:

| Scenario | Verdict | Tokens | Wall time | Response |
|---|---|---|---|---|
| 050 weather | PASS → PASS | 4374 → **4128** (−5.6%) | 4.27s → **3.97s** | held |
| 053 news | WARN → WARN | 18243 → **7451** (**−59%**) | 13.62s → 10.60s | held content, 4 LLM calls → 2 |
| 138 home control | WARN → WARN | 14438 → **13516** | **18.55s → 7.61s** (**−59%**) | hallucinated 2-paragraph → "Done." |

Pipeline duration 68.0s → 40.9s (−40%). Score 0.867 → 0.867 (held). Anomalies *Excessive synthesis latency*, *Token bloat for one-line response*, and *Hallucinated past exchange / prior state* all cleared on 138 and 053. The remaining 138 WARN is a step-7 deterministic harness bug (`json_path: "0.service"` returns None even though mock HA receives the correct `[{"service": "turn_on", ...}]` payload) — unaffected by this change.

Judge anomaly on 138 baseline: *"Inefficient ACT-Loop Iterations"* — 4 iterations, 18.5s for "Turn on my living room light". Improve cuts to 7.6s with "Done." reply.

## Test plan

- [x] Baseline #808 rc-0.7.1: 050 PASS, 053 WARN, 138 WARN — score 0.867
- [x] Improve #809: 050 PASS, 053 WARN, 138 WARN — score 0.867, tokens & latency dropped sharply
- [x] No tests assert the removed strings (\"comprehensive factual\" / \"Midea\" — grep clean)
- [x] `python -m py_compile services/system_message_prompt.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)