### PR TITLE
improve(weather): drop multiplicity invitation in rich-media trailer

### DIFF
--- a/backend/abilities/weather.py
+++ b/backend/abilities/weather.py
@@ -121,8 +121,7 @@ _RICH_MEDIA_INSTRUCTION = (
     "You MUST present this result by wrapping your synthesis in <span id='{tag}'>your synthesis here</span>. "
     "The span will render as a weather card; without it, the user sees only "
     "plain text. Example output: \"Current conditions in "
-    "<span id='{tag}'>Paris is 14°C with light rain — bring an umbrella.</span>\" "
-    "You may include multiple weather spans (one per location) and prose between them."
+    "<span id='{tag}'>Paris is 14°C with light rain — bring an umbrella.</span>\""
 )
 
 


### PR DESCRIPTION
## Summary

Drop one sentence from `backend/abilities/weather.py:120-126` `_RICH_MEDIA_INSTRUCTION`:

```diff
-    "<span id='{tag}'>Paris is 14°C with light rain — bring an umbrella.</span>\" "
-    "You may include multiple weather spans (one per location) and prose between them."
+    "<span id='{tag}'>Paris is 14°C with light rain — bring an umbrella.</span>\""
```

Net **−1 LOC** (deductive). MUST directive, failure mode (\"without it, the user sees only plain text\"), and the Paris synthesis example all preserved.

## Targeted evidence (083-tool-selection-formulations.yaml, pipeline #790, 2026-05-21)

Chronic **WARN 0.82** with judge anomaly:
> \"The harness exhibited significant inefficiency in the ACT loop, invoking the weather tool twice (iter 1 and iter 2) for a single location request.\"
> \"The model invoked the weather tool twice for the same request, suggesting a failure to recognize the first call was sufficient.\"

## Results — baseline #816 vs improve #817

| Scenario | Baseline | Improve | Delta |
|----------|----------|---------|-------|
| **083-tool-selection-formulations** (target) | WARN, 3 iters, 4 tools, 7.4k tok, 4.7s | **PASS, 2 iters, 1 tool (weather only), 4.7k tok, 2.5s** | **WARN→PASS, iter-0 fan-out eliminated** |
| 050-tool-weather (guard) | WARN, step-3 FAIL count=3, 4 iters, 5 tools, 14.5k tok, 8.3s | **PASS, all steps, 2 iters, 1 tool, 4.2k tok, 3.6s** | **WARN→PASS, −71% tokens** |
| 058-rich-media-weather-card (guard) | PASS, 3 iters, 61s | PASS, 3 iters, 33.5s | held, **−45% latency** |

## Mechanism

Tool-output behaviour-text trim, same class as TKT-577 (search.py/news.py rich-media). The dropped sentence is permissive language with no behavioural constraint the MUST directive doesn't already cover. Removing it cleans the iter-1 tool result and lets the model converge on a single weather call.

## Test plan

- [x] `ruff check` clean
- [x] Baseline #816 vs improve #817 on rc-0.7.1: all 3 weather scenarios improved or held
- [x] Span emission verified — 050/058/083 all emit `<span id=\"weather_1\">…</span>` correctly
- [x] No collateral edits; only `backend/abilities/weather.py` touched
- [x] No test refs to the dropped string anywhere in the repo

Refs: TKT-593

🤖 Generated with [Claude Code](https://claude.com/claude-code)