### PR TITLE
refactor(memory): drop multiplicity invitation from query.description

### DIFF
--- a/backend/abilities/memory.py
+++ b/backend/abilities/memory.py
@@ -90,12 +90,7 @@ class MemoryAbility(Ability):
             },
             "query": {
                 "type": "string",
-                "description": (
-                    "For recall/reflect: what to search for. One topic per "
-                    "call — to fetch memories about different topics, call "
-                    "this tool once for each topic. If results are broad or "
-                    "sparse, try searching again with more narrow queries."
-                ),
+                "description": "For recall/reflect: what to search for.",
             },
             "location": {
                 "type": "string",


### PR DESCRIPTION
## Opportunity (TKT-594)

Subtractive trim of `backend/abilities/memory.py:91-99` — drop multiplicity invitation in the `query` parameter description.

**Before** (6 lines)
```python
\"description\": (
    \"For recall/reflect: what to search for. One topic per \"
    \"call — to fetch memories about different topics, call \"
    \"this tool once for each topic. If results are broad or \"
    \"sparse, try searching again with more narrow queries.\"
),
```

**After** (1 line)
```python
\"description\": \"For recall/reflect: what to search for.\",
```

## Mechanism (TKT-593 convention, 2026-05-22)

Tool-output multiplicity invitations (\"call this tool once for each topic\", \"may include multiple X per Y\") contaminate ACT-loop discipline — models fan out single queries into N parallel calls. TKT-593 proved this on weather (\"Berlin Germany\" fired twice). This trim applies the same convention to memory.

## Evidence — pipeline #818 (baseline rc-0.7.1) vs #819 (improve)

### Primary target — 145-geo-pattern-learning-insight

| Metric | Baseline #818 | Improve #819 | Δ |
|---|---|---|---|
| Status | WARN | WARN | — |
| Iterations | 4 | **3** | −1 |
| Tool calls (total) | 9 | **3** | **−67%** |
| Memory calls | 2 | **0** | eliminated |
| Hallucinated iter-0 (document, schedule) | 4 | **0** | eliminated |
| Tokens | 20289 | **11587** | **−43%** |
| Latency | 21351 ms | **5318 ms** | **−75%** |
| Response quality | calendar synthesis correct | calendar synthesis correct | held |

Iter 0 transcript:
- Baseline: \`memory, document, schedule\` in parallel + \`find_tools\` (4 tools)
- Improve: \`find_tools\` only (1 tool)

### Guard — 138-capability-home-control

| Metric | Baseline | Improve |
|---|---|---|
| Status | WARN | WARN |
| Tools | find_tools×1, home×2 | find_tools×1, home×2 |
| Tokens | 11339 | 11307 |
| Latency | 6.3s | 5.8s |

Unchanged. Step-7 \`json_path(0.service)=None\` FAIL is a harness path-mismatch on the assertion (response body returns \`[{data,domain,service:turn_on}]\` correctly) — pre-existing on rc-0.7.1, unrelated to memory.

### Guard — 148-capability-ubiquiti-control-client

Pre-existing FAIL on rc-0.7.1 (abilities.sqlite drift — TKT-590 PR #1804). Both runs fail identically because find_tools cannot surface \`ubiquiti\` from FTS index. Memory change is orthogonal; the 30-iter cap variance reflects LLM noise inside the death spiral, not a regression — the ubiquiti routing problem is what fails, not memory behavior.

## Why ship

- Primary target shows a 4× latency improvement, 43% token reduction, eliminated iter-0 hallucinations — high-signal directional win.
- Two guards held: 138 unchanged, 148 fails for the same orthogonal reason.
- −5 LOC net subtraction; description still teaches the contract (\"For recall/reflect\").

## Convention reinforced

Drop multiplicity invitations in tool `query` / `parameter` descriptions. Single sentence stating the contract is sufficient; \"call once for each topic\" / \"may include multiple X\" patterns trigger parallel fan-out, especially in iter 0 where the schema is freshly visible to the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)