### PR TITLE
improve(prompt): scope memory-recall trigger to personal context

### DIFF
--- a/backend/services/system_message_prompt.py
+++ b/backend/services/system_message_prompt.py
@@ -94,7 +94,7 @@ Guiding framework for all interactions (internalize, do not recite):
 
 ## Operational Principles
 
-1. **Auto-store and recall.** When the user discloses a personal fact, store it via `memory` immediately — no permission needed. Before any response where stored preferences, constraints, or context could change the answer, check `memory` first.
+1. **Auto-store and recall.** When the user discloses a personal fact, store it via `memory` immediately — no permission needed. When a request turns on the user's own preferences, history, or personal context, check `memory` first — but answer objective factual questions directly.
 2. **Discover before guessing.** Use the tools available to you. If none fit, call `find_tools` to discover more — its description lists everything available.
 3. **Never fabricate tool results.** If a tool was not called or returned an error, do not claim it succeeded.
 


### PR DESCRIPTION
## Summary

Tightens Operational Principle #1 in `backend/services/system_message_prompt.py:97`. The recall trigger was an over-broad catch-all — *"Before any response where stored preferences, constraints, or **context** could change the answer, check `memory` first"* — which made the model invoke `memory` (and the associated `document`/`schedule`) on objective factual lookups where stored context is irrelevant.

**Change (1 line, net ~0 LOC, deductive/subtractive):**
- Before: `…Before any response where stored preferences, constraints, or context could change the answer, check memory first.`
- After: `…When a request turns on the user's own preferences, history, or personal context, check memory first — but answer objective factual questions directly.`

The auto-store half of the principle is kept verbatim. This narrows the recall trigger to personal-scoped requests and adds an explicit carve-out for objective factual questions.

## Evidence (baseline #880 vs branch #881/#882)

Target **051-tool-search** ("What's the current EUR/USD exchange rate?"):
- Baseline: WARN 0.76, **258.6s**, judge HIGH severity — *"performed 3 search iterations and multiple memory/document checks for a single exchange rate query, leading to a 251s response time and 58k tokens."*
- Branch: WARN 0.76, **58.5s** (−77% latency), judge MEDIUM — the memory/document over-exploration is gone (only redundant `read` calls remain).

Guard scenarios (no regression; the same over-routing anomaly cleared elsewhere):
| Scenario | Baseline | Branch | Note |
|---|---|---|---|
| 138 home-control | WARN 0.48 — *"invoked unrelated tools (memory, document, schedule) instead of the home tool"* | **PASS 0.92** | targeted anomaly cleared |
| 104 user-summary | WARN 0.72 (missing identity) | **PASS 1.0** | improved |
| 032 memory-recall | WARN 0.72, 239.6s | WARN 0.80, 87.2s | recall still fires (narrow strategy), −63% latency |
| 132 contacts | WARN 0.4 — *"used memory, document, schedule instead of contacts"* | WARN 0.4 — 0 spurious tools | over-fire cleared |
| 142 geo-recall | WARN 0.76 | WARN 0.76 | **recall still fires** — Valletta facts retrieved, deterministic 1/1 |
| 050 weather | WARN 0.76 | WARN 0.76 | memory not over-fired |

Recall is preserved across all three recall guards (032, 104, 142) — the tightened trigger does not suppress legitimate personal-context recall. The memory/document/schedule misrouting anomaly is eliminated or reduced on every scenario where it appeared.

Validated against `chalie-plans/message-processing.md` (CLAUDE.md rule #2): the doc documents the separate memory auto-seed wiring but does not pin Principle #1's wording, so no doc update required. Memory auto-seed is independent of this prompt line, so recall-dependent flows are unaffected.

## Test plan
- [x] `cd backend && pytest -m unit -q` — 1284 passed, 1 skipped
- [x] Targeted scenarios re-run on branch (051 + 6 guards) — see table above
- [x] CI build-log workflow green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
