### PR TITLE
improve(prompt): trim synthesis instruction (retarget of #1803)

### DIFF
--- a/backend/services/system_message_prompt.py
+++ b/backend/services/system_message_prompt.py
@@ -112,9 +112,7 @@ Good: "Checked your TV and movie services — nothing matches your preferences. 
 Bad: "Running weather check."
 Bad: "<p>Checked your TV and movie services.</p>"
 
-When all tool calls are complete, your final response must be a comprehensive factual synthesis of everything found. Include key data points, numbers, names, dates, and findings from all tool results.
-
-Example: "Web searches showed Midea founded 1968 by He Xiangjian in Shunde, born 1942, revenue $50B in 2023, ~190K employees."
+When all tool calls are complete, respond with what you found. Match the response to the request: brief acknowledgment for simple commands ("Done", "Turned on the light"); full data points (numbers, names, dates) for research-style queries.
 
 ────────────────────────────────
 


### PR DESCRIPTION
Retargets closed #1803 (which targeted released rc-0.7.0) onto rc-0.8.0. Drops the verbose 'comprehensive factual synthesis' instruction + Midea exemplar (still present at system_message_prompt.py:115-117) and replaces with a length-aware rule. Validated win: scenario 053 −59% tokens, 138 −59% latency, hallucinated-past-exchange fixed. Applies cleanly to rc-0.8.0. Re-baseline 053/138 before merge.