### PR TITLE
improve(weather): drop multiplicity sentence (retarget of #1807)

### DIFF
--- a/backend/abilities/weather.py
+++ b/backend/abilities/weather.py
@@ -121,8 +121,7 @@ _RICH_MEDIA_INSTRUCTION = (
     "You MUST present this result by wrapping your synthesis in <span id='{tag}'>your synthesis here</span>. "
     "The span will render as a weather card; without it, the user sees only "
     "plain text. Example output: \"Current conditions in "
-    "<span id='{tag}'>Paris is 14°C with light rain — bring an umbrella.</span>\" "
-    "You may include multiple weather spans (one per location) and prose between them."
+    "<span id='{tag}'>Paris is 14°C with light rain — bring an umbrella.</span>\""
 )
 
 


### PR DESCRIPTION
Retargets closed #1807 (targeted released rc-0.7.0) onto rc-0.8.0. Removes the 'You may include multiple weather spans (one per location)…' line from weather.py _RICH_MEDIA_INSTRUCTION (still at weather.py:127). Validated win: scenarios 083+050 WARN→PASS, −36% tokens; fixes double weather invocation on compound-qualifier inputs (e.g. 'Berlin Germany'). −1 LOC, applies cleanly.