### PR TITLE
improve(find_tools): smart-home EXAMPLES + raise example cap (retarget)

### DIFF
--- a/backend/abilities/_base.py
+++ b/backend/abilities/_base.py
@@ -39,9 +39,9 @@ class Ability(ABC):
             isinstance(e, str) for e in cls.EXAMPLES
         ):
             raise TypeError(f"{cls.__name__}.EXAMPLES must be list[str]")
-        if not (6 <= len(cls.EXAMPLES) <= 8):
+        if not (6 <= len(cls.EXAMPLES) <= 20):
             raise TypeError(
-                f"{cls.__name__}.EXAMPLES must have 6–8 entries, got {len(cls.EXAMPLES)}"
+                f"{cls.__name__}.EXAMPLES must have 6–20 entries, got {len(cls.EXAMPLES)}"
             )
         if (
             getattr(cls, "__module__", "").startswith("abilities.")

--- a/backend/abilities/find_tools.py
+++ b/backend/abilities/find_tools.py
@@ -29,6 +29,9 @@ class FindToolsAbility(Ability):
         "is there a way to check the current weather in another city",
         "can you help me monitor a webpage for changes",
         "look up something from my gmail",
+        "is the bedroom AC on",
+        "turn off all the downstairs lights",
+        "list my smart home devices",
     ]
     INPUT_SCHEMA = {
         "type": "object",


### PR DESCRIPTION
Retargeted onto rc-0.8.0 (was closed #1799). Staleness-verified: 0.8.0 find_tools has 8 EXAMPLES (at the _base cap) and none for smart-home; this adds 3 + raises the _base cap 8→20. NOTE: the cap raise and examples must land together. Needs standards/self-review before merge.