### PR TITLE
improve(memory): trim query-multiplicity description (retarget)

### DIFF
--- a/backend/abilities/memory.py
+++ b/backend/abilities/memory.py
@@ -90,12 +90,7 @@ class MemoryAbility(Ability):
             },
             "query": {
                 "type": "string",
-                "description": (
-                    "For recall/reflect: what to search for. One topic per "
-                    "call — to fetch memories about different topics, call "
-                    "this tool once for each topic. If results are broad or "
-                    "sparse, try searching again with more narrow queries."
-                ),
+                "description": "For recall/reflect: what to search for.",
             },
             "location": {
                 "type": "string",


### PR DESCRIPTION
Retargeted onto rc-0.8.0 (was closed #1808). Staleness-verified: 0.8.0 memory.py still carries the verbose 'One topic per call… narrow queries' description; the trim is not applied (parallels the multiplicity-trim convention). Needs standards/self-review before merge.
