### PR TITLE
fix(theme): dialog + scrollbar contrast in light theme (TKT-685/686)

### DIFF
--- a/frontend/interface/style.css
+++ b/frontend/interface/style.css
@@ -2059,7 +2059,7 @@ body.voice-loading .speech-form__speak-btn { display: none; }
 }
 
 .api-key-dialog__content {
-  background: rgba(12, 14, 24, 0.96);
+  background: color-mix(in oklab, var(--bg-2) 96%, transparent);
   backdrop-filter: blur(24px);
   -webkit-backdrop-filter: blur(24px);
   border: 1px solid color-mix(in oklab, var(--text) 7%, transparent);

--- a/frontend/shared/theme.css
+++ b/frontend/shared/theme.css
@@ -379,3 +379,5 @@ textarea::placeholder { color: var(--text-secondary); }
 ::-webkit-scrollbar-track  { background: transparent; }
 ::-webkit-scrollbar-thumb  { background: rgba(255, 255, 255, 0.12); border-radius: 3px; }
 ::-webkit-scrollbar-thumb:hover { background: rgba(255, 255, 255, 0.22); }
+[data-theme="light"] ::-webkit-scrollbar-thumb { background: rgba(0, 0, 0, 0.08); }
+[data-theme="light"] ::-webkit-scrollbar-thumb:hover { background: rgba(0, 0, 0, 0.15); }


### PR DESCRIPTION
## Summary
Two theme-contrast UI fixes (quick wins), touching different files, bundled into one PR.

- **TKT-685** — Upload dialog text nearly invisible. The `.api-key-dialog__content` panel (shared by the upload + API-key dialogs) hardcoded a near-black background `rgba(12,14,24,0.96)`, while its text uses theme-aware variables. In light theme the dark text rendered dark-on-dark. Swapped the hardcoded value for `color-mix(in oklab, var(--bg-2) 96%, transparent)` so the panel surface flips with the theme (dark `#0d0f18`, light `#FFFFFF`). No new token; preserves the dark-theme appearance exactly.
- **TKT-686** — Scrollbar invisible in light theme. `frontend/shared/theme.css` set the thumb to white `rgba(255,255,255,0.12)` with no light override. Added `[data-theme="light"]` thumb + hover overrides (`rgba(0,0,0,0.08)` / `0.15`), mirroring the existing Brain dashboard fix.

## Verification
Verified locally on a disposable static server (no backend/auth/vault, no live instance) using the actual edited CSS. Inspected computed styles + screenshots in BOTH themes:
- Light: dialog panel = white, title `rgb(26,22,38)` and body text now readable; scrollbar thumb visible dark-grey.
- Dark: unchanged — light text on dark panel, light scrollbar thumb. No regression.

## Files changed
- `frontend/interface/style.css` (1 line)
- `frontend/shared/theme.css` (+2 lines)

## Test plan
- [ ] `cd backend && pytest -m unit -q` green (CSS-only change; baseline confirmation)
- [ ] Visual check: open upload dialog in light + dark theme — all text readable
- [ ] Visual check: chat page scrollbar visible in light theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)