### PR TITLE
fix(tests): move web_download network tests to integration tier

### DIFF
--- a/backend/tests/test_web_download.py
+++ b/backend/tests/test_web_download.py
@@ -1,19 +1,77 @@
-"""Real-world tests for WebDownloadAbility. No mocks."""
+"""Tests for WebDownloadAbility.
+
+Two tiers, kept strictly separate:
+
+* ``@pytest.mark.unit`` — pure, deterministic, zero external dependencies.
+  Exercises URL validation: blocked schemes, private/internal-IP SSRF
+  rejection, and missing-URL handling. These never touch the network.
+
+* ``@pytest.mark.integration`` — real downloads against ``httpbin.org``.
+  Guarded by a skip when the host is unreachable so air-gapped CI, proxied
+  environments, and httpbin outages do not produce spurious failures.
+"""
 
 import os
+import socket
 import tempfile
 
 import pytest
 
 from abilities.web_download import WebDownloadAbility
 
-pytestmark = pytest.mark.unit
-
 _ability = WebDownloadAbility()
 _TMP = os.path.join(tempfile.gettempdir(), "chalie_downloads")
 
+_HTTPBIN_HOST = "httpbin.org"
 
-def test_successful_download():
+
+def _httpbin_reachable() -> bool:
+    """Best-effort TCP probe so integration tests skip (not fail) offline."""
+    try:
+        with socket.create_connection((_HTTPBIN_HOST, 443), timeout=3):
+            return True
+    except OSError:
+        return False
+
+
+@pytest.fixture
+def httpbin():
+    """Skip the requesting test when httpbin.org is unreachable.
+
+    The probe runs lazily inside the fixture (setup time of an integration
+    test) rather than at import — so collecting or running ``-m unit`` makes
+    zero network calls.
+    """
+    if not _httpbin_reachable():
+        pytest.skip(f"{_HTTPBIN_HOST} unreachable — skip network-dependent download tests.")
+
+
+# ── Unit tier: pure URL validation, no network ───────────────────────────────
+
+
+@pytest.mark.unit
+def test_blocked_schemes():
+    assert "blocked" in _ability.execute("text", {"url": "file:///etc/passwd"}, None).lower()
+    assert "blocked" in _ability.execute("text", {"url": "data:text/plain;base64,SGVsbG8="}, None).lower()
+
+
+@pytest.mark.unit
+def test_private_ip_blocked():
+    result = _ability.execute("text", {"url": "http://127.0.0.1/secret"}, None)
+    assert "blocked" in result.lower() or "private" in result.lower()
+
+
+@pytest.mark.unit
+def test_missing_url_is_rejected():
+    assert "required" in _ability.execute("text", {}, None).lower()
+    assert "required" in _ability.execute("text", {"url": ""}, None).lower()
+
+
+# ── Integration tier: real downloads against httpbin.org ─────────────────────
+
+
+@pytest.mark.integration
+def test_successful_download(httpbin):
     result = _ability.execute("text", {"url": "https://httpbin.org/robots.txt"}, None)
     assert os.path.isabs(result)
     assert result.startswith(_TMP)
@@ -30,7 +88,8 @@ def test_successful_download():
     os.remove(second)
 
 
-def test_timeout_and_edge_values():
+@pytest.mark.integration
+def test_timeout_and_edge_values(httpbin):
     result = _ability.execute("text", {"url": "https://httpbin.org/bytes/32", "timeout": 5}, None)
     assert os.path.exists(result)
     os.remove(result)
@@ -44,22 +103,8 @@ def test_timeout_and_edge_values():
     os.remove(result)
 
 
-def test_blocked_schemes():
-    assert "blocked" in _ability.execute("text", {"url": "file:///etc/passwd"}, None).lower()
-    assert "blocked" in _ability.execute("text", {"url": "data:text/plain;base64,SGVsbG8="}, None).lower()
-
-
-def test_private_ip_blocked():
-    result = _ability.execute("text", {"url": "http://127.0.0.1/secret"}, None)
-    assert "blocked" in result.lower() or "private" in result.lower()
-
-
-def test_errors():
-    assert "required" in _ability.execute("text", {}, None).lower()
-    assert "required" in _ability.execute("text", {"url": ""}, None).lower()
-
-    result = _ability.execute("text", {"url": "https://this-domain-does-not-exist-xyz123.example"}, None)
-    assert not os.path.exists(result)
-
+@pytest.mark.integration
+def test_http_error_status_is_reported(httpbin):
     result = _ability.execute("text", {"url": "https://httpbin.org/status/404"}, None)
     assert "404" in result or "not found" in result.lower() or "error" in result.lower()
+    assert not os.path.exists(result)


### PR DESCRIPTION
## Summary
- `backend/tests/test_web_download.py` was marked `pytestmark = pytest.mark.unit` but made 6 live HTTP calls to `httpbin.org` plus a non-deterministic NXDOMAIN assertion — violating the three-tier test contract (unit tests must be deterministic, zero external deps). It failed in air-gapped CI, behind proxies, and during httpbin outages.
- Kept only pure URL-validation behavior (blocked schemes, private-IP/SSRF rejection, missing-URL handling) under `@pytest.mark.unit`.
- Moved the three real-download tests to `@pytest.mark.integration`, gated by an `httpbin` fixture whose reachability probe runs **lazily at test setup** (not at import) so `pytest -m unit` collection makes zero network calls.
- Removed the non-deterministic NXDOMAIN assertion; deterministic error-path coverage retained via the missing-URL unit test.

Resolves TKT-649, TKT-669, TKT-681 (three duplicate tickets for the same issue).

## Test plan
- [x] `pytest -m unit -q` green (1283 passed, 1 skipped) and verified network-free (all `socket.connect` blocked → unit subset still passes)
- [x] `pytest -m integration --collect-only` collects the 3 download tests
- [x] `ruff check` clean on the changed file