### PR TITLE
fix(brain): theme toggle stays on /brain/ (TKT-687)

### DIFF
--- a/frontend/brain/sidebar.js
+++ b/frontend/brain/sidebar.js
@@ -53,12 +53,16 @@ const BrainSidebar = (() => {
       </a>
       <nav class="sidebar-scroll" id="sidebarNav"></nav>
       <div class="sidebar-footer">
-        <button class="icon-btn theme-toggle" id="themeToggleBtn" aria-label="Toggle theme">
+        <button type="button" class="icon-btn theme-toggle" id="themeToggleBtn" aria-label="Toggle theme">
           ${Icons.Sun()}
         </button>
       </div>`;
 
-    document.getElementById('themeToggleBtn').addEventListener('click', BrainApp.toggleTheme);
+    document.getElementById('themeToggleBtn').addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      BrainApp.toggleTheme();
+    });
     _renderNav();
   }
 


### PR DESCRIPTION
## Summary
- Fixes TKT-687: clicking the Brain sidebar theme-toggle (sun/moon, bottom-left) toggled the theme but also navigated the user away to the chat page at `/`.
- Root cause: the toggle `<button>` had no explicit `type`, so it defaulted to `type="submit"`, allowing its click to trigger navigation. The click handler also did not suppress default/bubbling behavior.
- Fix (minimal): add `type="button"` to the toggle and have the handler call `event.preventDefault()` + `event.stopPropagation()` before toggling the theme.

## Verification
- `cd backend && pytest -m unit -q` → 1285 passed, 1 skipped (no Python changed).
- `node --check frontend/brain/sidebar.js` → valid.
- Browser: served the worktree frontend on a disposable local static server (stubbed `/auth/status`), loaded `/brain/`, clicked the toggle twice. Theme flipped dark→light→dark and the URL stayed `/brain/` for both directions. No live/shared instance used.

Ticket: TKT-687