### PR TITLE
fix(phase4): remove stale self_model_service.py allowlist entry (TKT-648/670)

### DIFF
--- a/backend/tests/test_phase4_invariants.py
+++ b/backend/tests/test_phase4_invariants.py
@@ -330,7 +330,6 @@ def test_per_processor_tool_scope_matches_spec():
 #   * abilities/_registry.py        — owns the method
 #   * utils/build_ability_db.py     — rebuilds discovery DB from registry
 #   * services/act_dispatcher_service.py — populates dispatcher handlers
-#   * services/self_model_service.py — innate-skills inventory for /self_model
 #
 # To add a new caller, audit the use case (does it pre-inject discoverable
 # abilities?), then extend _ALLOWED_REGISTRY_ALL_CALLERS in this file.
@@ -339,7 +338,6 @@ _ALLOWED_REGISTRY_ALL_CALLERS = frozenset({
     "abilities/_registry.py",
     "utils/build_ability_db.py",
     "services/act_dispatcher_service.py",
-    "services/self_model_service.py",
     "services/policy_service.py",
 })
 


### PR DESCRIPTION
## Summary
- Removes the stale `"services/self_model_service.py"` entry from `_ALLOWED_REGISTRY_ALL_CALLERS` in `backend/tests/test_phase4_invariants.py`, plus its matching explanatory comment.
- The file `services/self_model_service.py` was deleted in commit `e3378aa0` (SelfModelService rip-out, -756 LOC). The leftover allowlist entry is a covert governance bypass: if a file by that name were ever recreated with an `AbilityRegistry.all()` call, the invariant guard would silently pre-authorize it.

## Verification
- Confirmed `services/self_model_service.py` does not exist anywhere in the repo (`git ls-files`, filesystem, `git grep`).
- `pytest tests/test_phase4_invariants.py` → 7 passed.
- Full unit suite `pytest -m unit -q` → 1285 passed, 1 skipped.
- `ruff check` clean; `vulture` reports no new findings (only the pre-existing `pytestmark` false positive).

## Out of scope (follow-up)
TKT-648 also requested adding `GeoPatternProcessor` to `_EXPECTED_SCOPE`. That is deferred: the ticket's suggested value `(frozenset(), frozenset())` is incorrect (the class actually declares `ALWAYS_AVAILABLE = ["save_pattern", "save_graph"]`), and adding it would trip the innate-leak guard — requiring a semantic relaxation beyond this stale-allowlist cleanup.

Closes TKT-648, TKT-670 (duplicates) for the core stale-entry fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)