### PR TITLE
test(vision): drop tautological vision_probe tests, keep parse-robustness

### DIFF
--- a/backend/tests/test_vision_probe.py
+++ b/backend/tests/test_vision_probe.py
@@ -1,6 +1,14 @@
-"""Unit tests for vision_probe scoring + probe_provider (no network)."""
+"""Unit tests for vision_probe JSON extraction from messy model replies.
+
+Scope note: these cover ONLY the parse-robustness of _extract_json — the one part
+of the probe with non-trivial, regression-prone logic (see the S5857 fenced-JSON
+regex fix). The probe's actual job — verifying a real model SEES vision-test.png —
+is validated in real use, not here: a model-free assertion against the scorer just
+restates the scoring constants back to themselves (tautological) and cannot catch
+the failure modes that matter (answer-key drift, a real model silently ignoring the
+image). See the TKT-715 decision log.
+"""
 import json
-from unittest.mock import patch
 
 import pytest
 
@@ -17,75 +25,16 @@ _PERFECT = json.dumps({
 })
 
 
-def test_perfect_scores_1():
-    from services.vision_probe import score_probe_response
-    assert score_probe_response(_PERFECT) == pytest.approx(1.0)
-
-
-def test_count_plus_two_shapes_plus_text_passes():
-    # 0.30 + 0.15 + 0.15 + 0.25 = 0.85  (≥ 0.80)
-    from services.vision_probe import score_probe_response
-    body = json.dumps({
-        "number_of_shapes": 3,
-        "shapes": [
-            {"shape": "rectangle", "color": "red"},
-            {"shape": "circle", "color": "yellow"},
-        ],
-        "text": "Chalie can read!",
-    })
-    assert score_probe_response(body) == pytest.approx(0.85)
-
-
-def test_count_plus_three_shapes_no_text_fails():
-    # 0.30 + 0.45 = 0.75  (< 0.80)
-    from services.vision_probe import score_probe_response
-    body = json.dumps({
-        "number_of_shapes": 3,
-        "shapes": [
-            {"shape": "rectangle", "color": "red"},
-            {"shape": "circle", "color": "yellow"},
-            {"shape": "hexagon", "color": "green"},
-        ],
-        "text": "",
-    })
-    assert score_probe_response(body) == pytest.approx(0.75)
-
-
-def test_three_shapes_text_wrong_count_fails():
-    # 0.45 + 0.25 = 0.70  (< 0.80)
-    from services.vision_probe import score_probe_response
-    body = json.dumps({
-        "number_of_shapes": 5,
-        "shapes": [
-            {"shape": "rectangle", "color": "red"},
-            {"shape": "circle", "color": "yellow"},
-            {"shape": "hexagon", "color": "green"},
-        ],
-        "text": "Chalie can read!",
-    })
-    assert score_probe_response(body) == pytest.approx(0.70)
-
-
-def test_case_insensitive_and_trimmed_text():
-    from services.vision_probe import score_probe_response
-    body = json.dumps({
-        "number_of_shapes": 3,
-        "shapes": [
-            {"shape": "Rectangle", "color": "RED"},
-            {"shape": "circle", "color": "Yellow"},
-            {"shape": "HEXAGON", "color": "green"},
-        ],
-        "text": "  chalie can read!  ",
-    })
-    assert score_probe_response(body) == pytest.approx(1.0)
-
-
 def test_json_in_code_fence_is_parsed():
+    # Guards the S5857 fenced-JSON regex: the payload has nested braces (one object
+    # per shape), so the extractor must capture the WHOLE object, not stop at the
+    # first '}'. A reluctant or [^}]* regex would truncate it and score 0.0.
     from services.vision_probe import score_probe_response
     assert score_probe_response(f"Here you go:\n```json\n{_PERFECT}\n```") == pytest.approx(1.0)
 
 
 def test_prose_then_json_is_parsed():
+    # Models often narrate before the JSON; find('{')..rfind('}') must still recover it.
     from services.vision_probe import score_probe_response
     assert score_probe_response(f"I can see three shapes. {_PERFECT}") == pytest.approx(1.0)
 
@@ -94,39 +43,3 @@ def test_garbage_scores_zero():
     from services.vision_probe import score_probe_response
     assert score_probe_response("no json here") == pytest.approx(0.0)
     assert score_probe_response("") == pytest.approx(0.0)
-
-
-def test_duplicate_correct_shape_counts_once():
-    # repeated (rectangle,red) must not double-count
-    from services.vision_probe import score_probe_response
-    body = json.dumps({
-        "number_of_shapes": 3,
-        "shapes": [
-            {"shape": "rectangle", "color": "red"},
-            {"shape": "rectangle", "color": "red"},
-        ],
-        "text": "Chalie can read!",
-    })
-    assert score_probe_response(body) == pytest.approx(0.70)  # 0.30 + 0.15 + 0.25
-
-
-def test_probe_provider_true_on_passing_reply():
-    from services import vision_probe
-    with patch("services.vision_service.send_image_with_config", return_value=_PERFECT):
-        assert vision_probe.probe_provider(
-            {"platform": "ollama", "model": "llava"}) is True
-
-
-def test_probe_provider_false_on_low_score():
-    from services import vision_probe
-    with patch("services.vision_service.send_image_with_config",
-               return_value='{"number_of_shapes": 0, "shapes": [], "text": ""}'):
-        assert vision_probe.probe_provider(
-            {"platform": "ollama", "model": "llava"}) is False
-
-
-def test_probe_provider_false_on_none_reply():
-    from services import vision_probe
-    with patch("services.vision_service.send_image_with_config", return_value=None):
-        assert vision_probe.probe_provider(
-            {"platform": "ollama", "model": "llava"}) is False


### PR DESCRIPTION
## Summary

Follow-up cleanup to TKT-715 (vision capability, landed as `aab672ba`). Removes 9 of the 12 unit tests in `test_vision_probe.py` that were tautological, and keeps the 3 that carry real regression value.

`vision_probe.py` is a **runtime classifier** that verifies a provider actually understands images — it is not a pytest test. Nine of its unit tests mocked away the real model call and asserted that the scorer scores its own hand-fed constants. They restate the `_EXPECTED_SHAPES` / `_EXPECTED_COUNT` / `_EXPECTED_TEXT` answer key and the `0.30 / 0.15 / 0.25` weights back to themselves, so they cannot catch the failure modes that actually matter (answer-key drift, or a real model silently ignoring the image). Those are validated on real provider-save, not at the unit layer.

**Kept** the three tests that exercise the one genuinely regression-prone part of the probe — `_extract_json` on messy model replies:
- `test_json_in_code_fence_is_parsed` — guards the S5857 greedy-regex fix (a nested-brace payload must not be truncated by a reluctant / `[^}]*` regex)
- `test_prose_then_json_is_parsed` — prose before the JSON object
- `test_garbage_scores_zero` — non-JSON / empty input

Also drops the now-unused `from unittest.mock import patch` import.

## Impact

- **No production code touched** — test-only change.
- Net: **−9 unit tests** (1363 → 1354).
- All converter tests (`test_vision_converters.py`) untouched — they assert the rule #2 byte-identical invariant + per-platform wire formats and remain valuable.

## Test plan

- [x] `pytest tests/test_vision_probe.py tests/test_vision_converters.py` — 16 passed
- [x] `ruff check tests/test_vision_probe.py` — clean (no F401 from the dropped import)
- [x] `vulture tests/test_vision_probe.py` — clean
- [x] Full `pytest -m unit` — **1354 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)