### PR TITLE
fix(chat): keep uploaded image in user bubble + stop error→reload bounce (TKT-794)

### DIFF
--- a/frontend/interface/chat.js
+++ b/frontend/interface/chat.js
@@ -130,6 +130,9 @@ export class Chat {
     const textarea = document.getElementById('messageInput');
     const text = textarea.value.trim();
     const attachments = this._imageAttach ? this._imageAttach.getAttachmentPaths() : [];
+    // Capture preview metadata (object URLs, filenames) BEFORE clear() wipes the
+    // strip — used to render the attachments inside the user's own turn bubble.
+    const attachmentPreviews = this._imageAttach ? this._imageAttach.getAttachments() : [];
 
     if (!text && !attachments.length) return;
 
@@ -158,7 +161,7 @@ export class Chat {
     textarea.style.height = 'auto';
     if (this._imageAttach) this._imageAttach.clear();
 
-    this._startTurn(text || '[File attached]', source, true, attachments);
+    this._startTurn(text || '[File attached]', source, true, attachments, attachmentPreviews);
   }
 
   // ---------------------------------------------------------------------------
@@ -236,10 +239,14 @@ export class Chat {
    * @param {string} source — "text" | "voice" | "subagent" etc.
    * @param {boolean} showUserBubble — whether to render a user speech-form
    * @param {string[]} attachments — file paths from POST /upload
+   * @param {Array<{filename: string, objectUrl: string|null, isImage: boolean}>} attachmentPreviews
+   *        — preview metadata rendered inside the user bubble
    */
-  _startTurn(text, source, showUserBubble = true, attachments = []) {
+  _startTurn(text, source, showUserBubble = true, attachments = [], attachmentPreviews = []) {
     if (showUserBubble) {
-      this._lastUserBubble = this._renderer.appendUserForm(text || '[File attached]', null, {});
+      this._lastUserBubble = this._renderer.appendUserForm(text || '[File attached]', null, {
+        attachments: attachmentPreviews,
+      });
     }
 
     const actEl = this._renderer.createActCycle();
@@ -278,7 +285,15 @@ export class Chat {
       },
       onError: (data) => {
         this._renderer.replaceActWithError(actEl, data.message);
-        if (!data.recoverable) this._onAuthFailureCb?.();
+        // A turn-level error (provider failure, quota/429, tool error) is NOT
+        // an auth event — surface it in place and let the turn finalise via the
+        // `done` event that always follows. Genuine session loss is detected by
+        // its own channels: the heartbeat (/auth/status poll) and api.js (any
+        // 401 → 'AUTH'). Only an explicit auth signal triggers the login
+        // redirect — never a generic non-recoverable turn error, which used to
+        // bounce an authenticated user through /login/ and reload the page,
+        // discarding the turn.
+        if (data.auth_failed) this._onAuthFailureCb?.();
       },
       onDone: (data) => {
         this._onResponseReceivedCb?.();

--- a/frontend/interface/image_attach.js
+++ b/frontend/interface/image_attach.js
@@ -57,8 +57,13 @@ export class ImageAttach {
     }
 
     const isImage = file.type.startsWith('image/');
+    // Object URL is created once and reused: the preview chip displays it now,
+    // and the sent-message bubble reuses it so the image stays visible in the
+    // user's own turn after send (the strip is cleared). Not revoked — the
+    // browser releases it on unload, and a handful per session is negligible.
+    const objectUrl = isImage ? URL.createObjectURL(file) : null;
     const chipEl = isImage
-      ? this._addImageChip(file)
+      ? this._addImageChip(file, objectUrl)
       : this._addDocChip(file.name);
 
     this._uploadsInProgress++;
@@ -79,7 +84,13 @@ export class ImageAttach {
         // Remove the in-progress spinner and mark as ready.
         chipEl.classList.remove('analyzing');
         chipEl.querySelector('.image-preview__spinner')?.remove();
-        this._attachments.push({ tmpPath: data.tmp_path, filename: data.filename, element: chipEl });
+        this._attachments.push({
+          tmpPath: data.tmp_path,
+          filename: data.filename,
+          element: chipEl,
+          objectUrl,
+          isImage,
+        });
       } else {
         chipEl.remove();
         this._updatePreviewVisibility();
@@ -101,6 +112,19 @@ export class ImageAttach {
    */
   getAttachmentPaths() {
     return this._attachments.map(a => a.tmpPath);
+  }
+
+  /**
+   * Returns preview metadata for rendering attachments inside the sent-message
+   * bubble. Must be read BEFORE clear() — clear() drops the attachment list.
+   * @returns {Array<{filename: string, objectUrl: string|null, isImage: boolean}>}
+   */
+  getAttachments() {
+    return this._attachments.map(a => ({
+      filename: a.filename,
+      objectUrl: a.objectUrl || null,
+      isImage: !!a.isImage,
+    }));
   }
 
   /**
@@ -198,9 +222,10 @@ export class ImageAttach {
    * The chip starts with the `analyzing` class and a spinner while uploading.
    *
    * @param {File} file
+   * @param {string} objectUrl — pre-created object URL for the file
    * @returns {HTMLElement}
    */
-  _addImageChip(file) {
+  _addImageChip(file, objectUrl) {
     const strip = document.getElementById('imagePreview');
     strip.classList.remove('hidden');
 
@@ -208,7 +233,7 @@ export class ImageAttach {
     thumb.className = 'image-preview__thumb analyzing';
 
     const img = document.createElement('img');
-    img.src = URL.createObjectURL(file);
+    img.src = objectUrl || URL.createObjectURL(file);
     img.alt = file.name;
     thumb.appendChild(img);
 

--- a/frontend/interface/renderer.js
+++ b/frontend/interface/renderer.js
@@ -59,20 +59,60 @@ export class Renderer {
    * Append a user speech form.
    * @param {string} text
    * @param {string|null} [ts]
-   * @param {{inWorkingMemory?: boolean}} [options]
+   * @param {{inWorkingMemory?: boolean, attachments?: Array}} [options]
    */
-  appendUserForm(text, ts = null, { inWorkingMemory = true } = {}) {
+  appendUserForm(text, ts = null, { inWorkingMemory = true, attachments = [] } = {}) {
     const el = this._createEl('div', 'speech-form speech-form--user');
     if (!inWorkingMemory) el.classList.add('message--faded');
     _attachGlyph(el, 'user');
 
-    const textEl = this._createEl('div', 'speech-form__text');
-    textEl.textContent = text;
-    el.appendChild(textEl);
+    this._appendUserAttachments(el, attachments);
+
+    // Suppress the '[File attached]' placeholder when there is nothing typed but
+    // the attachments are already shown above — the media is the message.
+    if (!(text === '[File attached]' && attachments.length)) {
+      const textEl = this._createEl('div', 'speech-form__text');
+      textEl.textContent = text;
+      el.appendChild(textEl);
+    }
 
     this._spine.appendChild(el);
     this._scrollToBottom();
     return el;
+  }
+
+  /**
+   * Render attachment previews (image thumbnails / doc chips) inside a user
+   * speech-form, above the text. No-op when there are no attachments.
+   *
+   * @param {HTMLElement} el — the .speech-form--user element
+   * @param {Array<{filename: string, objectUrl: string|null, isImage: boolean}>} attachments
+   */
+  _appendUserAttachments(el, attachments = []) {
+    if (!attachments.length) return;
+
+    const wrap = this._createEl('div', 'speech-form__attachments');
+    for (const att of attachments) {
+      if (att.isImage && att.objectUrl) {
+        const img = document.createElement('img');
+        img.className = 'speech-form__attachment-img';
+        img.src = att.objectUrl;
+        img.alt = att.filename || 'attached image';
+        img.loading = 'lazy';
+        wrap.appendChild(img);
+      } else {
+        const chip = this._createEl('div', 'speech-form__attachment-doc');
+        const icon = this._createEl('span', 'speech-form__attachment-doc-icon');
+        icon.setAttribute('aria-hidden', 'true');
+        icon.textContent = '📄';
+        chip.appendChild(icon);
+        const name = this._createEl('span', 'speech-form__attachment-doc-name');
+        name.textContent = att.filename || 'attachment';
+        chip.appendChild(name);
+        wrap.appendChild(chip);
+      }
+    }
+    el.appendChild(wrap);
   }
 
   /**

--- a/frontend/interface/style.css
+++ b/frontend/interface/style.css
@@ -819,6 +819,50 @@ body.speaker-user   #ambientBloom {
   font-weight: 600;
 }
 
+/* Attachment previews rendered inside the user's own turn bubble (above text) */
+.speech-form__attachments {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-sm);
+}
+
+.speech-form__attachments:last-child {
+  margin-bottom: 0;
+}
+
+.speech-form__attachment-img {
+  max-width: min(320px, 100%);
+  max-height: 320px;
+  width: auto;
+  height: auto;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-card);
+  object-fit: contain;
+  display: block;
+}
+
+.speech-form__attachment-doc {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--bg-chalie);
+  font-size: 0.85em;
+  max-width: 100%;
+}
+
+.speech-form__attachment-doc-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Light theme: user bubble = 80% white. */
 [data-theme="light"] .speech-form--user {
   background: rgba(255, 255, 255, 0.8);


### PR DESCRIPTION
## TKT-794 — Image upload breaks ACT loop with vision provider

Two distinct bugs when sending an image with a vision provider configured.

### Problem 1 — image vanished from chat on send
The preview strip was cleared on send and the user's turn bubble never rendered the attachment, so the image disappeared. Now the attachment preview metadata (object URL + filename) is captured **before** `clear()`, passed through `_startTurn → renderer.appendUserForm`, and rendered as image thumbnails (and doc chips) inside the user's own bubble, above the text. Themed via shared CSS variables (`--border`, `--shadow-card`, `--bg-chalie`) so both dark and light themes work. The `[File attached]` placeholder is suppressed when the media is shown.

### Problem 2 — page reloaded, LLM never answered
A turn-level backend error (provider quota/429, invalid model, tool error) is broadcast with `recoverable: false`. `chat.js` misclassified **any** non-recoverable error as an auth failure → `_handleAuthFailure()` → `location.replace('/login/')`, which `auth-gate.js` bounced back to `/` — a full page reload that discarded the turn. The `onError` handler now only triggers the auth redirect on an explicit auth signal (`data.auth_failed`). Genuine session loss is still detected by its dedicated channels: the heartbeat (`/auth/status` poll) and `api.js` (any 401 → `'AUTH'`). The error bubble (`replaceActWithError`) shows the error in place and the turn finalises normally via the `done` event.

## Verification (browser, disposable QA env on this branch, Gemini vision provider)
- **Problem 1:** image renders in the user bubble (verified `bubbleHasImage`/`bubbleImgVisible` true) and persists through the full turn — light **and** dark theme.
- **Problem 2 happy path:** image sent → no reload (in-page marker survived) → Gemini answered correctly about the image.
- **Problem 2 error path:** forced a real `400 INVALID_ARGUMENT` backend error → error bubble shown in place, **no reload**, **not** bounced to `/login/`, turn finalised cleanly.

Files: `frontend/interface/{chat.js,image_attach.js,renderer.js,style.css}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)