### PR TITLE
fix(TKT-950): detect half-open WebSocket and force reconnect

### DIFF
--- a/docs/13-MESSAGE-FLOW.md
+++ b/docs/13-MESSAGE-FLOW.md
@@ -37,6 +37,8 @@ POST /chat
  
 **Interrupt & cancel.** `POST /chat/interrupt` stops the active turn; a cancelled turn deletes its transcript and tool-call rows, leaving no trace. Sending a new message mid-turn cancels the active turn and starts a fresh one with the original + new text combined.
  
+**Connection resilience.** Because replies arrive only over the push channel, the client guards the socket on two fronts. A socket that closes cleanly (`onclose`) triggers exponential-backoff reconnection. A *half-open* socket — one a reverse proxy idle-drops at the TCP layer without sending a close frame, so `onclose` never fires and `readyState` stays `OPEN` — is caught by a liveness watchdog: the client stamps the arrival time of every inbound frame and, if none arrives for longer than 1.5× the server's keep-alive ping interval, tears the dead socket down and reconnects. A tab regaining focus re-runs the same staleness check on demand, so a backgrounded tab heals the moment the user returns instead of silently swallowing the next reply.
+ 
  ---
  
 ## The ACT Loop

--- a/frontend/interface/app.js
+++ b/frontend/interface/app.js
@@ -754,10 +754,11 @@ class ChalieApp {
   _initVisibilityTracking() {
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'visible') {
-        // Reconnect WebSocket if it was closed (mobile sleep/resume)
-        if (!this.ws.isConnected) {
-          this.ws.connect();
-        }
+        // Heal the WebSocket on resume. ensureAlive() handles both a cleanly
+        // closed socket (mobile sleep) and a half-open one silently dropped by a
+        // reverse proxy — the latter still reports isConnected === true, so a
+        // bare isConnected check would miss it.
+        this.ws.ensureAlive();
         // Scroll to latest message so user sees current state
         this.renderer.forceScrollToBottom();
       }

--- a/frontend/interface/ws.js
+++ b/frontend/interface/ws.js
@@ -12,7 +12,12 @@
  *     permission_request, intent, capability_alert
  *
  * The only client→server WS message is pong (keepalive response).
- * On disconnect, the page reloads to re-establish state.
+ *
+ * Reconnect strategy: a clean `onclose` triggers exponential-backoff
+ * reconnection. A reverse proxy can also idle-drop the socket at the TCP layer
+ * without sending a close frame (half-open) — `onclose` never fires — so a
+ * liveness watchdog force-reconnects when the backend's periodic pings stop
+ * arriving. `ensureAlive()` performs the same check on demand (e.g. tab refocus).
  */
 export class WSClient {
   /**
@@ -30,6 +35,14 @@ export class WSClient {
     this._disconnectHandler = null;
     this._connected = false;
     this._intentionallyClosed = false;
+    // Liveness watchdog (half-open detection). The backend pings every 60s of
+    // client silence (backend/api/websocket.py `_ws_handler`); if no frame
+    // arrives for longer than the stale threshold, the pipe is dead even though
+    // the browser still reports readyState === OPEN.
+    this._staleThresholdMs = 90000;  // 1.5× the 60s server ping — fire on full silence only
+    this._livenessCheckMs = 30000;   // how often the watchdog re-checks
+    this._lastInboundAt = 0;
+    this._livenessTimer = null;
   }
 
   _buildWsUrl() {
@@ -97,12 +110,28 @@ export class WSClient {
       return;
     }
 
+    // A backoff reconnect we scheduled earlier is now redundant — this connect()
+    // owns the new socket (e.g. a tab refocus called ensureAlive() while a
+    // _scheduleReconnect timer was still pending). Clear it so it cannot fire a
+    // second, no-op connect().
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
+
     this._ws.onopen = () => {
       this._connected = true;
       this._reconnectDelay = 1000;
+      // Count connect time as the last inbound so the first server ping (≤60s)
+      // has a full window to arrive before the watchdog can judge staleness.
+      this._lastInboundAt = Date.now();
+      this._startLivenessWatch();
     };
 
     this._ws.onmessage = (event) => {
+      // Any inbound frame proves the pipe is alive — stamp before parsing so a
+      // malformed frame still counts toward liveness.
+      this._lastInboundAt = Date.now();
       let data;
       try {
         data = JSON.parse(event.data);
@@ -114,6 +143,7 @@ export class WSClient {
 
     this._ws.onclose = () => {
       this._connected = false;
+      this._stopLivenessWatch();
       this._disconnectHandler?.();
       if (!this._intentionallyClosed) {
         this._scheduleReconnect();
@@ -127,6 +157,7 @@ export class WSClient {
 
   close() {
     this._intentionallyClosed = true;
+    this._stopLivenessWatch();
     if (this._reconnectTimer) {
       clearTimeout(this._reconnectTimer);
       this._reconnectTimer = null;
@@ -152,6 +183,70 @@ export class WSClient {
     }, this._reconnectDelay);
 
     this._reconnectDelay = Math.min(this._reconnectDelay * 1.5, this._maxReconnectDelay);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Liveness watchdog — detect a half-open socket (silent reverse-proxy idle
+  // drop) that never fires `onclose`, and force a reconnect. Without this, the
+  // socket reports readyState === OPEN forever, `isConnected` lies, and pushed
+  // replies vanish into the dead pipe while the user sees nothing.
+  // ---------------------------------------------------------------------------
+
+  _startLivenessWatch() {
+    this._stopLivenessWatch();
+    this._livenessTimer = setInterval(() => this._checkLiveness(), this._livenessCheckMs);
+  }
+
+  _stopLivenessWatch() {
+    if (this._livenessTimer) {
+      clearInterval(this._livenessTimer);
+      this._livenessTimer = null;
+    }
+  }
+
+  _checkLiveness() {
+    if (this._intentionallyClosed) return;
+    if (Date.now() - this._lastInboundAt > this._staleThresholdMs) {
+      this._forceReconnect();
+    }
+  }
+
+  /**
+   * Tear down a socket that is open at the browser level but has gone silent,
+   * then immediately reconnect. The stale socket's handlers are detached first
+   * so its delayed `onclose` (fired once the browser finally gives up) cannot
+   * trigger a second, competing reconnect.
+   */
+  _forceReconnect() {
+    this._stopLivenessWatch();
+    const stale = this._ws;
+    this._ws = null;
+    this._connected = false;
+    if (stale) {
+      stale.onopen = null;
+      stale.onmessage = null;
+      stale.onclose = null;
+      stale.onerror = null;
+      try { stale.close(); } catch { /* already dead — nothing to close */ }
+    }
+    this._disconnectHandler?.();
+    this.connect();
+  }
+
+  /**
+   * Verify the connection is genuinely alive and heal it if not. Used when the
+   * tab regains focus: `isConnected` alone is unreliable because a half-open
+   * socket still reports readyState === OPEN.
+   */
+  ensureAlive() {
+    if (this._intentionallyClosed) return;
+    if (!this.isConnected) {
+      this.connect();
+      return;
+    }
+    if (Date.now() - this._lastInboundAt > this._staleThresholdMs) {
+      this._forceReconnect();
+    }
   }
 
   abort() {


### PR DESCRIPTION
## Problem

Replies are delivered to the browser only over the `/ws` push channel. When a reverse proxy idle-drops that socket at the TCP layer **without sending a close frame** (a *half-open* socket), the browser never fires `onclose` and `readyState` stays `OPEN`. The existing reconnect logic is gated entirely on `onclose`, so it never runs — the pipe is dead, `isConnected` keeps reporting `true`, and every pushed reply silently vanishes until the user manually refreshes.

Addresses #1838.

## Fix

A **client liveness watchdog** in `WSClient` (`frontend/interface/ws.js`):

- Stamp `_lastInboundAt` on every inbound frame (stamped *before* `JSON.parse`, so even a malformed frame counts as proof-of-life).
- Poll every 30s. If no frame has arrived for **90s** — 1.5× the server's 60s keep-alive ping interval, so it only fires on genuine sustained silence — tear the dead socket down and reconnect.
- `_forceReconnect()` detaches the stale socket's handlers before closing it, so its delayed `onclose` cannot trigger a second, competing reconnect.
- New public `ensureAlive()` runs the same staleness check on demand. The tab-visibility handler (`app.js`) now calls it instead of a bare `isConnected` check, because a half-open socket lies — `isConnected` returns `true` for a dead pipe.

Clean-`onclose` exponential-backoff reconnection is unchanged; this only adds the missing half-open path.

## Verification

Real browser end-to-end (headless Chrome + Playwright fake-clock) against a disposable instance running this branch, driving the **deployed** `WSClient` through the half-open scenario:

| Check | Result |
|---|---|
| App opens an initial `/ws` socket, reaches OPEN | ✅ |
| No reconnect under the staleness threshold (30s silence) — no false positive | ✅ |
| Watchdog force-reconnects on a half-open socket (1 → 2 sockets) | ✅ |
| Stale socket torn down (`closed`) | ✅ |
| Exactly one reconnect — no double-reconnect storm | ✅ |
| Healed socket reaches OPEN | ✅ |
| A sent chat message's reply pushes over the **healed** socket | ✅ |

8/8 checks passed.

## Files

- `frontend/interface/ws.js` — liveness watchdog + `ensureAlive()` (+97 lines)
- `frontend/interface/app.js` — tab-refocus handler uses `ensureAlive()`
- `docs/13-MESSAGE-FLOW.md` — "Connection resilience" note

🤖 Generated with [Claude Code](https://claude.com/claude-code)
