### PR TITLE
fix(brain-ui): micro-alignment polish across Brain dashboard (TKT-587)

### DIFF
--- a/frontend/brain/cognition.js
+++ b/frontend/brain/cognition.js
@@ -283,13 +283,13 @@ const PanelCognition = (() => {
       { key: 'humor', left: 'Dry', right: 'Playful' },
     ];
     el.innerHTML = `<p class="panel-desc">Adjust how Chalie communicates. Changes take effect on the next message.</p>
-    <div class="personality-grid">${sliders.map(s => `<div class="personality-row">
-      <span class="pole pole-left">${s.left}</span>
-      <div class="personality-track">
-        <label class="personality-label">${s.key.charAt(0).toUpperCase() + s.key.slice(1)}</label>
+    <div class="personality-grid">${sliders.map(s => `<div class="personality-field">
+      <label class="personality-label">${s.key.charAt(0).toUpperCase() + s.key.slice(1)}</label>
+      <div class="personality-row">
+        <span class="pole pole-left">${s.left}</span>
         <input type="range" min="-2" max="2" step="1" value="${_personality[s.key] || 0}" data-key="${s.key}" class="personality-range">
+        <span class="pole pole-right">${s.right}</span>
       </div>
-      <span class="pole pole-right">${s.right}</span>
     </div>`).join('')}</div>
     <div class="personality-actions">
       <button class="btn btn-primary" id="savePersonalityBtn">Save</button>

--- a/frontend/brain/skills.js
+++ b/frontend/brain/skills.js
@@ -304,7 +304,7 @@ const PanelSkills = (() => {
     el.innerHTML = `
       <div class="provider-form-page">
         <div class="form-page-header">
-          <button class="btn btn-secondary btn-sm" id="backToSkills">${Icons.Chevron(14)} Back</button>
+          <button class="btn btn-secondary btn-sm back-btn" id="backToSkills">${Icons.Chevron(14)} Back</button>
           <h3>New Skill</h3>
         </div>
         <form id="createSkillForm">

--- a/frontend/brain/style.css
+++ b/frontend/brain/style.css
@@ -133,8 +133,8 @@ body::before {
 
 .sidebar-brand {
   display: flex; align-items: center; gap: 10px;
-  padding: 14px 16px; border-bottom: 1px solid var(--border);
-  min-height: var(--topbar-h);
+  height: var(--topbar-h); padding: 0 16px;
+  border-bottom: 1px solid var(--border);
   text-decoration: none; color: inherit;
 }
 .sidebar-brand img { width: 28px; height: 28px; border-radius: 6px; }
@@ -262,6 +262,9 @@ body::before {
   opacity: 0.5;
 }
 .panel-header h2 { margin: 0; font-size: 20px; font-weight: 600; letter-spacing: -0.01em; }
+/* Only icon-bearing headers (Skills, Import/Export) need flex to vertically
+   center the inline icon against the text; text-only headers stay in block flow. */
+.panel-header h2:has(svg) { display: flex; align-items: center; gap: 8px; }
 .panel-header-actions { display: flex; align-items: center; gap: 10px; }
 .panel-desc { color: var(--text-secondary); font-size: 13px; margin: 0 0 20px; line-height: 1.5; }
 
@@ -303,6 +306,7 @@ body::before {
 .btn-danger:hover { background: rgba(251,113,133,0.08); border-color: rgba(251,113,133,0.5); }
 
 /* ── Filter tabs ──────────────────────────────────────────────── */
+/* NB: inside .records-controls this bottom margin is reset to 0 — see the scoped override below. */
 .filter-tabs {
   display: flex; gap: 4px; margin-bottom: 16px;
   padding: 3px; background: var(--bg-surface); border-radius: 10px;
@@ -447,6 +451,9 @@ input[type="checkbox"]:checked::after {
 .val-cell { max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .row-actions { white-space: nowrap; }
 .records-controls { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 16px; flex-wrap: wrap; }
+/* Inside the controls row, filter-tabs must not carry their standalone bottom margin
+   (it mis-centers them ~8px against the search input). Base margin is load-bearing in the usage view, so scope the reset here. */
+.records-controls .filter-tabs { margin-bottom: 0; }
 .records-footer { display: flex; justify-content: center; padding: 12px 0; }
 
 /* ── Stat cards ───────────────────────────────────────────────── */
@@ -671,7 +678,7 @@ input[type="checkbox"]:checked::after {
 .provider-form-page { max-width: 560px; }
 .form-page-header { display: flex; align-items: center; gap: 12px; margin-bottom: 20px; }
 .form-page-header h3 { margin: 0; font-size: 18px; font-weight: 600; }
-.form-page-header .back-btn svg { transform: rotate(90deg); }
+.form-page-header .back-btn svg { transform: rotate(180deg); }
 .switch-label { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text-secondary); cursor: pointer; }
 
 /* ── Provider setup wizard ───────────────────────────────────── */
@@ -749,14 +756,14 @@ input[type="checkbox"]:checked::after {
 
 /* ── Personality sliders ──────────────────────────────────────── */
 .personality-grid { display: flex; flex-direction: column; gap: 16px; margin-bottom: 20px; }
+.personality-field { display: flex; flex-direction: column; gap: 6px; }
 .personality-row { display: flex; align-items: center; gap: 12px; }
 .pole { font-size: 12px; color: var(--text-secondary); width: 90px; }
 .pole-left { text-align: right; }
 .pole-right { text-align: left; }
-.personality-track { flex: 1; }
-.personality-label { display: block; font-size: 11px; font-weight: 600; color: var(--text-tertiary); margin-bottom: 4px; }
+.personality-label { font-size: 11px; font-weight: 600; color: var(--text-tertiary); }
 .personality-range {
-  width: 100%; height: 4px; -webkit-appearance: none; appearance: none;
+  flex: 1; height: 4px; -webkit-appearance: none; appearance: none;
   background: var(--bg-surface-2); border-radius: 2px; outline: none;
 }
 .personality-range::-webkit-slider-thumb {
@@ -823,7 +830,7 @@ input[type="checkbox"]:checked::after {
   display: flex; align-items: center; justify-content: space-between;
   gap: 8px; margin-bottom: 8px;
 }
-.mcp-out-name { font-size: 13px; font-weight: 600; color: var(--text-1); }
+.mcp-out-name { font-size: 13px; font-weight: 600; color: var(--text-primary); }
 .mcp-out-host { font-size: 12px; color: var(--text-secondary); }
 .mcp-out-badges { display: flex; gap: 6px; flex-shrink: 0; }
 .mcp-out-card-actions { display: flex; gap: 6px; flex-wrap: wrap; }
@@ -848,8 +855,8 @@ input[type="checkbox"]:checked::after {
 }
 .form-input {
   width: 100%; padding: 7px 10px; border-radius: 6px; font-size: 13px;
-  background: var(--bg-1); border: 1px solid var(--border);
-  color: var(--text-1); box-sizing: border-box;
+  background: var(--bg-input); border: 1px solid var(--border);
+  color: var(--text-primary); box-sizing: border-box;
 }
 .form-input:focus { outline: none; border-color: var(--violet); }
 
@@ -925,7 +932,7 @@ input[type="checkbox"]:checked::after {
 
 /* ── Error list ───────────────────────────────────────────────── */
 .error-list { display: flex; flex-direction: column; gap: 4px; }
-.error-item { padding: 10px 14px; gap: 10px; }
+.error-item { padding: 10px 14px; gap: 10px; align-items: flex-start; }
 .error-time { font-size: 11px; color: var(--text-tertiary); white-space: nowrap; flex-shrink: 0; font-family: 'Inter', monospace; }
 .error-msg { font-size: 13px; color: var(--text-secondary); }
 
@@ -1090,7 +1097,7 @@ input[type="checkbox"]:checked::after {
   font-size: 12px;
   line-height: 1.6;
   color: var(--text-secondary);
-  background: var(--bg-secondary);
+  background: var(--bg-surface-2);
   border: 1px solid var(--border);
   border-radius: 6px;
   padding: 12px;


### PR DESCRIPTION
## Summary

Micro-alignment polish across the Brain admin UI, using **TKT-587** (sidebar/topbar logo height mismatch) as the umbrella to sweep the small "things don't quite line up" issues throughout the dashboard — misaligned icons, a rotated chevron, and uneven spacing.

## Fixes

| # | Area | Before → After |
|---|------|----------------|
| 1 | Sidebar brand (TKT-587) | Logo block rendered ~70px, overhanging the 56px topbar by ~15px on every route → pinned to `--topbar-h` so its divider lines up with the topbar border |
| 2 | Panel headers | Inline header icons (Skills, Import/Export) sat on the text baseline → scoped a `flex`/center rule to icon-bearing headers via `:has(svg)`; text-only headers untouched |
| 3 | Back buttons | Chevrons were rotated 90° (pointing **down**) → rotated 180° (pointing **left**) across all seven back buttons |
| 4 | Skills "Back" | Missing the `.back-btn` class (the only inconsistent one of seven) → added, so it shares the chevron styling |
| 5 | Personality sliders | Pole labels (Cool/Warm…) floated above the slider line → trait label lifted into its own row so the poles center exactly on the slider |
| 6 | Errors list | Timestamp was vertically centered against multi-line messages → top-aligned to the first line |
| 7 | Memory controls | Filter tabs sat ~8px below the search input → bottom margin reset inside the controls row (scoped; the base margin is preserved for the Usage view) |
| 8 | Skill content preview | Used an undefined CSS var → rendered transparent → now uses the defined `--bg-surface-2` |
| 9 | CSS hygiene | Replaced remaining undefined vars (`--text-1`, `--bg-1`) with defined equivalents (no visual change) |

## Scope & safety

- **Frontend-only** — `frontend/brain/{style.css, skills.js, cognition.js}`, +24/−17.
- **Both dark and light themes** preserved; every change is layout-only or uses existing `theme.css` tokens.
- The icon-header rule is scoped via `:has(svg)` so the nine text-only headers render byte-identically to before.

## Verification

Rendered in a fresh instance built from this branch and checked in both dark and light themes:

- `.sidebar-brand` measured at **56px** — exactly `--topbar-h` (was ~70px).
- Personality pole ↔ slider vertical-center delta = **0px** on all five rows.
- Back-chevron computed transform = `matrix(-1,0,0,-1,0,0)` (rotate 180°, left-pointing).
- Filter-tab / search baseline, errors timestamp top-alignment, and the filled skill-preview panel confirmed visually in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
