### PR TITLE
P0 — Vue 3 frontend foundation (TKT-952)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,9 +67,7 @@ docs/superpowers/
 backend/docs/superpowers/
 
 # Vue frontend workspace
-frontend/node_modules/
-frontend/**/node_modules/
 frontend/**/dist/
 frontend/apps/*/test-results/
 frontend/apps/*/playwright-report/
-frontend/.auth/
+frontend/**/.auth/

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,11 @@ backend/.simplify_test_results.xml*
 # Superpowers dev plans/specs — local planning notes, never committed
 docs/superpowers/
 backend/docs/superpowers/
+
+# Vue frontend workspace
+frontend/node_modules/
+frontend/**/node_modules/
+frontend/**/dist/
+frontend/apps/*/test-results/
+frontend/apps/*/playwright-report/
+frontend/.auth/

--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -287,6 +287,31 @@ def _register_static_routes(app: Flask) -> None:
         """Serve login page."""
         return _serve_versioned_html(_LOGIN_DIR)
 
+    # ── Vue build coexistence (P0 migration) ─────────────────────────
+    # Vite content-hashes its own assets, so this build is served verbatim —
+    # it deliberately bypasses the legacy regex version-injection. Old static
+    # apps keep serving from their existing routes until cutover (P3).
+    _NEXT_INTERFACE_DIR = FileMapperService.get_frontend_path("apps", "interface", "dist")
+
+    @app.route('/next', methods=["GET"])
+    def next_interface_index_no_slash():
+        """Canonicalize /next → /next/ so the bare path isn't swallowed by the
+        legacy catch-all (which would silently serve the old interface)."""
+        return redirect('/next/', code=301)
+
+    @app.route('/next/', methods=["GET"])
+    def next_interface_index():
+        """Serve the Vue interface build index."""
+        return send_from_directory(str(_NEXT_INTERFACE_DIR), 'index.html')
+
+    @app.route('/next/<path:filename>', methods=["GET"])
+    def next_interface_static(filename):
+        """Serve a Vue build asset, or fall back to index.html (SPA history mode)."""
+        candidate = _NEXT_INTERFACE_DIR / filename
+        if candidate.is_file():
+            return send_from_directory(str(_NEXT_INTERFACE_DIR), filename)
+        return send_from_directory(str(_NEXT_INTERFACE_DIR), 'index.html')
+
     # Main interface SPA — catch-all (must be last)
     @app.route('/<path:filename>', methods=["GET"])
     def interface_static(filename):

--- a/backend/tests/test_next_static_serving.py
+++ b/backend/tests/test_next_static_serving.py
@@ -1,0 +1,81 @@
+"""Feature test: the Vue interface build is served at /next/ alongside legacy static.
+
+Real Flask app, real on-disk dist. No mocks.
+"""
+import pytest
+from services.file_mapper_service import FileMapperService
+
+
+@pytest.fixture
+def built_dist():
+    """Provide a minimal Vite-style dist for the route to serve, restoring any
+    real on-disk build afterward so the test never clobbers build output.
+
+    The route hardcodes the FileMapperService dist path, so the fixture writes
+    into the real dir (no monkeypatching / no mocks) and reverts on teardown.
+    """
+    dist = FileMapperService.get_frontend_path("apps", "interface", "dist")
+    assets = dist / "assets"
+    assets.mkdir(parents=True, exist_ok=True)
+    index = dist / "index.html"
+    app_js = assets / "app.js"
+    original_index = index.read_bytes() if index.exists() else None
+    app_js_preexisting = app_js.exists()
+    index.write_text(
+        '<!doctype html><html><body><div id="app"></div>'
+        '<script type="module" src="/next/assets/app.js"></script></body></html>',
+        encoding="utf-8",
+    )
+    app_js.write_text("export const ok = true;\n", encoding="utf-8")
+    try:
+        yield dist
+    finally:
+        if original_index is not None:
+            index.write_bytes(original_index)
+        else:
+            index.unlink(missing_ok=True)
+        if not app_js_preexisting:
+            app_js.unlink(missing_ok=True)
+
+
+def test_next_serves_index_and_hashed_asset(built_dist):
+    from api import create_app
+
+    app = create_app()
+    client = app.test_client()
+
+    # index.html at the mount root
+    r = client.get("/next/")
+    assert r.status_code == 200
+    assert b'<div id="app">' in r.data
+    # NOT version-injected — the asset ref stays exactly as Vite emitted it
+    assert b'/next/assets/app.js' in r.data
+
+    # hashed asset served verbatim with a JS mimetype
+    r = client.get("/next/assets/app.js")
+    assert r.status_code == 200
+    assert "javascript" in r.headers["Content-Type"]
+
+    # SPA fallback: unknown deep link returns index.html, not 404
+    r = client.get("/next/some/deep/link")
+    assert r.status_code == 200
+    assert b'<div id="app">' in r.data
+
+
+def test_next_bare_path_redirects_to_trailing_slash():
+    """Bare /next must 301 to /next/ — not fall through to the legacy catch-all."""
+    from api import create_app
+
+    app = create_app()
+    r = app.test_client().get("/next")
+    assert r.status_code == 301
+    assert r.headers["Location"].endswith("/next/")
+
+
+def test_legacy_interface_root_still_served():
+    """Coexistence: the old hand-rolled interface index still serves at '/'."""
+    from api import create_app
+
+    app = create_app()
+    r = app.test_client().get("/")
+    assert r.status_code == 200

--- a/frontend/.prettierrc.json
+++ b/frontend/.prettierrc.json
@@ -1,0 +1,1 @@
+{ "semi": true, "singleQuote": true, "printWidth": 100, "trailingComma": "all" }

--- a/frontend/apps/brain/env.d.ts
+++ b/frontend/apps/brain/env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue';
+  const component: DefineComponent<Record<string, never>, Record<string, never>, unknown>;
+  export default component;
+}

--- a/frontend/apps/brain/index.html
+++ b/frontend/apps/brain/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chalie · Brain</title>
+    <script>
+      // Theme bootstrap — runs before paint to avoid a dark→light flash on
+      // light-mode preference. Honours saved choice; falls back to system.
+      (function () {
+        function pickTheme(saved) {
+          if (saved === 'light' || saved === 'dark') return saved;
+          return globalThis.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+        }
+        try {
+          var saved = localStorage.getItem('chalie-theme');
+          document.documentElement.dataset.theme = pickTheme(saved);
+        } catch (err) {
+          console.warn('theme-persist failed', err);
+          document.documentElement.dataset.theme = 'dark';
+        }
+      })();
+    </script>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/apps/brain/package.json
+++ b/frontend/apps/brain/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@chalie/brain",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc --noEmit && vite build",
+    "preview": "vite preview",
+    "typecheck": "vue-tsc --noEmit"
+  },
+  "dependencies": {
+    "@chalie/shared": "workspace:*",
+    "pinia": "^2.2.0",
+    "vue": "^3.5.0",
+    "vue-router": "^4.4.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.1.0",
+    "vite": "^5.4.0",
+    "vue-tsc": "^2.1.0"
+  }
+}

--- a/frontend/apps/brain/src/App.vue
+++ b/frontend/apps/brain/src/App.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useTheme } from '@chalie/shared';
+const { init } = useTheme();
+onMounted(() => init());
+</script>
+
+<template>
+  <main style="padding: 2rem">
+    <h1>Brain — Vue scaffold</h1>
+    <p>Panels migrate in P2 (TKT-954).</p>
+  </main>
+</template>

--- a/frontend/apps/brain/src/main.ts
+++ b/frontend/apps/brain/src/main.ts
@@ -1,0 +1,6 @@
+import { createApp } from 'vue';
+import { createPinia } from 'pinia';
+import App from './App.vue';
+import '@chalie/shared/styles/main.scss';
+
+createApp(App).use(createPinia()).mount('#app');

--- a/frontend/apps/brain/tsconfig.json
+++ b/frontend/apps/brain/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["vite/client"],
+    "paths": { "@chalie/shared": ["../../packages/shared/src/index.ts"] }
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue", "env.d.ts"]
+}

--- a/frontend/apps/brain/vite.config.ts
+++ b/frontend/apps/brain/vite.config.ts
@@ -1,0 +1,19 @@
+import { fileURLToPath, URL } from 'node:url';
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  base: process.env.VITE_BASE ?? '/brain-next/',
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      // Alias to the package SOURCE DIR (not index.ts): a file-pointing string
+      // alias prefix-matches subpaths, so `@chalie/shared/styles/main.scss` would
+      // become `…/index.ts/styles/main.scss`. Pointing at the dir lets the bare
+      // import resolve via directory-index (→ src/index.ts) while subpath imports
+      // (the SCSS theme) resolve as real files (→ src/styles/main.scss).
+      '@chalie/shared': fileURLToPath(new URL('../../packages/shared/src', import.meta.url)),
+    },
+  },
+  build: { outDir: 'dist', emptyOutDir: true },
+});

--- a/frontend/apps/brain/vite.config.ts
+++ b/frontend/apps/brain/vite.config.ts
@@ -15,5 +15,10 @@ export default defineConfig({
       '@chalie/shared': fileURLToPath(new URL('../../packages/shared/src', import.meta.url)),
     },
   },
+  css: {
+    // Modern Sass compiler API — silences the Dart Sass legacy-js-api deprecation
+    // (which becomes a hard error at Dart Sass 2.0).
+    preprocessorOptions: { scss: { api: 'modern-compiler' } },
+  },
   build: { outDir: 'dist', emptyOutDir: true },
 });

--- a/frontend/apps/interface/.gitignore
+++ b/frontend/apps/interface/.gitignore
@@ -1,0 +1,4 @@
+.auth/
+test-results/
+playwright-report/
+.playwright/

--- a/frontend/apps/interface/env.d.ts
+++ b/frontend/apps/interface/env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue';
+  const component: DefineComponent<Record<string, never>, Record<string, never>, unknown>;
+  export default component;
+}

--- a/frontend/apps/interface/index.html
+++ b/frontend/apps/interface/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chalie</title>
+    <script>
+      // Theme bootstrap — runs before paint to avoid a dark→light flash on
+      // light-mode preference. Honours saved choice; falls back to system.
+      (function () {
+        function pickTheme(saved) {
+          if (saved === 'light' || saved === 'dark') return saved;
+          return globalThis.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+        }
+        try {
+          var saved = localStorage.getItem('chalie-theme');
+          document.documentElement.dataset.theme = pickTheme(saved);
+        } catch (err) {
+          console.warn('theme-persist failed', err);
+          document.documentElement.dataset.theme = 'dark';
+        }
+      })();
+    </script>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/apps/interface/package.json
+++ b/frontend/apps/interface/package.json
@@ -17,6 +17,7 @@
     "vue-router": "^4.4.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@vitejs/plugin-vue": "^5.1.0",
     "vite": "^5.4.0",
     "vue-tsc": "^2.1.0"

--- a/frontend/apps/interface/package.json
+++ b/frontend/apps/interface/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@chalie/interface",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc --noEmit && vite build",
+    "preview": "vite preview",
+    "typecheck": "vue-tsc --noEmit",
+    "test": "playwright test"
+  },
+  "dependencies": {
+    "@chalie/shared": "workspace:*",
+    "pinia": "^2.2.0",
+    "vue": "^3.5.0",
+    "vue-router": "^4.4.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.1.0",
+    "vite": "^5.4.0",
+    "vue-tsc": "^2.1.0"
+  }
+}

--- a/frontend/apps/interface/playwright.config.ts
+++ b/frontend/apps/interface/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+const BASE = process.env.CHALIE_BASE_URL;
+if (!BASE) throw new Error('CHALIE_BASE_URL must point at a running Chalie instance');
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  globalSetup: './tests/global-setup.ts',
+  // retain-on-failure (not on-first-retry): retries default to 0 — we want the
+  // trace on the very first failure, and retries would mask real flakiness.
+  use: { baseURL: BASE, storageState: '.auth/state.json', trace: 'retain-on-failure' },
+  reporter: [['list'], ['html', { open: 'never' }]],
+});

--- a/frontend/apps/interface/src/App.vue
+++ b/frontend/apps/interface/src/App.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useTheme } from '@chalie/shared';
+
+const { init } = useTheme();
+onMounted(() => init());
+</script>
+
+<template>
+  <RouterView />
+</template>

--- a/frontend/apps/interface/src/main.ts
+++ b/frontend/apps/interface/src/main.ts
@@ -1,0 +1,7 @@
+import { createApp } from 'vue';
+import { createPinia } from 'pinia';
+import App from './App.vue';
+import { router } from './router';
+import '@chalie/shared/styles/main.scss';
+
+createApp(App).use(createPinia()).use(router).mount('#app');

--- a/frontend/apps/interface/src/router.ts
+++ b/frontend/apps/interface/src/router.ts
@@ -1,0 +1,7 @@
+import { createRouter, createWebHistory } from 'vue-router';
+import HomeView from './views/HomeView.vue';
+
+export const router = createRouter({
+  history: createWebHistory(import.meta.env.BASE_URL),
+  routes: [{ path: '/', name: 'home', component: HomeView }],
+});

--- a/frontend/apps/interface/src/views/HomeView.vue
+++ b/frontend/apps/interface/src/views/HomeView.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import {
+  ApiClient,
+  getHost,
+  useTheme,
+  useWebSocket,
+  BaseButton,
+  BaseCard,
+  BaseField,
+} from '@chalie/shared';
+
+const { theme, toggle } = useTheme();
+const { connected } = useWebSocket();
+const api = new ApiClient(getHost);
+const ready = ref<string>('checking…');
+const note = ref('');
+
+onMounted(async () => {
+  const r = await api.ready();
+  ready.value = r.ready ? 'ready' : 'not-ready';
+});
+</script>
+
+<template>
+  <main data-testid="home" style="max-width: 640px; margin: 2rem auto; padding: 0 1rem">
+    <BaseCard title="Chalie — Vue foundation">
+      <p>
+        Theme: <strong data-testid="theme">{{ theme }}</strong>
+      </p>
+      <p>
+        WebSocket: <strong data-testid="ws-status">{{ connected ? 'connected' : 'disconnected' }}</strong>
+      </p>
+      <p>
+        Backend: <strong data-testid="ready">{{ ready }}</strong>
+      </p>
+      <BaseField v-model="note" data-testid="note" label="Scratch note" placeholder="type…" />
+      <div style="display: flex; gap: 0.5rem; margin-top: 1rem">
+        <BaseButton data-testid="toggle-theme" @click="toggle">Toggle theme</BaseButton>
+        <BaseButton variant="ghost">Ghost</BaseButton>
+      </div>
+    </BaseCard>
+  </main>
+</template>

--- a/frontend/apps/interface/tests/api-client.spec.ts
+++ b/frontend/apps/interface/tests/api-client.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test('backend readiness resolves through the typed ApiClient', async ({ page }) => {
+  await page.goto('/next/');
+  await expect(page.getByTestId('ready')).toHaveText('ready', { timeout: 15_000 });
+});
+
+test('unauthenticated API call is rejected (401)', async ({ page }) => {
+  await page.goto('/next/');
+  const status = await page.evaluate(async () => {
+    const r = await fetch('/conversation/recent?limit=1', { credentials: 'omit' });
+    return r.status;
+  });
+  expect(status).toBe(401);
+});

--- a/frontend/apps/interface/tests/global-setup.ts
+++ b/frontend/apps/interface/tests/global-setup.ts
@@ -1,0 +1,15 @@
+import { request } from '@playwright/test';
+import { mkdirSync } from 'node:fs';
+
+export default async function globalSetup(): Promise<void> {
+  const baseURL = process.env.CHALIE_BASE_URL!;
+  const username = process.env.CHALIE_TEST_USERNAME ?? 'admin';
+  const password = process.env.CHALIE_TEST_PASSWORD;
+  if (!password) throw new Error('CHALIE_TEST_PASSWORD must be set for the auth fixture');
+  const ctx = await request.newContext({ baseURL });
+  const res = await ctx.post('/auth/login', { data: { username, password } });
+  if (!res.ok()) throw new Error(`Login failed: ${res.status()} ${await res.text()}`);
+  mkdirSync('.auth', { recursive: true });
+  await ctx.storageState({ path: '.auth/state.json' });
+  await ctx.dispose();
+}

--- a/frontend/apps/interface/tests/smoke.spec.ts
+++ b/frontend/apps/interface/tests/smoke.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+test('boots and renders the Vue foundation home', async ({ page }) => {
+  await page.goto('/next/');
+  const home = page.getByTestId('home');
+  await expect(home).toBeVisible();
+  await expect(home).toContainText('Vue foundation');
+});
+
+test('theme toggles dark↔light and persists across reload', async ({ page }) => {
+  await page.goto('/next/');
+  await page.evaluate(() => localStorage.setItem('chalie-theme', 'dark'));
+  await page.reload();
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+  const darkBg = await page.evaluate(() => getComputedStyle(document.body).backgroundColor);
+
+  await page.getByTestId('toggle-theme').click();
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+  await expect(page.getByTestId('theme')).toHaveText('light');
+  const lightBg = await page.evaluate(() => getComputedStyle(document.body).backgroundColor);
+  // Inequality only — body has a 420ms background-color transition, so this read
+  // may land mid-interpolation. Do NOT harden to an exact value or it will flake.
+  expect(darkBg).not.toBe(lightBg);
+
+  await page.reload();
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+});
+
+test('base components render and accept input', async ({ page }) => {
+  await page.goto('/next/');
+  await expect(page.getByTestId('toggle-theme')).toBeVisible();
+  const note = page.getByTestId('note').locator('input');
+  await note.fill('hello');
+  await expect(note).toHaveValue('hello');
+});

--- a/frontend/apps/interface/tests/websocket.spec.ts
+++ b/frontend/apps/interface/tests/websocket.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('websocket connects and the status reflects it', async ({ page }) => {
+  await page.goto('/next/');
+  await expect(page.getByTestId('ws-status')).toHaveText('connected', { timeout: 15_000 });
+});
+
+test('a websocket handshake to /ws occurs on load', async ({ page }) => {
+  const wsPromise = page.waitForEvent('websocket');
+  await page.goto('/next/');
+  const ws = await wsPromise;
+  expect(ws.url()).toContain('/ws');
+});

--- a/frontend/apps/interface/tsconfig.json
+++ b/frontend/apps/interface/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["vite/client"],
+    "paths": { "@chalie/shared": ["../../packages/shared/src/index.ts"] }
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue", "env.d.ts"]
+}

--- a/frontend/apps/interface/vite.config.ts
+++ b/frontend/apps/interface/vite.config.ts
@@ -16,6 +16,11 @@ export default defineConfig({
       '@chalie/shared': fileURLToPath(new URL('../../packages/shared/src', import.meta.url)),
     },
   },
+  css: {
+    // Modern Sass compiler API — silences the Dart Sass legacy-js-api deprecation
+    // (which becomes a hard error at Dart Sass 2.0).
+    preprocessorOptions: { scss: { api: 'modern-compiler' } },
+  },
   build: {
     outDir: 'dist',
     emptyOutDir: true,

--- a/frontend/apps/interface/vite.config.ts
+++ b/frontend/apps/interface/vite.config.ts
@@ -1,0 +1,23 @@
+import { fileURLToPath, URL } from 'node:url';
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+// Served by Flask under /next/ during coexistence (P3 flips this to '/').
+export default defineConfig({
+  base: process.env.VITE_BASE ?? '/next/',
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      // Alias to the package SOURCE DIR (not index.ts): a file-pointing string
+      // alias prefix-matches subpaths, so `@chalie/shared/styles/main.scss` would
+      // become `…/index.ts/styles/main.scss`. Pointing at the dir lets the bare
+      // import resolve via directory-index (→ src/index.ts) while subpath imports
+      // (the SCSS theme) resolve as real files (→ src/styles/main.scss).
+      '@chalie/shared': fileURLToPath(new URL('../../packages/shared/src', import.meta.url)),
+    },
+  },
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+});

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,6 +1,7 @@
 import js from '@eslint/js';
 import vue from 'eslint-plugin-vue';
 import vueTs from '@vue/eslint-config-typescript';
+import eslintConfigPrettier from 'eslint-config-prettier';
 
 export default [
   {
@@ -25,4 +26,5 @@ export default [
       'vue/multi-word-component-names': 'off',
     },
   },
+  eslintConfigPrettier,
 ];

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,28 @@
+import js from '@eslint/js';
+import vue from 'eslint-plugin-vue';
+import vueTs from '@vue/eslint-config-typescript';
+
+export default [
+  {
+    ignores: [
+      '**/dist/**',
+      '**/node_modules/**',
+      '**/playwright-report/**',
+      '**/test-results/**',
+      // Legacy hand-rolled JS files — not part of the Vue migration
+      'brain/**',
+      'interface/**',
+      'login/**',
+      'on-boarding/**',
+      'shared/**',
+    ],
+  },
+  js.configs.recommended,
+  ...vue.configs['flat/recommended'],
+  ...vueTs(),
+  {
+    rules: {
+      'vue/multi-word-component-names': 'off',
+    },
+  },
+];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "test:interface": "pnpm --filter @chalie/interface test"
   },
   "devDependencies": {
+    "@eslint/js": "^9.13.0",
     "@playwright/test": "^1.48.0",
     "@vue/eslint-config-typescript": "^14.1.0",
     "eslint": "^9.13.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "chalie-frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "engines": { "node": ">=20" },
+  "scripts": {
+    "dev:interface": "pnpm --filter @chalie/interface dev",
+    "dev:brain": "pnpm --filter @chalie/brain dev",
+    "build": "pnpm -r build",
+    "typecheck": "pnpm -r typecheck",
+    "lint": "eslint .",
+    "format": "prettier --write .",
+    "test:interface": "pnpm --filter @chalie/interface test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.0",
+    "@vue/eslint-config-typescript": "^14.1.0",
+    "eslint": "^9.13.0",
+    "eslint-plugin-vue": "^9.30.0",
+    "prettier": "^3.3.3",
+    "sass": "^1.80.0",
+    "typescript": "^5.6.0",
+    "vite": "^5.4.0",
+    "vue-tsc": "^2.1.0"
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@playwright/test": "^1.48.0",
     "@vue/eslint-config-typescript": "^14.1.0",
     "eslint": "^9.13.0",
+    "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-vue": "^9.30.0",
     "prettier": "^3.3.3",
     "sass": "^1.80.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "engines": { "node": ">=20" },
+  "engines": { "node": ">=22.13" },
   "scripts": {
     "dev:interface": "pnpm --filter @chalie/interface dev",
     "dev:brain": "pnpm --filter @chalie/brain dev",

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@chalie/shared",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./styles/main.scss": "./src/styles/main.scss",
+    "./styles/*": "./src/styles/*"
+  },
+  "scripts": {
+    "typecheck": "vue-tsc --noEmit -p tsconfig.json"
+  },
+  "peerDependencies": {
+    "pinia": "^2.2.0",
+    "vue": "^3.5.0"
+  },
+  "devDependencies": {
+    "pinia": "^2.2.0",
+    "vue": "^3.5.0"
+  }
+}

--- a/frontend/packages/shared/src/composables/useTheme.ts
+++ b/frontend/packages/shared/src/composables/useTheme.ts
@@ -1,0 +1,8 @@
+import { storeToRefs } from 'pinia';
+import { useThemeStore } from '../stores/theme';
+
+export function useTheme() {
+  const store = useThemeStore();
+  const { theme } = storeToRefs(store);
+  return { theme, setTheme: store.setTheme, toggle: store.toggle, init: store.init };
+}

--- a/frontend/packages/shared/src/composables/useWebSocket.ts
+++ b/frontend/packages/shared/src/composables/useWebSocket.ts
@@ -1,0 +1,33 @@
+import { onMounted } from 'vue';
+import { storeToRefs } from 'pinia';
+import { WebSocketService } from '../services/WebSocketService';
+import { getHost } from '../config/host';
+import { useConnectionStore } from '../stores/connection';
+
+let service: WebSocketService | null = null;
+let focusBound = false;
+
+/** Process-wide singleton so every view shares one socket. */
+export function getWebSocket(): WebSocketService {
+  if (!service) service = new WebSocketService(getHost);
+  return service;
+}
+
+export function useWebSocket() {
+  const ws = getWebSocket();
+  const conn = useConnectionStore();
+  const { connected } = storeToRefs(conn);
+
+  onMounted(() => {
+    ws.onDisconnect(() => conn.setConnected(false));
+    ws.onAny(() => conn.setConnected(ws.isConnected));
+    ws.connect();
+    conn.setConnected(ws.isConnected);
+    if (!focusBound) {
+      focusBound = true;
+      globalThis.addEventListener('focus', () => ws.ensureAlive());
+    }
+  });
+
+  return { ws, connected };
+}

--- a/frontend/packages/shared/src/composables/useWebSocket.ts
+++ b/frontend/packages/shared/src/composables/useWebSocket.ts
@@ -21,6 +21,7 @@ export function useWebSocket() {
   onMounted(() => {
     ws.onDisconnect(() => conn.setConnected(false));
     ws.onAny(() => conn.setConnected(ws.isConnected));
+    ws.onConnect(() => conn.setConnected(ws.isConnected));
     ws.connect();
     conn.setConnected(ws.isConnected);
     if (!focusBound) {

--- a/frontend/packages/shared/src/config/host.ts
+++ b/frontend/packages/shared/src/config/host.ts
@@ -1,0 +1,20 @@
+const HOST_KEY = 'chalie_backend_host';
+
+/** Returns the configured backend host, or '' for same-origin. */
+export function getHost(): string {
+  try {
+    return localStorage.getItem(HOST_KEY) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+/** Persist (or clear, when empty) the backend host override. */
+export function setHost(host: string): void {
+  try {
+    if (host) localStorage.setItem(HOST_KEY, host);
+    else localStorage.removeItem(HOST_KEY);
+  } catch {
+    /* storage unavailable — fall back to same-origin */
+  }
+}

--- a/frontend/packages/shared/src/index.ts
+++ b/frontend/packages/shared/src/index.ts
@@ -1,5 +1,23 @@
-// Barrel export for @chalie/shared.
-// Placeholder until Task 7 populates the public API (services, stores,
-// composables, base UI components). It exists now so the package.json
-// `exports["."]` entrypoint resolves from Task 4 onward.
-export {};
+export { ApiClient, AuthError, HttpError } from './services/ApiClient';
+export type { GetHost } from './services/types';
+export { WebSocketService } from './services/WebSocketService';
+export type {
+  WsInboundEvent,
+  WsPushEvent,
+  WsPushType,
+  ChatCallbacks,
+  ActionCallbacks,
+} from './services/WebSocketService';
+export { getHost, setHost } from './config/host';
+export type { PlatformAdapter } from './platform/PlatformAdapter';
+export { webPlatformAdapter } from './platform/webPlatformAdapter';
+export { useThemeStore } from './stores/theme';
+export type { Theme } from './stores/theme';
+export { useConnectionStore } from './stores/connection';
+export { useTheme } from './composables/useTheme';
+export { useWebSocket, getWebSocket } from './composables/useWebSocket';
+export { default as BaseButton } from './ui/BaseButton.vue';
+export { default as BaseCard } from './ui/BaseCard.vue';
+export { default as BaseField } from './ui/BaseField.vue';
+export { default as BaseModal } from './ui/BaseModal.vue';
+export { default as BaseTooltip } from './ui/BaseTooltip.vue';

--- a/frontend/packages/shared/src/index.ts
+++ b/frontend/packages/shared/src/index.ts
@@ -1,0 +1,5 @@
+// Barrel export for @chalie/shared.
+// Placeholder until Task 7 populates the public API (services, stores,
+// composables, base UI components). It exists now so the package.json
+// `exports["."]` entrypoint resolves from Task 4 onward.
+export {};

--- a/frontend/packages/shared/src/platform/PlatformAdapter.ts
+++ b/frontend/packages/shared/src/platform/PlatformAdapter.ts
@@ -1,0 +1,29 @@
+/**
+ * The single seam between Chalie's UI and host-platform capabilities.
+ * Web ships the only implementation in P0; a later epic adds capacitor/tauri
+ * impls so the interface app can be wrapped natively without touching callers.
+ */
+export interface PlatformAdapter {
+  // Audio capture / playback (voice_recorder, voice_player)
+  getUserMedia(constraints: MediaStreamConstraints): Promise<MediaStream>;
+  createAudioContext(): AudioContext;
+
+  // Notifications (notifications.js)
+  notificationPermission(): NotificationPermission;
+  requestNotificationPermission(): Promise<NotificationPermission>;
+  showNotification(title: string, options?: NotificationOptions): void;
+
+  // Geolocation (heartbeat / ambient)
+  getCurrentPosition(options?: PositionOptions): Promise<GeolocationPosition>;
+
+  // Files (image_attach, document_upload)
+  readFileAsDataURL(file: File): Promise<string>;
+
+  // Key/value storage
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+
+  // Navigation — web opens a tab; native opens an in-app webview (later epic)
+  openBrain(): void;
+}

--- a/frontend/packages/shared/src/platform/webPlatformAdapter.ts
+++ b/frontend/packages/shared/src/platform/webPlatformAdapter.ts
@@ -1,0 +1,64 @@
+import type { PlatformAdapter } from './PlatformAdapter';
+
+export const webPlatformAdapter: PlatformAdapter = {
+  getUserMedia: (constraints) =>
+    // navigator.mediaDevices is undefined in non-secure (HTTP) contexts; guard so
+    // the PlatformAdapter contract (always returns a Promise) holds — a bare call
+    // would throw synchronously and escape callers' .catch() handlers.
+    navigator.mediaDevices
+      ? navigator.mediaDevices.getUserMedia(constraints)
+      : Promise.reject(
+          new DOMException('getUserMedia unavailable in non-secure context', 'NotSupportedError'),
+        ),
+  createAudioContext: () => {
+    const Ctor =
+      globalThis.AudioContext ??
+      (globalThis as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+    return new Ctor();
+  },
+  notificationPermission: () => ('Notification' in globalThis ? Notification.permission : 'denied'),
+  requestNotificationPermission: () =>
+    'Notification' in globalThis
+      ? Notification.requestPermission()
+      : Promise.resolve('denied' as NotificationPermission),
+  showNotification: (title, options) => {
+    if ('Notification' in globalThis && Notification.permission === 'granted') {
+      new Notification(title, options);
+    }
+  },
+  getCurrentPosition: (options) =>
+    new Promise((resolve, reject) =>
+      navigator.geolocation.getCurrentPosition(resolve, reject, options),
+    ),
+  readFileAsDataURL: (file) =>
+    new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = () => reject(reader.error);
+      reader.readAsDataURL(file);
+    }),
+  getItem: (key) => {
+    try {
+      return localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  },
+  setItem: (key, value) => {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      /* ignore */
+    }
+  },
+  removeItem: (key) => {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      /* ignore */
+    }
+  },
+  openBrain: () => {
+    globalThis.open('/brain/', '_blank');
+  },
+};

--- a/frontend/packages/shared/src/services/ApiClient.ts
+++ b/frontend/packages/shared/src/services/ApiClient.ts
@@ -1,0 +1,84 @@
+import type { GetHost } from './types';
+
+export class AuthError extends Error {
+  constructor() {
+    super('AUTH');
+    this.name = 'AuthError';
+  }
+}
+
+export class HttpError extends Error {
+  constructor(public readonly status: number) {
+    super(`HTTP ${status}`);
+    this.name = 'HttpError';
+  }
+}
+
+/** Centralised Chalie REST client. Configurable host; 401 → AuthError. */
+export class ApiClient {
+  constructor(private readonly getHost: GetHost) {}
+
+  private buildUrl(path: string): string {
+    const host = this.getHost();
+    return host ? host.replace(/\/$/, '') + path : path;
+  }
+
+  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const res = await fetch(this.buildUrl(path), {
+      credentials: 'same-origin',
+      ...init,
+      headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
+    });
+    if (res.status === 401) throw new AuthError();
+    if (!res.ok) throw new HttpError(res.status);
+    return (await res.json()) as T;
+  }
+
+  get<T>(path: string): Promise<T> {
+    return this.request<T>(path);
+  }
+  post<T>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>(path, { method: 'POST', body: JSON.stringify(body ?? {}) });
+  }
+  put<T>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>(path, { method: 'PUT', body: JSON.stringify(body ?? {}) });
+  }
+  async del<T>(path: string): Promise<T> {
+    const res = await fetch(this.buildUrl(path), {
+      method: 'DELETE',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    if (res.status === 401) throw new AuthError();
+    if (!res.ok) throw new HttpError(res.status);
+    return (await res.json().catch(() => ({}))) as T;
+  }
+
+  /** Multipart upload — no JSON Content-Type (browser sets the boundary). */
+  async upload<T>(path: string, formData: FormData): Promise<T> {
+    const res = await fetch(this.buildUrl(path), {
+      method: 'POST',
+      credentials: 'same-origin',
+      body: formData,
+    });
+    if (res.status === 401) throw new AuthError();
+    if (!res.ok) throw new HttpError(res.status);
+    return (await res.json()) as T;
+  }
+
+  // ── Foundation endpoints (feature endpoints added in P1/P2) ──────────────
+  health(): Promise<{ status: string } | null> {
+    return fetch(this.buildUrl('/health'), { credentials: 'same-origin' })
+      .then((r) => r.json())
+      .catch(() => null);
+  }
+  /** Never rejects. */
+  ready(): Promise<{ ready: boolean }> {
+    return fetch(this.buildUrl('/ready'), { credentials: 'same-origin' })
+      .then((r) => (r.ok ? r.json() : { ready: false }))
+      .catch(() => ({ ready: false }));
+  }
+  getSetting(key: string): Promise<{ key: string; value: string | null }> {
+    return this.get(`/system/settings/${encodeURIComponent(key)}`);
+  }
+}

--- a/frontend/packages/shared/src/services/WebSocketService.ts
+++ b/frontend/packages/shared/src/services/WebSocketService.ts
@@ -1,0 +1,346 @@
+import type { GetHost } from './types';
+
+// ── Server → client inbound events (discriminated on `type`) ───────────────
+export interface WsStatusEvent {
+  type: 'status';
+  stage: string;
+}
+export interface WsActNarrationEvent {
+  type: 'act_narration';
+  [k: string]: unknown;
+}
+export interface WsActToolStartEvent {
+  type: 'act_tool_start';
+  [k: string]: unknown;
+}
+export interface WsActToolEndEvent {
+  type: 'act_tool_end';
+  [k: string]: unknown;
+}
+export interface WsMessageEvent {
+  type: 'message';
+  [k: string]: unknown;
+}
+export interface WsErrorEvent {
+  type: 'error';
+  message: string;
+  recoverable?: boolean;
+}
+export interface WsDoneEvent {
+  type: 'done';
+  duration_ms: number;
+}
+export interface WsPingEvent {
+  type: 'ping';
+}
+
+/** Push/drift family — payloads refined per-handler in P1. */
+export type WsPushType =
+  | 'drift'
+  | 'task'
+  | 'reminder'
+  | 'escalation'
+  | 'notification'
+  | 'permission_request'
+  | 'intent'
+  | 'capability_alert';
+export interface WsPushEvent {
+  type: WsPushType;
+  [k: string]: unknown;
+}
+
+export type WsInboundEvent =
+  | WsStatusEvent
+  | WsActNarrationEvent
+  | WsActToolStartEvent
+  | WsActToolEndEvent
+  | WsMessageEvent
+  | WsErrorEvent
+  | WsDoneEvent
+  | WsPingEvent
+  | WsPushEvent;
+
+export interface ChatCallbacks {
+  onStatus?: (stage: string) => void;
+  onMessage?: (data: WsMessageEvent) => void;
+  onNarration?: (data: WsActNarrationEvent) => void;
+  onError?: (data: { message: string; recoverable?: boolean }) => void;
+  onDone?: (data: { duration_ms: number }) => void;
+  onToolStart?: (data: WsActToolStartEvent) => void;
+  onToolEnd?: (data: WsActToolEndEvent) => void;
+}
+
+export interface ActionCallbacks {
+  onMessage?: (data: WsMessageEvent) => void;
+  onError?: (data: { message: string; recoverable?: boolean }) => void;
+  onDone?: (data: { duration_ms: number }) => void;
+}
+
+type Timer = ReturnType<typeof setTimeout>;
+type Interval = ReturnType<typeof setInterval>;
+
+/**
+ * WebSocket client — receive-only server→client push channel.
+ * Client→server requests go over HTTP (POST /chat, /chat/interrupt, /action);
+ * the only client→server WS frame is `pong`.
+ */
+export class WebSocketService {
+  private ws: WebSocket | null = null;
+  private reconnectDelay = 1000;
+  private readonly maxReconnectDelay = 30000;
+  private reconnectTimer: Timer | null = null;
+  private chatCallbacks: (ChatCallbacks & ActionCallbacks) | null = null;
+  private driftHandler: ((data: WsPushEvent) => void) | null = null;
+  private anyHandler: ((data: WsInboundEvent) => void) | null = null;
+  private disconnectHandler: (() => void) | null = null;
+  private connected = false;
+  private intentionallyClosed = false;
+
+  // Liveness watchdog (half-open detection). Backend pings every 60s of client
+  // silence (backend/api/websocket.py); fire only on full silence past 90s.
+  private readonly staleThresholdMs = 90000;
+  private readonly livenessCheckMs = 30000;
+  private lastInboundAt = 0;
+  private livenessTimer: Interval | null = null;
+
+  constructor(private readonly getHost: GetHost) {}
+
+  private buildWsUrl(): string {
+    const host = this.getHost() || '';
+    const base = host ? host.replace(/\/$/, '') : globalThis.location.origin;
+    return base.replace(/^http/, 'ws') + '/ws';
+  }
+  private buildHttpUrl(path: string): string {
+    const host = this.getHost() || '';
+    const base = host ? host.replace(/\/$/, '') : globalThis.location.origin;
+    return base + path;
+  }
+
+  onDrift(handler: (data: WsPushEvent) => void): void {
+    this.driftHandler = handler;
+  }
+  onAny(handler: (data: WsInboundEvent) => void): void {
+    this.anyHandler = handler;
+  }
+  onDisconnect(handler: () => void): void {
+    this.disconnectHandler = handler;
+  }
+
+  connect(): void {
+    if (
+      this.ws &&
+      (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)
+    ) {
+      return;
+    }
+    this.intentionallyClosed = false;
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(this.buildWsUrl());
+    } catch (err) {
+      console.warn('[WS] Failed to create WebSocket:', err);
+      this.scheduleReconnect();
+      return;
+    }
+    this.ws = ws;
+
+    // A pending backoff reconnect is now redundant — this connect() owns the socket.
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
+    ws.onopen = () => {
+      this.connected = true;
+      this.reconnectDelay = 1000;
+      this.lastInboundAt = Date.now();
+      this.startLivenessWatch();
+    };
+    ws.onmessage = (event: MessageEvent) => {
+      this.lastInboundAt = Date.now();
+      let data: WsInboundEvent;
+      try {
+        data = JSON.parse(event.data as string) as WsInboundEvent;
+      } catch {
+        return;
+      }
+      this.dispatch(data);
+    };
+    ws.onclose = () => {
+      this.connected = false;
+      this.stopLivenessWatch();
+      this.disconnectHandler?.();
+      if (!this.intentionallyClosed) this.scheduleReconnect();
+    };
+    ws.onerror = () => {
+      /* onclose fires after onerror — reconnect handled there */
+    };
+  }
+
+  close(): void {
+    this.intentionallyClosed = true;
+    this.stopLivenessWatch();
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+    this.connected = false;
+  }
+
+  get isConnected(): boolean {
+    return this.connected && this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  private scheduleReconnect(): void {
+    if (this.intentionallyClosed || this.reconnectTimer) return;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, this.reconnectDelay);
+    this.reconnectDelay = Math.min(this.reconnectDelay * 1.5, this.maxReconnectDelay);
+  }
+
+  // ── Liveness watchdog ──────────────────────────────────────────────────
+  private startLivenessWatch(): void {
+    this.stopLivenessWatch();
+    this.livenessTimer = setInterval(() => this.checkLiveness(), this.livenessCheckMs);
+  }
+  private stopLivenessWatch(): void {
+    if (this.livenessTimer) {
+      clearInterval(this.livenessTimer);
+      this.livenessTimer = null;
+    }
+  }
+  private checkLiveness(): void {
+    if (this.intentionallyClosed) return;
+    if (Date.now() - this.lastInboundAt > this.staleThresholdMs) this.forceReconnect();
+  }
+  private forceReconnect(): void {
+    this.stopLivenessWatch();
+    const stale = this.ws;
+    this.ws = null;
+    this.connected = false;
+    if (stale) {
+      stale.onopen = null;
+      stale.onmessage = null;
+      stale.onclose = null;
+      stale.onerror = null;
+      try {
+        stale.close();
+      } catch {
+        /* already dead */
+      }
+    }
+    this.disconnectHandler?.();
+    this.connect();
+  }
+
+  /** Heal the connection if it has silently died (tab refocus). */
+  ensureAlive(): void {
+    if (this.intentionallyClosed) return;
+    if (!this.isConnected) {
+      this.connect();
+      return;
+    }
+    if (Date.now() - this.lastInboundAt > this.staleThresholdMs) this.forceReconnect();
+  }
+
+  abort(): void {
+    this.chatCallbacks = null;
+  }
+
+  send(text: string, source: 'text' | 'voice', callbacks: ChatCallbacks = {}, files: File[] = []): void {
+    this.chatCallbacks = callbacks;
+    if (!this.isConnected) {
+      callbacks.onError?.({ message: 'Not connected. Please wait...', recoverable: true });
+      callbacks.onDone?.({ duration_ms: 0 });
+      this.chatCallbacks = null;
+      return;
+    }
+    this.postChat(text, source, files);
+  }
+
+  sendAction(payload: unknown, callbacks: ActionCallbacks = {}): void {
+    this.abort();
+    this.chatCallbacks = callbacks;
+    if (!this.isConnected) {
+      callbacks.onError?.({ message: 'Not connected.', recoverable: true });
+      callbacks.onDone?.({ duration_ms: 0 });
+      this.chatCallbacks = null;
+      return;
+    }
+    fetch(this.buildHttpUrl('/action'), {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }).catch(() => {
+      callbacks.onError?.({ message: 'Action request failed.', recoverable: true });
+      callbacks.onDone?.({ duration_ms: 0 });
+      this.chatCallbacks = null;
+    });
+  }
+
+  private postChat(text: string, source: string, files: File[]): void {
+    const form = new FormData();
+    form.append('text', text);
+    form.append('source', source);
+    for (const file of files) form.append('files', file, file.name);
+    fetch(this.buildHttpUrl('/chat'), {
+      method: 'POST',
+      credentials: 'same-origin',
+      body: form,
+    }).catch(() => {
+      this.chatCallbacks?.onError?.({ message: 'Chat request failed.', recoverable: true });
+      this.chatCallbacks?.onDone?.({ duration_ms: 0 });
+      this.chatCallbacks = null;
+    });
+  }
+
+  private dispatch(data: WsInboundEvent): void {
+    if (this.anyHandler) {
+      try {
+        this.anyHandler(data);
+      } catch {
+        /* never break the WS pipe */
+      }
+    }
+    if (data.type === 'ping') {
+      if (this.ws?.readyState === WebSocket.OPEN) this.ws.send(JSON.stringify({ type: 'pong' }));
+      return;
+    }
+    if (this.chatCallbacks) {
+      switch (data.type) {
+        case 'status':
+          this.chatCallbacks.onStatus?.(data.stage);
+          return;
+        case 'act_narration':
+          this.chatCallbacks.onNarration?.(data);
+          return;
+        case 'act_tool_start':
+          this.chatCallbacks.onToolStart?.(data);
+          return;
+        case 'act_tool_end':
+          this.chatCallbacks.onToolEnd?.(data);
+          return;
+        case 'message':
+          this.chatCallbacks.onMessage?.(data);
+          return;
+        case 'error':
+          this.chatCallbacks.onError?.(data);
+          return;
+        case 'done': {
+          const cb = this.chatCallbacks;
+          this.chatCallbacks = null;
+          cb?.onDone?.(data);
+          return;
+        }
+      }
+    }
+    this.driftHandler?.(data as WsPushEvent);
+  }
+}

--- a/frontend/packages/shared/src/services/WebSocketService.ts
+++ b/frontend/packages/shared/src/services/WebSocketService.ts
@@ -93,6 +93,7 @@ export class WebSocketService {
   private driftHandler: ((data: WsPushEvent) => void) | null = null;
   private anyHandler: ((data: WsInboundEvent) => void) | null = null;
   private disconnectHandler: (() => void) | null = null;
+  private connectHandler: (() => void) | null = null;
   private connected = false;
   private intentionallyClosed = false;
 
@@ -125,6 +126,9 @@ export class WebSocketService {
   onDisconnect(handler: () => void): void {
     this.disconnectHandler = handler;
   }
+  onConnect(handler: () => void): void {
+    this.connectHandler = handler;
+  }
 
   connect(): void {
     if (
@@ -155,6 +159,11 @@ export class WebSocketService {
       this.reconnectDelay = 1000;
       this.lastInboundAt = Date.now();
       this.startLivenessWatch();
+      try {
+        this.connectHandler?.();
+      } catch {
+        /* never break onopen */
+      }
     };
     ws.onmessage = (event: MessageEvent) => {
       this.lastInboundAt = Date.now();

--- a/frontend/packages/shared/src/services/types.ts
+++ b/frontend/packages/shared/src/services/types.ts
@@ -1,0 +1,2 @@
+/** Returns the current backend host, or '' for same-origin. */
+export type GetHost = () => string;

--- a/frontend/packages/shared/src/stores/connection.ts
+++ b/frontend/packages/shared/src/stores/connection.ts
@@ -1,0 +1,10 @@
+import { defineStore } from 'pinia';
+
+export const useConnectionStore = defineStore('connection', {
+  state: () => ({ connected: false }),
+  actions: {
+    setConnected(v: boolean) {
+      this.connected = v;
+    },
+  },
+});

--- a/frontend/packages/shared/src/stores/theme.ts
+++ b/frontend/packages/shared/src/stores/theme.ts
@@ -1,0 +1,36 @@
+import { defineStore } from 'pinia';
+
+export type Theme = 'light' | 'dark';
+const THEME_KEY = 'chalie-theme';
+
+function systemTheme(): Theme {
+  return globalThis.matchMedia?.('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+}
+
+export const useThemeStore = defineStore('theme', {
+  state: () => ({ theme: ((document.documentElement.dataset.theme as Theme) || 'dark') as Theme }),
+  actions: {
+    setTheme(t: Theme) {
+      this.theme = t;
+      document.documentElement.dataset.theme = t;
+      try {
+        localStorage.setItem(THEME_KEY, t);
+      } catch {
+        /* ignore */
+      }
+    },
+    toggle() {
+      this.setTheme(this.theme === 'dark' ? 'light' : 'dark');
+    },
+    /** Adopt the pre-paint choice (saved → system). Idempotent. */
+    init() {
+      let saved: string | null = null;
+      try {
+        saved = localStorage.getItem(THEME_KEY);
+      } catch {
+        /* ignore */
+      }
+      this.setTheme(saved === 'light' || saved === 'dark' ? (saved as Theme) : systemTheme());
+    },
+  },
+});

--- a/frontend/packages/shared/src/styles/_reset.scss
+++ b/frontend/packages/shared/src/styles/_reset.scss
@@ -1,0 +1,11 @@
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--bs-body-bg);
+  color: var(--bs-body-color);
+  font-family: var(--bs-body-font-family);
+  font-size: var(--bs-body-font-size);
+  line-height: var(--bs-body-line-height);
+  -webkit-font-smoothing: antialiased;
+}
+button { font: inherit; color: inherit; }

--- a/frontend/packages/shared/src/styles/_tokens.scss
+++ b/frontend/packages/shared/src/styles/_tokens.scss
@@ -1,0 +1,383 @@
+/* ── Bootstrap v5 variable overrides ──────────────────────────────────────── */
+/* Dark theme (default). `:root` so pages without `data-theme` still get it.   */
+:root,
+[data-theme="dark"] {
+  color-scheme: dark;
+
+  /* Primary = violet #8A5CFF */
+  --bs-primary:             #8A5CFF;
+  --bs-primary-rgb:         138, 92, 255;
+  /* Secondary = magenta #FF2FD1 */
+  --bs-secondary:           #FF2FD1;
+  --bs-secondary-rgb:       255, 47, 209;
+  /* Info = cyan #00F0FF */
+  --bs-info:                #00F0FF;
+  --bs-info-rgb:            0, 240, 255;
+  /* Semantic */
+  --bs-success:             #34d399;
+  --bs-success-rgb:         52, 211, 153;
+  --bs-danger:              #fb7185;
+  --bs-danger-rgb:          251, 113, 133;
+  --bs-warning:             #fbbf24;
+  --bs-warning-rgb:         251, 191, 36;
+  /* Body */
+  --bs-body-bg:             #06080e;
+  --bs-body-color:          #eae6f2;
+  --bs-body-font-family:    'Inter', system-ui, sans-serif;
+  --bs-body-font-size:      0.9375rem;
+  --bs-body-line-height:    1.6;
+  /* Borders */
+  --bs-border-color:        rgba(255, 255, 255, 0.07);
+  --bs-border-radius:       8px;
+  --bs-border-radius-lg:    16px;
+  --bs-border-radius-xl:    24px;
+  --bs-border-radius-pill:  9999px;
+  /* Card */
+  --bs-card-bg:             rgba(255, 255, 255, 0.03);
+  --bs-card-border-color:   rgba(255, 255, 255, 0.07);
+  --bs-card-cap-bg:         rgba(255, 255, 255, 0.02);
+  /* Link */
+  --bs-link-color:          #8A5CFF;
+  --bs-link-hover-color:    #a07dff;
+  --bs-link-color-rgb:      138, 92, 255;
+  /* Form / Input */
+  --bs-form-control-bg:     rgba(255, 255, 255, 0.05);
+
+  /* ── Radiant tokens (backward compat + Chalie-specific) ───────────────────── */
+  --violet:                 #8A5CFF;
+  --violet-hover:           #9B6FFF;
+  --magenta:                #FF2FD1;
+  --cyan:                   #00F0FF;
+
+  --accent-primary:         var(--violet);
+  --accent-secondary:       var(--magenta);
+  --accent-tertiary:        var(--cyan);
+  --bg:                     #06080e;
+  --bg-2:                   #0d0f18;
+  --bg-surface:             rgba(255, 255, 255, 0.03);
+  --bg-surface-2:           rgba(255, 255, 255, 0.05);
+  --bg-input:               rgba(255, 255, 255, 0.05);
+  --bg-user:                rgba(138, 92, 255, 0.07);
+  --bg-chalie:              rgba(255, 255, 255, 0.025);
+  --text:                   #eae6f2;
+  --text-primary:           #eae6f2;
+  --text-secondary:         rgba(234, 230, 242, 0.58);
+  --text-muted:             rgba(234, 230, 242, 0.50);
+  --text-tertiary:          rgba(234, 230, 242, 0.30);
+  --text-subtle:            rgba(234, 230, 242, 0.30);
+  --border:                 rgba(255, 255, 255, 0.07);
+  --border-subtle:          rgba(255, 255, 255, 0.07);
+  --border-strong:          rgba(255, 255, 255, 0.12);
+  --success:                #34d399;
+  --error:                  #fb7185;
+  --warning:                #fbbf24;
+  --warning-banner-text:    #e89c50;
+  --ease-out:               cubic-bezier(0.16, 1, 0.3, 1);
+
+  /* Effects */
+  --shadow-card:            0 1px 0 rgba(255,255,255,0.03) inset, 0 12px 40px rgba(0,0,0,0.35);
+  --grain-opacity:          0.04;
+  --grain-blend:            overlay;
+
+  /* Ambient orbs (drive the canvas + decorative orbs) */
+  --orb-1:                  rgba(138, 92, 255, 0.55);
+  --orb-2:                  rgba(255, 47, 209, 0.30);
+  --orb-3:                  rgba(0, 240, 255, 0.22);
+
+  /* Surface scrim / dock backdrop — used by fixed bars */
+  --scrim-top:              rgba(6, 8, 14, 0.92);
+  --scrim-dock:             rgba(6, 8, 14, 0.92);
+  --scrim-fallback:         rgba(6, 8, 14, 0.98);
+
+  /* Legacy aliases kept for backward compat */
+  --accent:                 var(--violet);
+  --accent-hover:           var(--violet-hover);
+  --bg-dark:                var(--bg);
+  --bg-card:                var(--bg-surface);
+}
+
+/* ── Light theme ──────────────────────────────────────────────────────────────
+   Mirrors the dark token system. Violet stays primary (nudged for AA on
+   light), warm paper background (never pure white), softer ambient orbs
+   blended via `multiply` so they tint the page rather than glow on it. */
+[data-theme="light"] {
+  color-scheme: light;
+
+  /* Bootstrap */
+  --bs-primary:             #6E3DEB;
+  --bs-primary-rgb:         110, 61, 235;
+  --bs-secondary:           #DB1FAF;
+  --bs-secondary-rgb:       219, 31, 175;
+  --bs-info:                #0098A8;
+  --bs-info-rgb:            0, 152, 168;
+  --bs-success:             #0F9D6E;
+  --bs-success-rgb:         15, 157, 110;
+  --bs-danger:              #DC3654;
+  --bs-danger-rgb:          220, 54, 84;
+  --bs-warning:             #B47B00;
+  --bs-warning-rgb:         180, 123, 0;
+  --bs-body-bg:             #F6F4F1;
+  --bs-body-color:          #1A1626;
+  --bs-border-color:        rgba(26, 22, 38, 0.08);
+  --bs-card-bg:             rgba(255, 255, 255, 0.72);
+  --bs-card-border-color:   rgba(26, 22, 38, 0.08);
+  --bs-card-cap-bg:         rgba(255, 255, 255, 0.55);
+  --bs-link-color:          #6E3DEB;
+  --bs-link-hover-color:    #5B2DD8;
+  --bs-link-color-rgb:      110, 61, 235;
+  --bs-form-control-bg:     rgba(255, 255, 255, 0.88);
+
+  /* Radiant tokens */
+  --violet:                 #6E3DEB;
+  --violet-hover:           #5B2DD8;
+  --magenta:                #DB1FAF;
+  --cyan:                   #0098A8;
+
+  --accent-primary:         var(--violet);
+  --accent-secondary:       var(--magenta);
+  --accent-tertiary:        var(--cyan);
+  --bg:                     #F6F4F1;
+  --bg-2:                   #FFFFFF;
+  --bg-surface:             rgba(255, 255, 255, 0.72);
+  --bg-surface-2:           rgba(255, 255, 255, 0.92);
+  --bg-input:               rgba(255, 255, 255, 0.88);
+  --bg-user:                rgba(110, 61, 235, 0.07);
+  --bg-chalie:              rgba(255, 255, 255, 0.65);
+  --text:                   #1A1626;
+  --text-primary:           #1A1626;
+  --text-secondary:         rgba(26, 22, 38, 0.62);
+  --text-muted:             rgba(26, 22, 38, 0.50);
+  --text-tertiary:          rgba(26, 22, 38, 0.34);
+  --text-subtle:            rgba(26, 22, 38, 0.34);
+  --border:                 rgba(26, 22, 38, 0.08);
+  --border-subtle:          rgba(26, 22, 38, 0.08);
+  --border-strong:          rgba(26, 22, 38, 0.14);
+  --success:                #0F9D6E;
+  --error:                  #DC3654;
+  --warning:                #B47B00;
+  --warning-banner-text:    #8B5E00;
+
+  /* Effects */
+  --shadow-card:            none;
+  --grain-opacity:          0.035;
+  --grain-blend:            multiply;
+
+  /* Ambient orbs — softer, more pastel on light */
+  --orb-1:                  rgba(138, 92, 255, 0.28);
+  --orb-2:                  rgba(255, 47, 209, 0.18);
+  --orb-3:                  rgba(0, 200, 220, 0.18);
+
+  /* Surface scrims react to the warm paper bg */
+  --scrim-top:              rgba(246, 244, 241, 0.88);
+  --scrim-dock:             rgba(246, 244, 241, 0.92);
+  --scrim-fallback:         rgba(246, 244, 241, 0.98);
+
+  --accent-hover:           var(--violet-hover);
+  --bg-dark:                var(--bg);
+  --bg-card:                var(--bg-surface);
+}
+
+/* ── Base resets ──────────────────────────────────────────────────────────── */
+body {
+  background-color: var(--bs-body-bg);
+  color: var(--bs-body-color);
+  transition: background-color 420ms ease, color 420ms ease;
+}
+
+/* ── JS-coupled class aliases (cannot be renamed in JS) ───────────────────── */
+.hidden       { display: none !important; }
+.form-group   { margin-bottom: 1rem; }
+.tab-panel    { display: none; }
+.tab-panel.active { display: block; }
+
+/* ── Bootstrap component dark-theme overrides ─────────────────────────────── */
+
+/* Forms */
+.form-control,
+.form-select {
+  background-color: var(--bg-input);
+  border-color: var(--bs-border-color);
+  color: var(--bs-body-color);
+}
+.form-control:focus,
+.form-select:focus {
+  background-color: var(--bg-input);
+  border-color: rgba(138, 92, 255, 0.45);
+  color: var(--bs-body-color);
+  box-shadow: 0 0 0 3px rgba(138, 92, 255, 0.12);
+}
+.form-control::placeholder { color: var(--text-secondary); }
+.form-label { color: var(--bs-body-color); font-size: 0.8125rem; font-weight: 600; }
+
+/* Inputs / textareas inherit dark bg */
+input[type="text"],
+input[type="password"],
+input[type="email"],
+input[type="search"],
+input[type="url"],
+input[type="number"],
+input[type="datetime-local"],
+input[type="time"],
+textarea,
+select {
+  background-color: var(--bg-input);
+  border: 1px solid var(--bs-border-color);
+  border-radius: var(--bs-border-radius);
+  color: var(--bs-body-color);
+}
+input::placeholder,
+textarea::placeholder { color: var(--text-secondary); }
+
+/* Buttons */
+.btn-primary {
+  --bs-btn-bg:              #8A5CFF;
+  --bs-btn-border-color:    #8A5CFF;
+  --bs-btn-hover-bg:        #9B6FFF;
+  --bs-btn-hover-border-color: #9B6FFF;
+  --bs-btn-active-bg:       #7a4eee;
+  --bs-btn-disabled-bg:     #8A5CFF;
+  --bs-btn-color:           #fff;
+  --bs-btn-hover-color:     #fff;
+}
+.btn-secondary {
+  --bs-btn-bg:              rgba(255, 255, 255, 0.05);
+  --bs-btn-border-color:    rgba(255, 255, 255, 0.07);
+  --bs-btn-hover-bg:        rgba(255, 255, 255, 0.09);
+  --bs-btn-hover-border-color: rgba(138, 92, 255, 0.3);
+  --bs-btn-color:           var(--bs-body-color);
+  --bs-btn-hover-color:     var(--bs-body-color);
+  --bs-btn-active-bg:       rgba(255, 255, 255, 0.08);
+}
+.btn-danger {
+  --bs-btn-bg:              transparent;
+  --bs-btn-border-color:    rgba(251, 113, 133, 0.30);
+  --bs-btn-hover-bg:        rgba(251, 113, 133, 0.10);
+  --bs-btn-hover-border-color: rgba(251, 113, 133, 0.55);
+  --bs-btn-active-bg:       rgba(251, 113, 133, 0.15);
+  --bs-btn-color:           #fb7185;
+  --bs-btn-hover-color:     #fb7185;
+  --bs-btn-disabled-bg:     transparent;
+  --bs-btn-disabled-color:  rgba(251, 113, 133, 0.45);
+}
+.btn-outline-primary {
+  --bs-btn-color:           #8A5CFF;
+  --bs-btn-border-color:    #8A5CFF;
+  --bs-btn-hover-bg:        rgba(138, 92, 255, 0.15);
+  --bs-btn-hover-color:     #8A5CFF;
+}
+
+/* Cards */
+.card {
+  background-color: var(--bg-surface);
+  border-color: var(--bs-border-color);
+  color: var(--bs-body-color);
+}
+.card-header,
+.card-footer {
+  background-color: var(--bs-card-cap-bg);
+  border-color: var(--bs-border-color);
+}
+
+/* Modals */
+.modal-content {
+  background-color: var(--bg-2);
+  border-color: var(--bs-border-color);
+  color: var(--bs-body-color);
+}
+.modal-header,
+.modal-footer {
+  border-color: var(--bs-border-color);
+}
+.modal-backdrop.show { opacity: 0.75; }
+
+/* Badges */
+.badge.bg-primary   { background-color: rgba(var(--bs-primary-rgb), 0.18) !important; color: var(--accent-primary); }
+.badge.bg-secondary { background-color: rgba(var(--bs-secondary-rgb), 0.14) !important; color: var(--accent-secondary); }
+.badge.bg-info      { background-color: rgba(var(--bs-info-rgb), 0.12) !important;  color: var(--accent-tertiary); }
+.badge.bg-success   { background-color: rgba(var(--bs-success-rgb), 0.14) !important; color: var(--success); }
+.badge.bg-danger    { background-color: rgba(var(--bs-danger-rgb), 0.14) !important; color: var(--error); }
+.badge.bg-warning   { background-color: rgba(var(--bs-warning-rgb), 0.14) !important;  color: var(--warning); }
+
+/* Alerts */
+.alert { border-radius: var(--bs-border-radius); }
+.alert-primary   { background-color: rgba(var(--bs-primary-rgb), 0.12); border-color: rgba(var(--bs-primary-rgb), 0.3); color: var(--accent-primary); }
+.alert-info      { background-color: rgba(var(--bs-info-rgb), 0.08);  border-color: rgba(var(--bs-info-rgb), 0.25); color: var(--accent-tertiary); }
+.alert-success   { background-color: rgba(var(--bs-success-rgb), 0.10); border-color: rgba(var(--bs-success-rgb), 0.3); color: var(--success); }
+.alert-danger    { background-color: rgba(var(--bs-danger-rgb), 0.10); border-color: rgba(var(--bs-danger-rgb), 0.3); color: var(--error); }
+.alert-warning   { background-color: rgba(var(--bs-warning-rgb), 0.10);  border-color: rgba(var(--bs-warning-rgb), 0.3);  color: var(--warning); }
+
+/* Spinners */
+.spinner-border { color: var(--bs-primary); }
+
+/* Tables */
+.table         { --bs-table-color: var(--bs-body-color); --bs-table-border-color: var(--bs-border-color); }
+.table-dark    { --bs-table-bg: rgba(255, 255, 255, 0.03); }
+.table-striped { --bs-table-striped-bg: rgba(255, 255, 255, 0.02); }
+
+/* Nav tabs */
+.nav-tabs {
+  border-color: var(--bs-border-color);
+}
+.nav-tabs .nav-link {
+  color: var(--text-secondary);
+  border-color: transparent;
+}
+.nav-tabs .nav-link:hover {
+  color: var(--bs-body-color);
+  border-color: var(--bs-border-color);
+}
+.nav-tabs .nav-link.active {
+  background-color: rgba(255, 255, 255, 0.04);
+  border-color: var(--bs-border-color) var(--bs-border-color) transparent;
+  color: var(--bs-body-color);
+}
+
+/* Dropdowns */
+.dropdown-menu {
+  background-color: var(--bg-2);
+  border-color: var(--bs-border-color);
+}
+.dropdown-item { color: var(--bs-body-color); }
+.dropdown-item:hover, .dropdown-item:focus {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: var(--bs-body-color);
+}
+.dropdown-divider { border-color: var(--bs-border-color); }
+
+/* Accordion */
+.accordion-item {
+  background-color: var(--bg-surface);
+  border-color: var(--bs-border-color);
+}
+.accordion-button {
+  background-color: var(--bg-surface);
+  color: var(--bs-body-color);
+}
+.accordion-button:not(.collapsed) {
+  background-color: rgba(138, 92, 255, 0.08);
+  color: #8A5CFF;
+  box-shadow: inset 0 -1px 0 var(--bs-border-color);
+}
+.accordion-button::after {
+  filter: invert(1) brightness(0.7);
+}
+
+/* Toast */
+.toast {
+  background-color: var(--bg-2);
+  border-color: var(--bs-border-color);
+  color: var(--bs-body-color);
+}
+.toast-header {
+  background-color: rgba(255, 255, 255, 0.03);
+  border-color: var(--bs-border-color);
+  color: var(--bs-body-color);
+}
+
+/* Scrollbar */
+::-webkit-scrollbar        { width: 6px; height: 6px; }
+::-webkit-scrollbar-track  { background: transparent; }
+::-webkit-scrollbar-thumb  { background: rgba(255, 255, 255, 0.12); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: rgba(255, 255, 255, 0.22); }
+[data-theme="light"] ::-webkit-scrollbar-thumb { background: rgba(0, 0, 0, 0.08); }
+[data-theme="light"] ::-webkit-scrollbar-thumb:hover { background: rgba(0, 0, 0, 0.15); }

--- a/frontend/packages/shared/src/styles/main.scss
+++ b/frontend/packages/shared/src/styles/main.scss
@@ -1,0 +1,2 @@
+@use 'tokens';
+@use 'reset';

--- a/frontend/packages/shared/src/ui/BaseButton.vue
+++ b/frontend/packages/shared/src/ui/BaseButton.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{ variant?: 'primary' | 'secondary' | 'ghost'; disabled?: boolean; type?: 'button' | 'submit' }>(),
+  { variant: 'primary', disabled: false, type: 'button' },
+);
+defineEmits<{ click: [MouseEvent] }>();
+</script>
+
+<template>
+  <button
+    :type="type"
+    :disabled="disabled"
+    :class="['base-btn', `base-btn--${variant}`]"
+    @click="(e) => $emit('click', e)"
+  >
+    <slot />
+  </button>
+</template>
+
+<style scoped lang="scss">
+.base-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid transparent;
+  border-radius: var(--bs-border-radius);
+  cursor: pointer;
+  transition: filter 0.15s ease, background 0.15s ease;
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  &:hover:not(:disabled) {
+    filter: brightness(1.1);
+  }
+  &--primary {
+    background: var(--bs-primary);
+    color: #fff;
+  }
+  &--secondary {
+    background: var(--bs-secondary);
+    color: #fff;
+  }
+  &--ghost {
+    background: transparent;
+    border-color: var(--bs-border-color);
+    color: var(--bs-body-color);
+  }
+}
+</style>

--- a/frontend/packages/shared/src/ui/BaseCard.vue
+++ b/frontend/packages/shared/src/ui/BaseCard.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+defineProps<{ title?: string }>();
+</script>
+
+<template>
+  <section class="base-card">
+    <header v-if="title || $slots.header" class="base-card__head">
+      <slot name="header">{{ title }}</slot>
+    </header>
+    <div class="base-card__body"><slot /></div>
+  </section>
+</template>
+
+<style scoped lang="scss">
+.base-card {
+  background: var(--bs-card-bg);
+  border: 1px solid var(--bs-card-border-color);
+  border-radius: var(--bs-border-radius-lg);
+  overflow: hidden;
+  &__head {
+    padding: 0.75rem 1rem;
+    background: var(--bs-card-cap-bg);
+    border-bottom: 1px solid var(--bs-card-border-color);
+    font-weight: 600;
+  }
+  &__body {
+    padding: 1rem;
+  }
+}
+</style>

--- a/frontend/packages/shared/src/ui/BaseField.vue
+++ b/frontend/packages/shared/src/ui/BaseField.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+const model = defineModel<string>();
+defineProps<{ label?: string; placeholder?: string; type?: string; id?: string }>();
+</script>
+
+<template>
+  <label class="base-field">
+    <span v-if="label" class="base-field__label">{{ label }}</span>
+    <input
+      :id="id"
+      v-model="model"
+      class="base-field__input"
+      :type="type ?? 'text'"
+      :placeholder="placeholder"
+    />
+  </label>
+</template>
+
+<style scoped lang="scss">
+.base-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  &__label {
+    font-size: 0.8125rem;
+    color: var(--bs-body-color);
+    opacity: 0.8;
+  }
+  &__input {
+    padding: 0.5rem 0.75rem;
+    background: var(--bs-body-bg);
+    color: var(--bs-body-color);
+    border: 1px solid var(--bs-border-color);
+    border-radius: var(--bs-border-radius);
+    &:focus {
+      outline: none;
+      border-color: var(--bs-primary);
+    }
+  }
+}
+</style>

--- a/frontend/packages/shared/src/ui/BaseModal.vue
+++ b/frontend/packages/shared/src/ui/BaseModal.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+defineProps<{ open: boolean; title?: string }>();
+defineEmits<{ close: [] }>();
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="modal-fade">
+      <div v-if="open" class="base-modal__backdrop" @click.self="$emit('close')">
+        <div class="base-modal" role="dialog" aria-modal="true">
+          <header v-if="title" class="base-modal__head">
+            <h2>{{ title }}</h2>
+            <button class="base-modal__x" aria-label="Close" @click="$emit('close')">×</button>
+          </header>
+          <div class="base-modal__body"><slot /></div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped lang="scss">
+.base-modal__backdrop {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+}
+.base-modal {
+  background: var(--bs-card-bg);
+  border: 1px solid var(--bs-card-border-color);
+  border-radius: var(--bs-border-radius-lg);
+  min-width: 320px;
+  max-width: 90vw;
+  &__head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--bs-card-border-color);
+    h2 {
+      margin: 0;
+      font-size: 1rem;
+    }
+  }
+  &__x {
+    background: none;
+    border: none;
+    font-size: 1.25rem;
+    cursor: pointer;
+    color: var(--bs-body-color);
+  }
+  &__body {
+    padding: 1rem;
+  }
+}
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity 0.15s ease;
+}
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/frontend/packages/shared/src/ui/BaseTooltip.vue
+++ b/frontend/packages/shared/src/ui/BaseTooltip.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+defineProps<{ text: string }>();
+</script>
+
+<template>
+  <span class="base-tooltip">
+    <slot />
+    <span class="base-tooltip__bubble" role="tooltip">{{ text }}</span>
+  </span>
+</template>
+
+<style scoped lang="scss">
+.base-tooltip {
+  position: relative;
+  display: inline-flex;
+  &__bubble {
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%) translateY(-4px);
+    padding: 0.25rem 0.5rem;
+    background: var(--bs-body-color);
+    color: var(--bs-body-bg);
+    border-radius: var(--bs-border-radius);
+    font-size: 0.75rem;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.12s ease;
+  }
+  &:hover &__bubble {
+    opacity: 1;
+  }
+}
+</style>

--- a/frontend/packages/shared/tsconfig.json
+++ b/frontend/packages/shared/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue"]
+}

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -1,0 +1,2237 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.13.0
+        version: 9.39.4
+      '@playwright/test':
+        specifier: ^1.48.0
+        version: 1.60.0
+      '@vue/eslint-config-typescript':
+        specifier: ^14.1.0
+        version: 14.8.0(eslint-plugin-vue@9.33.0(eslint@9.39.4))(eslint@9.39.4)(typescript@5.9.3)
+      eslint:
+        specifier: ^9.13.0
+        version: 9.39.4
+      eslint-plugin-vue:
+        specifier: ^9.30.0
+        version: 9.33.0(eslint@9.39.4)
+      prettier:
+        specifier: ^3.3.3
+        version: 3.8.4
+      sass:
+        specifier: ^1.80.0
+        version: 1.101.0
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vite:
+        specifier: ^5.4.0
+        version: 5.4.21(sass@1.101.0)
+      vue-tsc:
+        specifier: ^2.1.0
+        version: 2.2.12(typescript@5.9.3)
+
+packages:
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@parcel/watcher-android-arm64@2.5.6':
+    resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    resolution: {integrity: sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    resolution: {integrity: sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    resolution: {integrity: sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    resolution: {integrity: sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    resolution: {integrity: sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    resolution: {integrity: sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@parcel/watcher@2.5.6':
+    resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
+    engines: {node: '>= 10.0.0'}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@rollup/rollup-android-arm-eabi@4.61.1':
+    resolution: {integrity: sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.61.1':
+    resolution: {integrity: sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.61.1':
+    resolution: {integrity: sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.61.1':
+    resolution: {integrity: sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.61.1':
+    resolution: {integrity: sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.61.1':
+    resolution: {integrity: sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
+    resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
+    resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.61.1':
+    resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.61.1':
+    resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.61.1':
+    resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.61.1':
+    resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
+    resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.61.1':
+    resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
+    resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.61.1':
+    resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.61.1':
+    resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.61.1':
+    resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.61.1':
+    resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.61.1':
+    resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.61.1':
+    resolution: {integrity: sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.61.1':
+    resolution: {integrity: sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.61.1':
+    resolution: {integrity: sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.61.1':
+    resolution: {integrity: sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.61.1':
+    resolution: {integrity: sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@typescript-eslint/eslint-plugin@8.61.0':
+    resolution: {integrity: sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.61.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.61.0':
+    resolution: {integrity: sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.61.0':
+    resolution: {integrity: sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.61.0':
+    resolution: {integrity: sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.61.0':
+    resolution: {integrity: sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.61.0':
+    resolution: {integrity: sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.61.0':
+    resolution: {integrity: sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.61.0':
+    resolution: {integrity: sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.61.0':
+    resolution: {integrity: sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.61.0':
+    resolution: {integrity: sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@volar/language-core@2.4.15':
+    resolution: {integrity: sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==}
+
+  '@volar/source-map@2.4.15':
+    resolution: {integrity: sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==}
+
+  '@volar/typescript@2.4.15':
+    resolution: {integrity: sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==}
+
+  '@vue/compiler-core@3.5.38':
+    resolution: {integrity: sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==}
+
+  '@vue/compiler-dom@3.5.38':
+    resolution: {integrity: sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==}
+
+  '@vue/compiler-vue2@2.7.16':
+    resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
+
+  '@vue/eslint-config-typescript@14.8.0':
+    resolution: {integrity: sha512-yIquzhXH7ZsrwSSm+rYvoGCRY6wcuF4qBi76e0l7hHLq7YU0f9aC+RcR5fL+XJNfmBZxgX5cVl4sppt4x7ZCBg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^9.10.0 || ^10.0.0
+      eslint-plugin-vue: ^9.28.0 || ^10.0.0
+      typescript: '>=4.8.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@vue/language-core@2.2.12':
+    resolution: {integrity: sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@vue/shared@3.5.38':
+    resolution: {integrity: sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  alien-signals@1.0.13:
+    resolution: {integrity: sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+
+  brace-expansion@2.1.1:
+    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  de-indent@1.0.2:
+    resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-plugin-vue@9.33.0:
+    resolution: {integrity: sha512-174lJKuNsuDIlLpjeXc5E2Tss8P44uIimAfGD0b90k0NoirJqpG7stLuU9Vp/9ioTOrQdWVREc4mRd1BD+CvGw==}
+    engines: {node: ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.2.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
+
+  eslint-scope@7.2.2:
+    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@13.24.0:
+    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
+    engines: {node: '>=8'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  immutable@5.1.6:
+    resolution: {integrity: sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  postcss-selector-parser@6.1.4:
+    resolution: {integrity: sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==}
+    engines: {node: '>=4'}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  prettier@3.8.4:
+    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rollup@4.61.1:
+    resolution: {integrity: sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  sass@1.101.0:
+    resolution: {integrity: sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+
+  semver@7.8.4:
+    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  type-fest@0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+
+  typescript-eslint@8.61.0:
+    resolution: {integrity: sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  vue-eslint-parser@10.4.1:
+    resolution: {integrity: sha512-Gk6gRDj0n/fkRa3C3l0bBheoBckUq/Rs0F/TvMWIS6nzzx67amAViMe9CkNgsP2tXyQONvGiHQESHwFtZ3aYDA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+
+  vue-eslint-parser@9.4.3:
+    resolution: {integrity: sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg==}
+    engines: {node: ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '>=6.0.0'
+
+  vue-tsc@2.2.12:
+    resolution: {integrity: sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  xml-name-validator@4.0.0:
+    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
+    engines: {node: '>=12'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
+    dependencies:
+      eslint: 9.39.4
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.2':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.5':
+    dependencies:
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.2.0
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
+  '@parcel/watcher-android-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher@2.5.6':
+    dependencies:
+      detect-libc: 2.1.2
+      is-glob: 4.0.3
+      node-addon-api: 7.1.1
+      picomatch: 4.0.4
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.5.6
+      '@parcel/watcher-darwin-arm64': 2.5.6
+      '@parcel/watcher-darwin-x64': 2.5.6
+      '@parcel/watcher-freebsd-x64': 2.5.6
+      '@parcel/watcher-linux-arm-glibc': 2.5.6
+      '@parcel/watcher-linux-arm-musl': 2.5.6
+      '@parcel/watcher-linux-arm64-glibc': 2.5.6
+      '@parcel/watcher-linux-arm64-musl': 2.5.6
+      '@parcel/watcher-linux-x64-glibc': 2.5.6
+      '@parcel/watcher-linux-x64-musl': 2.5.6
+      '@parcel/watcher-win32-arm64': 2.5.6
+      '@parcel/watcher-win32-ia32': 2.5.6
+      '@parcel/watcher-win32-x64': 2.5.6
+    optional: true
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
+  '@rollup/rollup-android-arm-eabi@4.61.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.61.1':
+    optional: true
+
+  '@types/esrecurse@4.3.1': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.61.0(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.61.0
+      eslint: 9.39.4
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.61.0(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.61.0
+      debug: 4.4.3
+      eslint: 9.39.4
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.61.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.61.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.61.0':
+    dependencies:
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/visitor-keys': 8.61.0
+
+  '@typescript-eslint/tsconfig-utils@8.61.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.61.0(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.4)(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.39.4
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.61.0': {}
+
+  '@typescript-eslint/typescript-estree@8.61.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/visitor-keys': 8.61.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.4
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.61.0(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
+      eslint: 9.39.4
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.61.0':
+    dependencies:
+      '@typescript-eslint/types': 8.61.0
+      eslint-visitor-keys: 5.0.1
+
+  '@volar/language-core@2.4.15':
+    dependencies:
+      '@volar/source-map': 2.4.15
+
+  '@volar/source-map@2.4.15': {}
+
+  '@volar/typescript@2.4.15':
+    dependencies:
+      '@volar/language-core': 2.4.15
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
+  '@vue/compiler-core@3.5.38':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.38
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.38':
+    dependencies:
+      '@vue/compiler-core': 3.5.38
+      '@vue/shared': 3.5.38
+
+  '@vue/compiler-vue2@2.7.16':
+    dependencies:
+      de-indent: 1.0.2
+      he: 1.2.0
+
+  '@vue/eslint-config-typescript@14.8.0(eslint-plugin-vue@9.33.0(eslint@9.39.4))(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.4)(typescript@5.9.3)
+      eslint: 9.39.4
+      eslint-plugin-vue: 9.33.0(eslint@9.39.4)
+      fast-glob: 3.3.3
+      typescript-eslint: 8.61.0(eslint@9.39.4)(typescript@5.9.3)
+      vue-eslint-parser: 10.4.1(eslint@9.39.4)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vue/language-core@2.2.12(typescript@5.9.3)':
+    dependencies:
+      '@volar/language-core': 2.4.15
+      '@vue/compiler-dom': 3.5.38
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.38
+      alien-signals: 1.0.13
+      minimatch: 9.0.9
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@vue/shared@3.5.38': {}
+
+  acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
+  acorn@8.17.0: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  alien-signals@1.0.13: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  boolbase@1.0.0: {}
+
+  brace-expansion@1.1.15:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.1.1:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  callsites@3.1.0: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  concat-map@0.0.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  cssesc@3.0.0: {}
+
+  de-indent@1.0.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
+
+  detect-libc@2.1.2:
+    optional: true
+
+  entities@7.0.1: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-plugin-vue@9.33.0(eslint@9.39.4):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      eslint: 9.39.4
+      globals: 13.24.0
+      natural-compare: 1.4.0
+      nth-check: 2.1.1
+      postcss-selector-parser: 6.1.4
+      semver: 7.8.4
+      vue-eslint-parser: 9.4.3(eslint@9.39.4)
+      xml-name-validator: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-scope@7.2.2:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@9.39.4:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 4.2.1
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 5.0.1
+
+  espree@9.6.1:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 3.4.3
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  estree-walker@2.0.2: {}
+
+  esutils@2.0.3: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
+
+  fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
+    optional: true
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@13.24.0:
+    dependencies:
+      type-fest: 0.20.2
+
+  globals@14.0.0: {}
+
+  has-flag@4.0.0: {}
+
+  he@1.2.0: {}
+
+  ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
+
+  immutable@5.1.6: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  isexe@2.0.0: {}
+
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  lodash@4.18.1: {}
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.15
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.1
+
+  ms@2.1.3: {}
+
+  muggle-string@0.4.1: {}
+
+  nanoid@3.3.12: {}
+
+  natural-compare@1.4.0: {}
+
+  node-addon-api@7.1.1:
+    optional: true
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  path-browserify@1.0.1: {}
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.4: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  postcss-selector-parser@6.1.4:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prelude-ls@1.2.1: {}
+
+  prettier@3.8.4: {}
+
+  punycode@2.3.1: {}
+
+  queue-microtask@1.2.3: {}
+
+  readdirp@5.0.0: {}
+
+  resolve-from@4.0.0: {}
+
+  reusify@1.1.0: {}
+
+  rollup@4.61.1:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.61.1
+      '@rollup/rollup-android-arm64': 4.61.1
+      '@rollup/rollup-darwin-arm64': 4.61.1
+      '@rollup/rollup-darwin-x64': 4.61.1
+      '@rollup/rollup-freebsd-arm64': 4.61.1
+      '@rollup/rollup-freebsd-x64': 4.61.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.61.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.61.1
+      '@rollup/rollup-linux-arm64-gnu': 4.61.1
+      '@rollup/rollup-linux-arm64-musl': 4.61.1
+      '@rollup/rollup-linux-loong64-gnu': 4.61.1
+      '@rollup/rollup-linux-loong64-musl': 4.61.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.61.1
+      '@rollup/rollup-linux-ppc64-musl': 4.61.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.61.1
+      '@rollup/rollup-linux-riscv64-musl': 4.61.1
+      '@rollup/rollup-linux-s390x-gnu': 4.61.1
+      '@rollup/rollup-linux-x64-gnu': 4.61.1
+      '@rollup/rollup-linux-x64-musl': 4.61.1
+      '@rollup/rollup-openbsd-x64': 4.61.1
+      '@rollup/rollup-openharmony-arm64': 4.61.1
+      '@rollup/rollup-win32-arm64-msvc': 4.61.1
+      '@rollup/rollup-win32-ia32-msvc': 4.61.1
+      '@rollup/rollup-win32-x64-gnu': 4.61.1
+      '@rollup/rollup-win32-x64-msvc': 4.61.1
+      fsevents: 2.3.3
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  sass@1.101.0:
+    dependencies:
+      chokidar: 5.0.0
+      immutable: 5.1.6
+      source-map-js: 1.2.1
+    optionalDependencies:
+      '@parcel/watcher': 2.5.6
+
+  semver@7.8.4: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  type-fest@0.20.2: {}
+
+  typescript-eslint@8.61.0(eslint@9.39.4)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.61.0(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.4)(typescript@5.9.3)
+      eslint: 9.39.4
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript@5.9.3: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
+
+  vite@5.4.21(sass@1.101.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.15
+      rollup: 4.61.1
+    optionalDependencies:
+      fsevents: 2.3.3
+      sass: 1.101.0
+
+  vscode-uri@3.1.0: {}
+
+  vue-eslint-parser@10.4.1(eslint@9.39.4):
+    dependencies:
+      debug: 4.4.3
+      eslint: 9.39.4
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      semver: 7.8.4
+    transitivePeerDependencies:
+      - supports-color
+
+  vue-eslint-parser@9.4.3(eslint@9.39.4):
+    dependencies:
+      debug: 4.4.3
+      eslint: 9.39.4
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      esquery: 1.7.0
+      lodash: 4.18.1
+      semver: 7.8.4
+    transitivePeerDependencies:
+      - supports-color
+
+  vue-tsc@2.2.12(typescript@5.9.3):
+    dependencies:
+      '@volar/typescript': 2.4.15
+      '@vue/language-core': 2.2.12(typescript@5.9.3)
+      typescript: 5.9.3
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
+
+  xml-name-validator@4.0.0: {}
+
+  yocto-queue@0.1.0: {}

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -39,6 +39,40 @@ importers:
         specifier: ^2.1.0
         version: 2.2.12(typescript@5.9.3)
 
+  apps/interface:
+    dependencies:
+      '@chalie/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      pinia:
+        specifier: ^2.2.0
+        version: 2.3.1(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3))
+      vue:
+        specifier: ^3.5.0
+        version: 3.5.38(typescript@5.9.3)
+      vue-router:
+        specifier: ^4.4.0
+        version: 4.6.4(vue@3.5.38(typescript@5.9.3))
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: ^5.1.0
+        version: 5.2.4(vite@5.4.21(sass@1.101.0))(vue@3.5.38(typescript@5.9.3))
+      vite:
+        specifier: ^5.4.0
+        version: 5.4.21(sass@1.101.0)
+      vue-tsc:
+        specifier: ^2.1.0
+        version: 2.2.12(typescript@5.9.3)
+
+  packages/shared:
+    devDependencies:
+      pinia:
+        specifier: ^2.2.0
+        version: 2.3.1(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3))
+      vue:
+        specifier: ^3.5.0
+        version: 3.5.38(typescript@5.9.3)
+
 packages:
 
   '@babel/helper-string-parser@7.29.7':
@@ -253,6 +287,9 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -565,6 +602,13 @@ packages:
     resolution: {integrity: sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitejs/plugin-vue@5.2.4':
+    resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0
+      vue: ^3.2.25
+
   '@volar/language-core@2.4.15':
     resolution: {integrity: sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==}
 
@@ -580,8 +624,17 @@ packages:
   '@vue/compiler-dom@3.5.38':
     resolution: {integrity: sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==}
 
+  '@vue/compiler-sfc@3.5.38':
+    resolution: {integrity: sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==}
+
+  '@vue/compiler-ssr@3.5.38':
+    resolution: {integrity: sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA==}
+
   '@vue/compiler-vue2@2.7.16':
     resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
+
+  '@vue/devtools-api@6.6.4':
+    resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
 
   '@vue/eslint-config-typescript@14.8.0':
     resolution: {integrity: sha512-yIquzhXH7ZsrwSSm+rYvoGCRY6wcuF4qBi76e0l7hHLq7YU0f9aC+RcR5fL+XJNfmBZxgX5cVl4sppt4x7ZCBg==}
@@ -601,6 +654,20 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@vue/reactivity@3.5.38':
+    resolution: {integrity: sha512-pG6LV/NDNRbKizcUjFFLAfjaL8mcv4DmR9avNcUw2gDHBzZneuS2TWCmp633ynzxz9YYKNeEPK2I8Wraqy2HUQ==}
+
+  '@vue/runtime-core@3.5.38':
+    resolution: {integrity: sha512-iyW8WVfF1CpCXxncZY5Ei6rSd6oZr5DgEom//fUjRBRl56AXPD+s9ATvukRt77ZFTuYlnVA1bxY+dJB94tWVYw==}
+
+  '@vue/runtime-dom@3.5.38':
+    resolution: {integrity: sha512-apX2wt9sdfDshS+a2xueFZLVpt0GkRJZSoPmrW/SA4yzXTznhfcMVW59gr7h4YQeY0vJhdJkk2rsIDwgfFgC5A==}
+
+  '@vue/server-renderer@3.5.38':
+    resolution: {integrity: sha512-vue8vbf2QlV4quHqzwmJy6dWfmRhP1J8l4wtZg60CL6VoKqcPY2oe7may3+1d9qfpedjK5PRLFqd5k3Isj9mUw==}
+    peerDependencies:
+      vue: 3.5.38
 
   '@vue/shared@3.5.38':
     resolution: {integrity: sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==}
@@ -682,6 +749,9 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
@@ -928,6 +998,9 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1004,6 +1077,15 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pinia@2.3.1:
+    resolution: {integrity: sha512-khUlZSwt9xXCaTbbxFYBKDc/bWAGWJjOgvxETwkTN7KRm66EeT1ZdZj6i2ceh9sP2Pzqsbc704r2yngBrxBVug==}
+    peerDependencies:
+      typescript: '>=4.4.4'
+      vue: ^2.7.0 || ^3.5.11
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   playwright-core@1.60.0:
     resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
@@ -1163,6 +1245,17 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  vue-demi@0.14.10:
+    resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+
   vue-eslint-parser@10.4.1:
     resolution: {integrity: sha512-Gk6gRDj0n/fkRa3C3l0bBheoBckUq/Rs0F/TvMWIS6nzzx67amAViMe9CkNgsP2tXyQONvGiHQESHwFtZ3aYDA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1175,11 +1268,24 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
 
+  vue-router@4.6.4:
+    resolution: {integrity: sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==}
+    peerDependencies:
+      vue: ^3.5.0
+
   vue-tsc@2.2.12:
     resolution: {integrity: sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==}
     hasBin: true
     peerDependencies:
       typescript: '>=5.0.0'
+
+  vue@3.5.38:
+    resolution: {integrity: sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -1343,6 +1449,8 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -1593,6 +1701,11 @@ snapshots:
       '@typescript-eslint/types': 8.61.0
       eslint-visitor-keys: 5.0.1
 
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(sass@1.101.0))(vue@3.5.38(typescript@5.9.3))':
+    dependencies:
+      vite: 5.4.21(sass@1.101.0)
+      vue: 3.5.38(typescript@5.9.3)
+
   '@volar/language-core@2.4.15':
     dependencies:
       '@volar/source-map': 2.4.15
@@ -1618,10 +1731,29 @@ snapshots:
       '@vue/compiler-core': 3.5.38
       '@vue/shared': 3.5.38
 
+  '@vue/compiler-sfc@3.5.38':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.5.38
+      '@vue/compiler-dom': 3.5.38
+      '@vue/compiler-ssr': 3.5.38
+      '@vue/shared': 3.5.38
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.15
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.38':
+    dependencies:
+      '@vue/compiler-dom': 3.5.38
+      '@vue/shared': 3.5.38
+
   '@vue/compiler-vue2@2.7.16':
     dependencies:
       de-indent: 1.0.2
       he: 1.2.0
+
+  '@vue/devtools-api@6.6.4': {}
 
   '@vue/eslint-config-typescript@14.8.0(eslint-plugin-vue@9.33.0(eslint@9.39.4))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
@@ -1648,6 +1780,28 @@ snapshots:
       path-browserify: 1.0.1
     optionalDependencies:
       typescript: 5.9.3
+
+  '@vue/reactivity@3.5.38':
+    dependencies:
+      '@vue/shared': 3.5.38
+
+  '@vue/runtime-core@3.5.38':
+    dependencies:
+      '@vue/reactivity': 3.5.38
+      '@vue/shared': 3.5.38
+
+  '@vue/runtime-dom@3.5.38':
+    dependencies:
+      '@vue/reactivity': 3.5.38
+      '@vue/runtime-core': 3.5.38
+      '@vue/shared': 3.5.38
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.38(vue@3.5.38(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.38
+      '@vue/shared': 3.5.38
+      vue: 3.5.38(typescript@5.9.3)
 
   '@vue/shared@3.5.38': {}
 
@@ -1721,6 +1875,8 @@ snapshots:
       which: 2.0.2
 
   cssesc@3.0.0: {}
+
+  csstype@3.2.3: {}
 
   de-indent@1.0.2: {}
 
@@ -1987,6 +2143,10 @@ snapshots:
 
   lodash@4.18.1: {}
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -2053,6 +2213,16 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  pinia@2.3.1(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3)):
+    dependencies:
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.38(typescript@5.9.3)
+      vue-demi: 0.14.10(vue@3.5.38(typescript@5.9.3))
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@vue/composition-api'
 
   playwright-core@1.60.0: {}
 
@@ -2195,6 +2365,10 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
+  vue-demi@0.14.10(vue@3.5.38(typescript@5.9.3)):
+    dependencies:
+      vue: 3.5.38(typescript@5.9.3)
+
   vue-eslint-parser@10.4.1(eslint@9.39.4):
     dependencies:
       debug: 4.4.3
@@ -2220,10 +2394,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  vue-router@4.6.4(vue@3.5.38(typescript@5.9.3)):
+    dependencies:
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.38(typescript@5.9.3)
+
   vue-tsc@2.2.12(typescript@5.9.3):
     dependencies:
       '@volar/typescript': 2.4.15
       '@vue/language-core': 2.2.12(typescript@5.9.3)
+      typescript: 5.9.3
+
+  vue@3.5.38(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.38
+      '@vue/compiler-sfc': 3.5.38
+      '@vue/runtime-dom': 3.5.38
+      '@vue/server-renderer': 3.5.38(vue@3.5.38(typescript@5.9.3))
+      '@vue/shared': 3.5.38
+    optionalDependencies:
       typescript: 5.9.3
 
   which@2.0.2:

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       eslint:
         specifier: ^9.13.0
         version: 9.39.4
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.2(eslint@9.39.4)
       eslint-plugin-vue:
         specifier: ^9.30.0
         version: 9.33.0(eslint@9.39.4)
@@ -32,6 +35,31 @@ importers:
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
+      vite:
+        specifier: ^5.4.0
+        version: 5.4.21(sass@1.101.0)
+      vue-tsc:
+        specifier: ^2.1.0
+        version: 2.2.12(typescript@5.9.3)
+
+  apps/brain:
+    dependencies:
+      '@chalie/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      pinia:
+        specifier: ^2.2.0
+        version: 2.3.1(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3))
+      vue:
+        specifier: ^3.5.0
+        version: 3.5.38(typescript@5.9.3)
+      vue-router:
+        specifier: ^4.4.0
+        version: 4.6.4(vue@3.5.38(typescript@5.9.3))
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: ^5.1.0
+        version: 5.2.4(vite@5.4.21(sass@1.101.0))(vue@3.5.38(typescript@5.9.3))
       vite:
         specifier: ^5.4.0
         version: 5.4.21(sass@1.101.0)
@@ -784,6 +812,12 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  eslint-config-prettier@9.1.2:
+    resolution: {integrity: sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
 
   eslint-plugin-vue@9.33.0:
     resolution: {integrity: sha512-174lJKuNsuDIlLpjeXc5E2Tss8P44uIimAfGD0b90k0NoirJqpG7stLuU9Vp/9ioTOrQdWVREc4mRd1BD+CvGw==}
@@ -1918,6 +1952,10 @@ snapshots:
       '@esbuild/win32-x64': 0.21.5
 
   escape-string-regexp@4.0.0: {}
+
+  eslint-config-prettier@9.1.2(eslint@9.39.4):
+    dependencies:
+      eslint: 9.39.4
 
   eslint-plugin-vue@9.33.0(eslint@9.39.4):
     dependencies:

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
         specifier: ^4.4.0
         version: 4.6.4(vue@3.5.38(typescript@5.9.3))
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@vitejs/plugin-vue':
         specifier: ^5.1.0
         version: 5.2.4(vite@5.4.21(sass@1.101.0))(vue@3.5.38(typescript@5.9.3))

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'packages/*'
+  - 'apps/*'

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - 'packages/*'
   - 'apps/*'
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true

--- a/frontend/tsconfig.base.json
+++ b/frontend/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "exactOptionalPropertyTypes": false,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "useDefineForClassFields": true
+  }
+}


### PR DESCRIPTION
## Summary

Foundation (P0) for migrating Chalie's hand-rolled HTML/CSS/JS frontend to **Vue 3 + TypeScript**. Purely **additive** — the legacy interface is untouched and continues to serve at `/`; the new Vue build is served alongside it at `/next/`, so the two coexist during the migration.

- **pnpm workspace** under `frontend/` — `packages/shared` (cross-app library) + `apps/interface` + `apps/brain`.
- **Toolchain**: Vite + Vue 3 + TypeScript (strict) + SCSS, with ESLint (flat config), Prettier, and `vue-tsc` typechecking.
- **Shared package**:
  - Typed `ApiClient` (`AuthError` / `HttpError`).
  - Typed `WebSocketService` — faithful port of the existing client preserving reconnect/backoff and the half-open liveness watchdog, over a typed inbound-event union.
  - `PlatformAdapter` interface + web implementation (seam for future native wrappers).
  - SCSS theme port — existing design tokens preserved as CSS variables under `[data-theme]`, so dark/light theming carries over unchanged.
  - Base UI components replacing Bootstrap.
- **Apps**: `interface` Vue shell with a smoke route; `brain` scaffold placeholder.
- **Backend**: a serve-layer route exposing the built Vue interface at `/next/` next to the legacy static assets.
- **E2E**: a Playwright harness against a real Chalie instance (boot / theme / api / websocket), zero mocks.

## Verification

All gates green at HEAD `8d8fe616`:

- TypeScript (`vue-tsc --noEmit`): `packages/shared`, `apps/interface`, `apps/brain` — all clean.
- Vite build: both apps build (`✓ built`).
- ESLint: clean.
- Playwright discovery: 7 tests across 3 specs.
- Backend `pytest -m unit`: **1466 passed**.

## Scope / safety

- Additive only — no existing files removed or rewritten (52 files, **+4351 / −0**).
- Base branch: `rc-0.9.0`. Merge is intentionally left as a manual step.

Ref: TKT-952 (Vue 3 frontend migration — P0 Foundation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
