### PR TITLE
refactor(web_search): snippet-first delegate prompt; disable per-search rich card

### DIFF
--- a/backend/abilities/search.py
+++ b/backend/abilities/search.py
@@ -175,7 +175,15 @@ class SearchAbility(Ability):
             # Weak-routing supplement mixes DDG into a real result set — name it.
             result_meta["fallback"] = _DDG
 
-        rich = self._build_rich_card(results) if structured else None
+        # --- Rich media card temporarily disabled (web_search latency work) ---
+        # _build_rich_card resolves og:image URLs with synchronous network calls
+        # on every search. Inside the web_search delegate (which never broadcasts
+        # the card to the user) that is pure latency tax, and even on the chat
+        # channel it serialises the turn behind 1-3 extra HTTP fetches. Left in
+        # place but not invoked; to be re-wired properly with a design spec.
+        # See follow-up ticket: "Re-wire rich media card for web_search results".
+        # rich = self._build_rich_card(results) if structured else None
+        rich = None
         return ToolResult.ok(structured, rich=rich, **result_meta)
 
     # ── Provider registry ──────────────────────────────────────────────────────

--- a/backend/configs/channels/web_search.py
+++ b/backend/configs/channels/web_search.py
@@ -31,14 +31,17 @@ from abilities._delegate import render_trail
 from services.processor_config import ProcessorConfig
 
 _WEB_SEARCH_SYSTEM_PROMPT = (
-    "You are a focused web-research agent. You receive a single research query "
-    "and answer it by searching the web and reading the most relevant sources.\n\n"
-    "Loop: search → read the best results → search again to fill gaps → "
-    "synthesise. Cite the sources you actually read. Do not fabricate URLs, "
-    "quotes, or facts. If the web yields nothing useful, say so honestly.\n\n"
-    "Return a concise, well-grounded synthesis that directly answers the query. "
-    "You have no conversation history and no user personality — work only from "
-    "the query you were given."
+    "You are a focused web-research agent. You receive one research query and "
+    "answer it from the web.\n\n"
+    "Be efficient. Run ONE search, then work from the result snippets — they "
+    "usually already answer the query. Read a full page only when the snippets "
+    "are genuinely insufficient for a specific missing detail, and read at most "
+    "the one or two most relevant pages. Do not re-search to fill gaps; "
+    "synthesise from what the first search and any targeted reads gave you.\n\n"
+    "Cite the sources you actually used. Never fabricate URLs, quotes, or facts. "
+    "If the web yields nothing useful, say so plainly.\n\n"
+    "Return a concise synthesis that directly answers the query. You have no "
+    "conversation history and no user personality — work only from the query."
 )
 
 _WEB_SEARCH_TOOLS: tuple[str, ...] = ("search", "read", "web_download")


### PR DESCRIPTION
## What

Two focus changes to the `web_search` delegate.

**1. Snippet-first system prompt.** Rewrites the delegate prompt to:
- Run **one** search, then answer from the result snippets (which usually already contain the answer).
- Read a full page only when a specific detail is genuinely missing — at most one or two pages.
- **Never re-search to fill gaps**; synthesise from the first search plus any targeted reads.

The previous prompt told the model to *"search again to fill gaps"*. This replaces that with tighter focus guidance so the delegate stays on the original query instead of fanning out.

**2. Disable the per-search rich-media card** in `SearchAbility.run()`. Building the card resolves `og:image` URLs with 1–3 synchronous network fetches on every search. Inside the `web_search` delegate the card is never broadcast to the user, so those fetches are pure overhead. The builder is left in place but uninvoked, to be re-wired behind a proper design spec (see follow-up ticket).

## Out of scope / unchanged

- The ACT `max_iterations` cap stays at **50** — it is an extreme-case safety net against a hallucinating model, **not** a tuning knob, and is deliberately left untouched.

## Note on framing

This is a **guidance + redundant-work** change, not a measured performance win. Spot-checking across queries showed end-to-end time is dominated by the model's own generation, not by search strategy, so the value here is a cleaner, more focused delegate and the removal of unnecessary per-search image fetches — not a latency target.
