### PR TITLE
chore(snapshot): drop dead session_secret + delete generation chain

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -3,7 +3,6 @@ REST API package — Flask app factory with Blueprint registration, WebSocket,
 and static file serving (replaces nginx).
 """
 
-import os
 import re
 import importlib
 import mimetypes
@@ -149,37 +148,6 @@ def _serve_versioned_html(directory: Path, filename: str = 'index.html') -> Resp
     return resp
 
 
-def _get_or_generate_session_secret() -> str:
-    """Return the Flask session signing secret.
-
-    Priority:
-    1. SESSION_SECRET_KEY environment variable (for multi-instance or reverse-proxy setups)
-    2. Persisted value in data/.session_secret (auto-generated on first run, mode 0600)
-    """
-    import secrets
-
-    env_key = os.environ.get('SESSION_SECRET_KEY', '').strip()
-    if env_key:
-        return env_key
-
-    secret_file = FileMapperService.get_session_secret_path()
-    if secret_file.exists():
-        try:
-            value = secret_file.read_text().strip()
-            if value:
-                return value
-        except Exception as e:
-            logger.warning(f"[Flask] Could not read {secret_file}: {e}")
-
-    # Generate a new secret and persist it
-    secret_file.parent.mkdir(parents=True, exist_ok=True)
-    value = secrets.token_hex(32)
-    secret_file.write_text(value)
-    secret_file.chmod(0o600)
-    logger.info(f"[Flask] Generated new session secret → {secret_file}")
-    return value
-
-
 def _register_blueprints(app: Flask) -> None:
     """Auto-discover and register every Blueprint defined in this package.
 
@@ -219,7 +187,6 @@ def _serve_spa(directory: Path, filename: str) -> Response:
 
 def _configure_app(app: Flask) -> None:
     """Apply Flask config, proxy middleware, and CORS to a new app instance."""
-    app.secret_key = _get_or_generate_session_secret()
     app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024
     app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 0
 

--- a/backend/services/file_mapper_service.py
+++ b/backend/services/file_mapper_service.py
@@ -46,11 +46,6 @@ class FileMapperService:
         return cls._DATA_DIR / "chalie.db"
 
     @classmethod
-    def get_session_secret_path(cls) -> Path:
-        """Return path to the persisted Flask session secret."""
-        return cls._DATA_DIR / ".session_secret"
-
-    @classmethod
     def get_secure_dir(cls) -> Path:
         """Return the directory holding vault key-material backups.
 

--- a/backend/services/snapshot_service.py
+++ b/backend/services/snapshot_service.py
@@ -2,8 +2,8 @@
 
 Produces a single standard ``.zip`` that is a complete clone of the running
 instance (the WAL-folded SQLite databases, the vault key-material backups, the
-document store, the user skills, the session secret, and the VERSION marker),
-and restores such a clone with a true wipe-and-replace at the next boot.
+document store, the user skills, and the VERSION marker), and restores such a
+clone with a true wipe-and-replace at the next boot.
 
 Crypto: a password yields a real WZ-AES-256 zip via ``pyzipper``; no password
 yields a plain ``ZIP_DEFLATED`` zip. One read path (``pyzipper.AESZipFile``)
@@ -52,7 +52,6 @@ _TS_FORMAT = "%Y%m%dT%H%M%S%fZ"
 # Mirrors VaultService: secure DIR owner-rwx, each backup file owner-read-only.
 _SECURE_DIR_MODE = 0o700
 _SECURE_FILE_MODE = 0o400
-_SESSION_SECRET_MODE = 0o600
 _RESTORE_FAILED_PREFIX = ".restore-failed-"
 _PRE_RESTORE_PREFIX = ".pre-restore-"
 
@@ -64,7 +63,6 @@ _KIND_SKILLS = "skills"
 _KIND_SECURE = "secure"
 _KIND_DOCUMENTS = "documents"
 _KIND_SKILLS_USER = "skills_user"
-_KIND_SESSION_SECRET = "session_secret"
 _KIND_VERSION = "version"
 
 # The three WAL-folded SQLite databases, in (kind, destination-helper) form.
@@ -104,7 +102,6 @@ class SnapshotService:
             _KIND_CHALIE_DB: self._fm.get_db_path(),
             _KIND_MCP_TOOLS: self._fm.get_mcp_tools_db_path(),
             _KIND_SKILLS: self._fm.get_skills_db_path(),
-            _KIND_SESSION_SECRET: self._fm.get_session_secret_path(),
             _KIND_VERSION: self._fm.get_version_path(),
         }
         return routes[kind]
@@ -173,13 +170,13 @@ class SnapshotService:
         """Lay every artifact into *staged* and return the manifest dict.
 
         WAL-folds the three DBs, copies the secure/documents/skills_user trees,
-        and copies the session secret + VERSION, recording KIND + arcname +
-        sha256 for each member.
+        and copies the VERSION marker, recording KIND + arcname + sha256 for
+        each member.
         """
         entries: list[dict] = []
         self._stage_single_file_dbs(staged, entries)
         self._stage_trees(staged, entries)
-        self._stage_loose_files(staged, entries)
+        self._stage_version(staged, entries)
         return {"version": _MANIFEST_VERSION, "artifacts": entries}
 
     def _stage_single_file_dbs(self, staged: Path, entries: list[dict]) -> None:
@@ -219,20 +216,16 @@ class SnapshotService:
                 shutil.copy2(item, target)
                 entries.append(self._entry(kind, arcname, target, rel=rel))
 
-    def _stage_loose_files(self, staged: Path, entries: list[dict]) -> None:
-        """Copy the session secret and VERSION marker into staging."""
-        loose = {
-            _KIND_SESSION_SECRET: self._fm.get_session_secret_path(),
-            _KIND_VERSION: self._fm.get_version_path(),
-        }
-        for kind, src in loose.items():
-            if not src.exists():
-                continue
-            arcname = f"{kind}/{src.name}"
-            target = staged / arcname
-            target.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(src, target)
-            entries.append(self._entry(kind, arcname, target))
+    def _stage_version(self, staged: Path, entries: list[dict]) -> None:
+        """Copy the VERSION marker into staging."""
+        src = self._fm.get_version_path()
+        if not src.exists():
+            return
+        arcname = f"{_KIND_VERSION}/{src.name}"
+        target = staged / arcname
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, target)
+        entries.append(self._entry(_KIND_VERSION, arcname, target))
 
     def _entry(self, kind: str, arcname: str, staged_file: Path, rel: str | None = None) -> dict:
         """Build one manifest entry recording KIND + arcname + sha256 (+ rel)."""
@@ -433,17 +426,14 @@ class SnapshotService:
     def _reenforce_secure_perms(self) -> None:
         """Re-lock the restored key material — zip extraction does not preserve
         the restrictive perms VaultService writes (secure dir 0o700, each backup
-        0o400) nor the 0o600 session secret. Best-effort: a restore that already
-        succeeded must not be undone by a chmod failure, so log loudly instead."""
+        0o400). Best-effort: a restore that already succeeded must not be undone
+        by a chmod failure, so log loudly instead."""
         secure_dir = self._fm.get_secure_dir()
         try:
             if secure_dir.is_dir():
                 os.chmod(secure_dir, _SECURE_DIR_MODE)
                 for backup in self._fm.list_vault_backups():
                     os.chmod(backup, _SECURE_FILE_MODE)
-            secret = self._fm.get_session_secret_path()
-            if secret.exists():
-                os.chmod(secret, _SESSION_SECRET_MODE)
         except OSError:
             logger.exception("[snapshot] could not re-enforce secure-dir perms after restore")
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -172,8 +172,7 @@ def authed_client(db):
 
     with patch('services.auth_session_service.validate_session', return_value=True), \
          patch('services.memory_store.get_shared_store', return_value=real_store), \
-         patch('services.memory_client.MemoryClientService.create_connection', return_value=real_store), \
-         patch('api._get_or_generate_session_secret', return_value='test-secret'):
+         patch('services.memory_client.MemoryClientService.create_connection', return_value=real_store):
         app = create_app()
         app.config['TESTING'] = True
         with app.test_client() as client:

--- a/backend/tests/test_api_updates_memory.py
+++ b/backend/tests/test_api_updates_memory.py
@@ -11,7 +11,6 @@ DB effects.  No collaborators are mocked.
 """
 
 import pytest
-from unittest.mock import patch
 
 from services.wrapper_auth_service import WrapperAuthService
 
@@ -27,17 +26,12 @@ pytestmark = pytest.mark.unit
 # ---------------------------------------------------------------------------
 
 def _make_client():
-    """Return a real Flask test client with no session patches applied.
-
-    The only infra patch is ``_get_or_generate_session_secret`` → it reads from
-    disk (or generates a file) during app construction, which is irrelevant to
-    bearer-auth tests and would fail if the file path is not writable in CI.
-    """
-    with patch('api._get_or_generate_session_secret', return_value='test-secret-updates'):
-        from api import create_app
-        app = create_app()
-        app.config['TESTING'] = True
-        return app.test_client()
+    """Return a real Flask test client with no session patches applied, so the
+    real require_auth decorator runs the real bearer path."""
+    from api import create_app
+    app = create_app()
+    app.config['TESTING'] = True
+    return app.test_client()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_file_mapper_service.py
+++ b/backend/tests/test_file_mapper_service.py
@@ -58,7 +58,6 @@ class TestFileMapperService:
         root = FileMapperService._CHALIE_ROOT
         candidates = [
             FileMapperService.get_db_path(),
-            FileMapperService.get_session_secret_path(),
             FileMapperService.get_schema_path(),
             FileMapperService.get_version_path(),
             FileMapperService.get_abilities_db_path(),

--- a/backend/tests/test_moments_rewrite.py
+++ b/backend/tests/test_moments_rewrite.py
@@ -182,8 +182,7 @@ def authed_client768(db768):
     real_store = MemoryStore()
     with patch("services.auth_session_service.validate_session", return_value=True), \
          patch("services.memory_store.get_shared_store", return_value=real_store), \
-         patch("services.memory_client.MemoryClientService.create_connection", return_value=real_store), \
-         patch("api._get_or_generate_session_secret", return_value="test-secret"):
+         patch("services.memory_client.MemoryClientService.create_connection", return_value=real_store):
         app = create_app()
         app.config["TESTING"] = True
         with app.test_client() as client:

--- a/backend/tests/test_snapshot_service.py
+++ b/backend/tests/test_snapshot_service.py
@@ -83,8 +83,8 @@ def instance(_db_template, tmp_path, monkeypatch):
     ``FileMapperService`` class attributes, so redirecting ``_CHALIE_ROOT`` /
     ``_DATA_DIR`` / ``_SECURE_DIR`` to a temp tree relocates the whole instance
     — chalie.db, data/secure/, data/documents/, data/skills/user/,
-    .session_secret, the .pending-restore / .pre-restore-<ts> dirs — without
-    touching the real ``data/`` directory. The DB is the fully-converged
+    the .pending-restore / .pre-restore-<ts> dirs — without touching the real
+    ``data/`` directory. The DB is the fully-converged
     session template (real schema.sql via SchemaConvergenceService), copied to
     the redirected db path, and injected as the process-wide singleton exactly
     like the ``db`` fixture does. VERSION and schema.sql are copied so the
@@ -129,8 +129,6 @@ def instance(_db_template, tmp_path, monkeypatch):
     # A real skills.sqlite + mcp_tools.sqlite so the WAL-fold step has genuine DBs.
     _make_min_sqlite(str(FileMapperService.get_skills_db_path()))
     _make_min_sqlite(str(FileMapperService.get_mcp_tools_db_path()))
-    # A real .session_secret so the clone has the file to carry.
-    FileMapperService.get_session_secret_path().write_text("a" * 64, encoding="utf-8")
 
     # Inject a real DatabaseService bound to the redirected path as the singleton.
     db_service = DatabaseService(db_path)
@@ -188,8 +186,7 @@ def client(instance):
     real_store = MemoryStore()
     with patch('services.auth_session_service.validate_session', return_value=True), \
          patch('services.memory_store.get_shared_store', return_value=real_store), \
-         patch('services.memory_client.MemoryClientService.create_connection', return_value=real_store), \
-         patch('api._get_or_generate_session_secret', return_value='test-secret'):
+         patch('services.memory_client.MemoryClientService.create_connection', return_value=real_store):
         app = create_app()
         app.config['TESTING'] = True
         with app.test_client() as c:


### PR DESCRIPTION
## What

Removes the `session_secret` from the Brain Import/Export snapshot bundle **and** deletes the entire dead `app.secret_key` / `.session_secret` generation chain.

## Why

The login session is an opaque random token (`secrets.token_urlsafe(32)`) stored in the `auth_sessions` SQLite table and validated by a DB lookup — **not** a Flask signed-session. A backend grep confirms Chalie uses no `flask.session`, `flash`, CSRF, or `oauth_state` anywhere, so `app.secret_key` (the persisted `.session_secret`) signed nothing the app ever read. Exporting it and regenerating it on every boot was dead weight, and a Flask restart never invalidated logins to begin with (they rehydrate from the DB).

## Changes

- `snapshot_service.py` — drop `session_secret` from export staging + restore; rename `_stage_loose_files` → `_stage_version` (VERSION-only); drop the session-secret chmod block in `_reenforce_secure_perms`.
- `api/__init__.py` — delete `_get_or_generate_session_secret()` and the `app.secret_key` assignment.
- `file_mapper_service.py` — delete `get_session_secret_path()`.
- Tests — remove the now-unneeded patches of the deleted generator.

## Verification

- Full pre-merge gate green: `1476 passed, 137 deselected`.
- Net `-60` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)