### PR TITLE
feat(abilities): heal model-mangled tool argument keys at the dispatch seam (TKT-964)

### DIFF
--- a/backend/abilities/_ability.py
+++ b/backend/abilities/_ability.py
@@ -241,7 +241,6 @@ class Ability(ABC):
         params: dict,
         name: str,
         *,
-        aliases: tuple[str, ...] = (),
         default: object = _MISSING,
         choices: "tuple | None" = None,
         clamp: "tuple | None" = None,
@@ -249,28 +248,27 @@ class Ability(ABC):
     ) -> object:
         """Resolve one input the model passed, with self-correcting failures.
 
-        Resolution order: the canonical ``name`` first, then each alias in turn
-        (the TKT-834 ``read`` alias-ladder generalised) — the first key present
-        with a non-None value wins. Missing → *default* (or a ``ToolParamError``
-        when *required* / no default). ``choices`` validates membership; ``clamp``
-        ``(lo, hi)`` bounds a numeric. All failures raise ``ToolParamError`` —
-        the dispatcher catches it and renders ``code=invalid-param`` with a
-        ``hint`` and ``valid=`` so the model fixes the call without re-reading the
-        schema. ``final`` — sealed at import by ``__init_subclass__``.
+        The canonical ``name`` (a :class:`abilities._params.Keys` constant) is
+        matched; the first key present with a non-None value wins. Argument-key
+        healing — a model addressing the parameter by a mangled (``source"``) or
+        alias (``url`` for ``source``) spelling — happens ONCE upstream at the
+        dispatch seam (``abilities._params.canonicalize_keys``, fed by the shared
+        :data:`abilities._params.VARIANTS` ladders), so by the time ``run()`` calls
+        ``param`` the key is already canonical and this method only matches *name*.
+        Missing → *default* (or a ``ToolParamError`` when *required* / no default).
+        ``choices`` validates membership; ``clamp`` ``(lo, hi)`` bounds a numeric.
+        All failures raise ``ToolParamError`` — the dispatcher catches it and
+        renders ``code=invalid-param`` with a ``hint`` and ``valid=`` so the model
+        fixes the call without re-reading the schema. ``final`` — sealed at import
+        by ``__init_subclass__``.
         """
-        value = _MISSING
-        for key in (name, *aliases):
-            if key in params and params[key] is not None:
-                value = params[key]
-                break
-
-        if value is _MISSING:
+        value = params.get(name)
+        if value is None:
             if required:
-                tried = ", ".join((name, *aliases))
                 raise ToolParamError(
                     f"Required parameter '{name}' is missing.",
                     code="invalid-param",
-                    hint=f"pass one of: {tried}.",
+                    hint=f"pass '{name}'.",
                 )
             if default is _MISSING:
                 return None

--- a/backend/abilities/_dispatcher.py
+++ b/backend/abilities/_dispatcher.py
@@ -32,6 +32,7 @@ from uuid import uuid4
 # Neither imports this module, so both import normally — no alias/patch hack.
 from abilities._event_emitter import ActEventEmitter
 from abilities._mcp_ability import _MCPAbility
+from abilities._params import canonicalize_keys
 from abilities._registry import AbilityRegistry
 from abilities._result import ToolParamError, ToolResult
 # ClientContext owns the per-request client-telemetry snapshot that _run()
@@ -81,26 +82,42 @@ class ToolDispatcher:
         ability = self._bind(tool_name)
         if ability is None:
             result_text = f"Unknown tool: {tool_name}"
-        elif (pre := self._prevalidate(ability, params)) is not None:
-            # ACTION_REQUIRED pre-gate fires BEFORE the permission is formed: a
-            # hallucinated action would otherwise lazily seed a bogus
-            # '<tool>.<action>' ask row and freeze the turn waiting for human
-            # approval. Malformed input never reaches the policy gate or run().
-            result_text = self._render(tool_name, pre, None)
         else:
-            # The risk class the gate keys on is derived from the inputs via the
-            # ability's classify_action hook (default None), NOT trusted from a
-            # model-supplied 'action' — a self-declared action is prompt-injectable
-            # and must never decide the permission. Fall back to the action param
-            # only when the tool offers no classification.
-            classified = ability.classify_action(params)
-            action = classified if classified is not None else params.get("action")
-            permission = f"{tool_name}.{action}" if action else tool_name
-            result_text = PolicyManager.wrap(
-                channel=getattr(config, "policy_channel", None),
-                permission=permission,
-                callback=lambda: self._execute(ability, params, act_summary),
-            )
+            # Heal model-mangled argument KEYS against the tool's declared schema
+            # before any gate or run() reads them: a stray-quote/case/alias key
+            # (e.g. 'source"', 'URL', or read's 'url' for 'source') is rewritten
+            # to its canonical parameter, so the ACTION_REQUIRED pre-gate and the
+            # ability see the real key instead of a corrupt one that would bounce
+            # on a spurious required-field error (TKT-963 / TKT-964). Defensive: a
+            # registry/schema fault must never break dispatch — on failure the raw
+            # params flow through unchanged.
+            try:
+                params = canonicalize_keys(params, ability.get_parameters())
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "[ToolDispatcher] key canonicalisation failed for %s — "
+                    "proceeding with raw params", tool_name,
+                )
+            if (pre := self._prevalidate(ability, params)) is not None:
+                # ACTION_REQUIRED pre-gate fires BEFORE the permission is formed: a
+                # hallucinated action would otherwise lazily seed a bogus
+                # '<tool>.<action>' ask row and freeze the turn waiting for human
+                # approval. Malformed input never reaches the policy gate or run().
+                result_text = self._render(tool_name, pre, None)
+            else:
+                # The risk class the gate keys on is derived from the inputs via the
+                # ability's classify_action hook (default None), NOT trusted from a
+                # model-supplied 'action' — a self-declared action is prompt-injectable
+                # and must never decide the permission. Fall back to the action param
+                # only when the tool offers no classification.
+                classified = ability.classify_action(params)
+                action = classified if classified is not None else params.get("action")
+                permission = f"{tool_name}.{action}" if action else tool_name
+                result_text = PolicyManager.wrap(
+                    channel=getattr(config, "policy_channel", None),
+                    permission=permission,
+                    callback=lambda: self._execute(ability, params, act_summary),
+                )
 
         from services.act_trail import ActTrail  # noqa: PLC0415
         ActTrail().record(

--- a/backend/abilities/_params.py
+++ b/backend/abilities/_params.py
@@ -1,0 +1,357 @@
+"""Parameter-key canonicalisation — the shared key registry and the dispatch-seam
+key healer that make every tool resilient to the argument keys a weak model emits.
+
+Two cooperating layers, applied to every tool call at the dispatch seam BEFORE
+the ACTION_REQUIRED pre-gate, the policy gate, or ``run()`` ever sees the params:
+
+1. **Key sanitisation (generic, all tools).** An incoming argument key is
+   lower-cased and stripped of every character outside ``[a-z0-9_-]``. This alone
+   heals the single commonest model defect — a stray escaped quote or a capital,
+   e.g. ``source"`` → ``source`` and ``MAX_CHARS`` → ``max_chars`` — with zero
+   per-tool knowledge. (This is the class of breakage TKT-963 root-caused: a
+   model stored ``{"source\"": "https://…"}`` and ``read`` bounced on
+   ``source-required`` because the corrupt KEY never matched.)
+
+2. **Variant resolution (registry-driven, per-tool).** A sanitised key that is
+   not one of the tool's declared parameters is matched against the variant
+   ladders in :data:`VARIANTS`; when it belongs to exactly one of *that tool's
+   own* declared parameters it is rewritten to that parameter's canonical key.
+   This is what lets ``read({"url": …})`` resolve to ``source`` while ``url``
+   stays canonical for ``web_download`` — resolution is scoped to the tool's
+   declared keys, never a global rename.
+
+Resolution is two-pass and **declared-canonical-first**, so a parameter that is
+itself a synonym of another (calendar's ``summary`` vs ``title``; ``document``'s
+``id`` vs the ``list`` tool's ``id`` alias) always wins as itself and is never
+rewritten away. An unrecognised key passes through **verbatim** (never the lossy
+lower-cased form), so MCP camelCase keys (``serverName``) and any out-of-band key
+survive intact for the tool or framework to handle.
+
+:class:`Keys` is the single source of truth for every native parameter name: each
+ability references ``Keys.<name>`` in its schema and its reads, so the registry
+keys and the wire keys can never drift. :func:`validate_registry` enforces the
+no-overlap invariant the whole design rests on — that no variant of one parameter
+can collide with another parameter (or a framework key) within the same tool. It
+runs as a feature test, NOT at import: importing every ability here would be a
+circular import, and the invariant is a property of the live registry.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+# The two keys the framework injects into / strips from every call (see
+# Ability.get_input_schema and ToolDispatcher.dispatch/_execute). No parameter and
+# no variant may ever collide with these, or a model key could hijack a framework
+# slot. Compared on the squeezed form (see ``squeeze``).
+_FRAMEWORK_KEYS = ("act_summary", "async")
+
+
+class Keys:
+    """Canonical names for every native ability parameter — one source of truth.
+
+    Each constant's VALUE is the exact wire key the model sees in the tool schema;
+    abilities reference the constant (``Keys.source``) instead of a bare string so
+    the schema, the reads, and the :data:`VARIANTS` ladders can never drift apart.
+    Attribute names mirror the wire key 1:1 (``id``/``list`` shadow builtins by
+    design — the wire key is what matters).
+    """
+
+    action = "action"
+    active_only = "active_only"
+    area = "area"
+    automation_id = "automation_id"
+    body = "body"
+    buffer_minutes = "buffer_minutes"
+    category = "category"
+    cc = "cc"
+    code = "code"
+    command = "command"
+    content = "content"
+    contents = "contents"
+    context_lines = "context_lines"
+    date_from = "date_from"
+    date_time = "date_time"
+    date_to = "date_to"
+    destination_location = "destination_location"
+    direction = "direction"
+    directory = "directory"
+    domain = "domain"
+    down_kbps = "down_kbps"
+    dtend = "dtend"
+    dtstart = "dtstart"
+    due_at = "due_at"
+    duration_seconds = "duration_seconds"
+    entity_id = "entity_id"
+    evidence_transcript_ids = "evidence_transcript_ids"
+    frequency = "frequency"
+    goal = "goal"
+    headers = "headers"
+    host = "host"
+    id = "id"  # noqa: A003 — attr name mirrors the wire key (shadows builtin)
+    identifier = "identifier"
+    image = "image"
+    include_subagent_transcripts = "include_subagent_transcripts"
+    item_id = "item_id"
+    item_type = "item_type"
+    items = "items"
+    key = "key"
+    keyword = "keyword"
+    kind = "kind"
+    language = "language"
+    limit = "limit"
+    list = "list"  # noqa: A003 — attr name mirrors the wire key (shadows builtin)
+    location = "location"
+    max_chars = "max_chars"
+    max_files = "max_files"
+    message = "message"
+    minutes = "minutes"
+    name = "name"
+    operation = "operation"
+    path = "path"
+    permissions = "permissions"
+    port_idx = "port_idx"
+    provider = "provider"
+    query = "query"
+    quota_mb = "quota_mb"
+    recurrence = "recurrence"
+    rule = "rule"
+    rule_id = "rule_id"
+    section = "section"
+    select = "select"
+    sender = "sender"
+    server_id = "server_id"
+    service = "service"
+    service_data = "service_data"
+    source = "source"
+    subject = "subject"
+    summary = "summary"
+    tags = "tags"
+    target = "target"
+    time_anchor = "time_anchor"
+    time_range = "time_range"
+    timeout = "timeout"
+    timeout_s = "timeout_s"
+    title = "title"
+    to = "to"
+    triage = "triage"
+    uid = "uid"
+    unanswered = "unanswered"
+    up_kbps = "up_kbps"
+    updates = "updates"
+    url = "url"
+    use_for = "use_for"
+    value = "value"
+    window_end = "window_end"
+    window_start = "window_start"
+    wlan_id = "wlan_id"
+
+    @classmethod
+    def values(cls) -> "frozenset[str]":
+        """Every canonical wire key declared on this class (for schema-completeness
+        checks: a registered ability's property keys MUST be a subset of these)."""
+        return frozenset(
+            v for k, v in vars(cls).items()
+            if not k.startswith("_") and isinstance(v, str)
+        )
+
+
+# ── The variant registry ──────────────────────────────────────────────────────
+#
+# ``canonical key → the alternative keys a model emits for it``. Kept DELIBERATELY
+# small and evidence-backed: every ladder here traces to a real, observed model
+# failure, never a guess. The sanitisation layer (squeeze/lower) already gives
+# EVERY parameter junk/case resilience for free; these ladders add only the
+# semantic synonyms we have proof a model reaches for. Adding a ladder later is a
+# one-line edit — :func:`validate_registry` (a feature test) guarantees the
+# no-overlap invariant holds before the change can ship.
+#
+# Variants are matched on the squeezed form (see ``squeeze``), so listing both
+# ``filepath`` and ``file_path`` is redundant — one covers both.
+VARIANTS: "dict[str, frozenset[str]]" = {
+    # read's historical source-alias ladder (TKT-834 / TKT-899): a model addresses
+    # the read target by many names. Canonical = source.
+    Keys.source: frozenset({
+        Keys.url, "uri", "link", "href", Keys.path, "file", "filepath", "file_path",
+    }),
+    # web_download earns the SAME family on its canonical 'url' (TKT-964): the keys
+    # a model uses for a fetch target are identical to read's. 'source' is included
+    # so a model that learned read's key still lands. Canonical = url.
+    Keys.url: frozenset({
+        "uri", "link", "href", Keys.source, "address", "file_url", "download_url",
+    }),
+    # the list tool's historical 'id' alias for its list selector. Canonical = list.
+    Keys.list: frozenset({Keys.id}),
+}
+
+
+class RegistryOverlapError(Exception):
+    """Raised by :func:`validate_registry` when a tool's variant ladders overlap
+    with another of its parameters or a framework key — the invariant that keeps
+    key healing unambiguous."""
+
+
+# ── Normalisation primitives ──────────────────────────────────────────────────
+
+_DROP = re.compile(r"[^a-z0-9_-]")
+
+
+def normalize(key: str) -> str:
+    """Lower-case *key* and drop every character outside ``[a-z0-9_-]``.
+
+    This is the generic sanitisation layer: ``source"`` → ``source``,
+    ``"URL"`` → ``url``, ``max chars`` → ``maxchars`` (space dropped). Separators
+    ``-`` / ``_`` are preserved so ``max_chars`` keeps its shape for the exact
+    match; :func:`squeeze` removes them for the loose match.
+    """
+    return _DROP.sub("", str(key).lower())
+
+
+def squeeze(key: str) -> str:
+    """:func:`normalize` then drop ``-`` / ``_`` — the form keys are matched on.
+
+    Collapses every spelling of one key to a single token, so ``MAX_CHARS``,
+    ``max-chars`` and ``maxchars`` all compare equal (``maxchars``). Used for both
+    the exact (declared-param) match and the variant match.
+    """
+    return normalize(key).replace("-", "").replace("_", "")
+
+
+# ── The per-tool key healer (called at the dispatch seam) ──────────────────────
+
+def canonicalize_keys(params: dict, schema: dict) -> dict:
+    """Return *params* with its keys healed against a tool's declared *schema*.
+
+    For each incoming key, in order:
+      1. **exact** — if its squeezed form matches a declared parameter, emit that
+         parameter's canonical key (heals quotes/case/separators, e.g.
+         ``source"`` → ``source``, ``MAX_CHARS`` → ``max_chars``).
+      2. **variant** — else if its squeezed form is a variant of exactly one
+         declared parameter (via :data:`VARIANTS`), emit that parameter's key
+         (e.g. ``url`` → ``source`` for ``read``).
+      3. **passthrough** — else emit the ORIGINAL key verbatim, so MCP camelCase
+         and any unknown key survive untouched.
+
+    First write wins if two incoming keys resolve to the same canonical, mirroring
+    the historical alias-ladder's "first key present wins". *schema* is the bare
+    ``get_parameters()`` body (no framework fields); an empty/parameterless schema
+    or empty params is returned unchanged.
+    """
+    properties = schema.get("properties") if schema else None
+    if not properties or not params:
+        return dict(params)
+
+    declared = list(properties.keys())
+    by_squeeze = {squeeze(k): k for k in declared}      # squeezed form → canonical key
+    variant_map = _variant_map(declared, by_squeeze)    # squeezed variant → canonical key
+
+    healed: dict = {}
+    source_key: dict = {}                               # canonical → the raw key that filled it
+    for key, value in params.items():
+        sq = squeeze(key)
+        canonical = by_squeeze.get(sq) or variant_map.get(sq) or key
+        if canonical not in healed:
+            healed[canonical] = value
+            source_key[canonical] = key
+        elif key != source_key[canonical]:
+            # Two DISTINCT incoming keys resolved to one canonical (e.g. a model sent
+            # both ``source`` and its ``url`` alias). First write wins — mirroring the
+            # historical alias ladder — but the dropped value is never silent: a weak
+            # model double-emitting a key is exactly the confusion worth surfacing.
+            logger.warning(
+                "[canonicalize_keys] %r and %r both map to %r — keeping %r, dropping %r",
+                source_key[canonical], key, canonical, source_key[canonical], key,
+            )
+    return healed
+
+
+def _variant_map(declared: "list[str]", by_squeeze: "dict[str, str]") -> "dict[str, str]":
+    """Build ``squeezed variant → canonical key`` for one tool's declared params.
+
+    A variant that squeezes onto a declared parameter is dropped (the real
+    parameter always wins as itself), and a variant claimed by two declared
+    parameters is dropped as ambiguous. :func:`validate_registry` forbids both for
+    the real registry, so this is defensive: a future bad edit degrades to "no
+    aliasing for that key", never silent mis-routing.
+    """
+    out: "dict[str, str | None]" = {}
+    for canonical in declared:
+        for variant in VARIANTS.get(canonical, ()):
+            sq = squeeze(variant)
+            if sq in by_squeeze:
+                continue                       # a real parameter owns this form
+            if sq in out and out[sq] != canonical:
+                out[sq] = None                 # ambiguous across two params → drop
+            elif sq not in out:
+                out[sq] = canonical
+    return {sq: c for sq, c in out.items() if c is not None}
+
+
+# ── The invariant enforcer (run as a feature test, never at import) ────────────
+
+def validate_registry(abilities: "list") -> None:
+    """Assert the no-overlap invariant for every ability, or raise.
+
+    For each tool, every variant of every declared parameter must:
+      * not squeeze onto a DIFFERENT declared parameter of the same tool, and
+      * not be claimed by two declared parameters of the same tool, and
+      * not collide with a framework key.
+
+    No declared parameter may collide with a framework key either. Every
+    :data:`VARIANTS` key must be a real parameter of at least one ability (catches
+    a typo'd canonical). Raises :class:`RegistryOverlapError` listing EVERY
+    violation found (not just the first), so one run fixes the whole registry.
+    """
+    framework_sq = {squeeze(k) for k in _FRAMEWORK_KEYS}
+    problems: "list[str]" = []
+    all_declared: "set[str]" = set()
+
+    for ability in abilities:
+        name = ability.get_name()
+        try:
+            properties = (ability.get_parameters() or {}).get("properties") or {}
+        except Exception as exc:  # noqa: BLE001
+            problems.append(f"{name}: get_parameters() raised {exc!r}")
+            continue
+        declared = list(properties.keys())
+        all_declared.update(declared)
+        by_squeeze = {squeeze(k): k for k in declared}
+
+        for param in declared:
+            if squeeze(param) in framework_sq:
+                problems.append(f"{name}: parameter {param!r} collides with a framework key")
+
+        seen: "dict[str, str]" = {}
+        for canonical in declared:
+            for variant in VARIANTS.get(canonical, ()):
+                sq = squeeze(variant)
+                if sq in framework_sq:
+                    problems.append(
+                        f"{name}: variant {variant!r} of {canonical!r} collides with a framework key"
+                    )
+                other = by_squeeze.get(sq)
+                if other is not None and other != canonical:
+                    problems.append(
+                        f"{name}: variant {variant!r} of {canonical!r} collides with declared "
+                        f"parameter {other!r}"
+                    )
+                if sq in seen and seen[sq] != canonical:
+                    problems.append(
+                        f"{name}: variant {variant!r} is claimed by both {seen[sq]!r} and "
+                        f"{canonical!r}"
+                    )
+                seen[sq] = canonical
+
+    unknown = [k for k in VARIANTS if k not in all_declared]
+    if unknown:
+        problems.append(
+            f"VARIANTS keys are not declared parameters of any ability: {sorted(unknown)}"
+        )
+
+    if problems:
+        raise RegistryOverlapError(
+            "Parameter-key registry overlap(s):\n  " + "\n  ".join(problems)
+        )

--- a/backend/abilities/bash.py
+++ b/backend/abilities/bash.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import ClassVar
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult, truncate
 
 logger = logging.getLogger(__name__)
@@ -147,7 +148,7 @@ class BashAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "command": {
+            Keys.command: {
                 "type": "string",
                 "description": (
                     "Shell command to run via bash -c. "
@@ -157,7 +158,7 @@ class BashAbility(Ability):
                     "web_download for downloads, document for saving notes."
                 ),
             },
-            "timeout_s": {
+            Keys.timeout_s: {
                 "type": "integer",
                 "description": (
                     "Timeout in seconds (default 30, max 300). "
@@ -165,7 +166,7 @@ class BashAbility(Ability):
                 ),
             },
         },
-        "required": ["command"],
+        "required": [Keys.command],
     }
 
     def get_parameters(self) -> dict:
@@ -180,13 +181,13 @@ class BashAbility(Ability):
         no model-supplied action to trust. Returns ``read`` (the benign
         inspection floor) when no heavier pattern matches.
         """
-        command = (params.get("command") or "").strip()
+        command = (params.get(Keys.command) or "").strip()
         if not command:
             return _DEFAULT_ACTION
         return _classify_heuristic(command) or _DEFAULT_ACTION
 
     def run(self, params: dict) -> ToolResult:
-        command = (params.get("command") or "").strip()
+        command = (params.get(Keys.command) or "").strip()
         if not command:
             return ToolResult.err(
                 "command is required.",
@@ -202,7 +203,7 @@ class BashAbility(Ability):
                 hint="this command is blocked outright; it cannot be run.",
             )
 
-        timeout_s = _resolve_timeout(params.get("timeout_s"))
+        timeout_s = _resolve_timeout(params.get(Keys.timeout_s))
         safe_env = _build_safe_env()
 
         return _run_command(command, timeout_s, safe_env)

--- a/backend/abilities/browser.py
+++ b/backend/abilities/browser.py
@@ -24,6 +24,7 @@ from typing import ClassVar
 from urllib.parse import urlparse
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult
 from tools.browser.session import record_screenshot, run_verb
 
@@ -61,7 +62,7 @@ class BrowserAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "action": {
+            Keys.action: {
                 "type": "string",
                 "enum": [
                     "open", "read", "find", "click", "fill",
@@ -72,11 +73,11 @@ class BrowserAbility(Ability):
                     "the page that is already open."
                 ),
             },
-            "url": {
+            Keys.url: {
                 "type": "string",
                 "description": "Absolute http(s) URL. Only used by 'open'.",
             },
-            "target": {
+            Keys.target: {
                 "type": "string",
                 "description": (
                     "Visible text of the element to act on — a button or link "
@@ -84,25 +85,25 @@ class BrowserAbility(Ability):
                     "'Email'). Used by click/fill/select."
                 ),
             },
-            "value": {
+            Keys.value: {
                 "type": "string",
                 "description": "Text to type ('fill') or option to choose ('select').",
             },
-            "query": {
+            Keys.query: {
                 "type": "string",
                 "description": "Text to search for on the page. Only used by 'find'.",
             },
-            "section": {
+            Keys.section: {
                 "type": "string",
                 "description": "Optional heading text — 'read' returns only that section.",
             },
-            "direction": {
+            Keys.direction: {
                 "type": "string",
                 "enum": ["down", "up"],
                 "description": "Scroll direction. Only used by 'scroll'.",
             },
         },
-        "required": ["action"],
+        "required": [Keys.action],
     }
 
     def get_parameters(self) -> dict:
@@ -114,13 +115,13 @@ class BrowserAbility(Ability):
     # missing a required param → one code=missing-params naming it. run() never
     # sees either case.
     ACTION_REQUIRED: ClassVar[dict] = {
-        "open": ("url",),
+        "open": (Keys.url,),
         "read": (),
-        "find": ("query",),
-        "click": ("target",),
-        "fill": ("target", "value"),
-        "select": ("target", "value"),
-        "scroll": ("direction",),
+        "find": (Keys.query,),
+        "click": (Keys.target,),
+        "fill": (Keys.target, Keys.value),
+        "select": (Keys.target, Keys.value),
+        "scroll": (Keys.direction,),
         "back": (),
         "screenshot": (),
     }
@@ -128,22 +129,22 @@ class BrowserAbility(Ability):
     # verb -> params forwarded to the session layer (the required half is the
     # dispatcher pre-gate's job, above).
     _FORWARDED: ClassVar[dict] = {
-        "open": ("url",),
-        "read": ("section",),
-        "find": ("query",),
-        "click": ("target",),
-        "fill": ("target", "value"),
-        "select": ("target", "value"),
-        "scroll": ("direction",),
+        "open": (Keys.url,),
+        "read": (Keys.section,),
+        "find": (Keys.query,),
+        "click": (Keys.target,),
+        "fill": (Keys.target, Keys.value),
+        "select": (Keys.target, Keys.value),
+        "scroll": (Keys.direction,),
         "back": (),
         "screenshot": (),
     }
 
     def run(self, params: dict) -> ToolResult:
-        action = (params.get("action") or "").strip().lower()
+        action = (params.get(Keys.action) or "").strip().lower()
         if action == "open":
             from tools.browser.security import validate_url  # noqa: PLC0415
-            ok, reason = validate_url(str(params["url"]).strip())
+            ok, reason = validate_url(str(params[Keys.url]).strip())
             if not ok:
                 return ToolResult.err(
                     f"URL blocked: {reason}",

--- a/backend/abilities/calendar.py
+++ b/backend/abilities/calendar.py
@@ -36,6 +36,7 @@ from datetime import timedelta, timezone
 from typing import ClassVar
 
 from abilities._capability import CapabilityAbility
+from abilities._params import Keys
 from abilities._result import ToolResult
 from services.time_utils import utc_now
 from utils.data_utils import parse_json_column
@@ -80,7 +81,7 @@ class CalendarAbility(CapabilityAbility):
     ACTION_REQUIRED: ClassVar[dict[str, tuple[str, ...]]] = {
         "list_events": (),
         "get_event": (),
-        "create_event": ("summary", "dtstart", "dtend"),
+        "create_event": (Keys.summary, Keys.dtstart, Keys.dtend),
         "update_event": (),
         "delete_event": (),
     }
@@ -116,7 +117,7 @@ class CalendarAbility(CapabilityAbility):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "action": {
+            Keys.action: {
                 "type": "string",
                 "enum": list(_ALL_ACTIONS),
                 "description": (
@@ -128,32 +129,32 @@ class CalendarAbility(CapabilityAbility):
                     "delete_event — remove an event addressed by uid or title."
                 ),
             },
-            "date_from": {
+            Keys.date_from: {
                 "type": "string",
                 "description": (
                     "list_events: ISO date lower bound (YYYY-MM-DD). "
                     "Defaults to today when omitted."
                 ),
             },
-            "date_to": {
+            Keys.date_to: {
                 "type": "string",
                 "description": (
                     "list_events: ISO date upper bound (YYYY-MM-DD). "
                     "Defaults to 7 days after date_from when omitted."
                 ),
             },
-            "limit": {
+            Keys.limit: {
                 "type": "integer",
                 "description": "list_events: maximum number of events to return (1–200, default 50).",
             },
-            "uid": {
+            Keys.uid: {
                 "type": "string",
                 "description": (
                     "get_event / update_event / delete_event: the event's CalDAV UID. "
                     "Prefer this when known; otherwise pass title for a fuzzy match."
                 ),
             },
-            "title": {
+            Keys.title: {
                 "type": "string",
                 "description": (
                     "get_event / update_event / delete_event: event title for a fuzzy "
@@ -161,11 +162,11 @@ class CalendarAbility(CapabilityAbility):
                     "get the candidate uids back to disambiguate."
                 ),
             },
-            "summary": {
+            Keys.summary: {
                 "type": "string",
                 "description": "create_event / update_event: the event title.",
             },
-            "dtstart": {
+            Keys.dtstart: {
                 "type": "string",
                 "description": (
                     "create_event / update_event: start datetime. Natural language is "
@@ -174,20 +175,20 @@ class CalendarAbility(CapabilityAbility):
                     "NOT need to compute the UTC offset."
                 ),
             },
-            "dtend": {
+            Keys.dtend: {
                 "type": "string",
                 "description": (
                     "create_event / update_event: end datetime, same formats as dtstart."
                 ),
             },
         },
-        "required": ["action"],
+        "required": [Keys.action],
     }
 
     # ── Entry point — reads inline, writes through the base ────────────────────
 
     def run(self, params: dict) -> ToolResult:
-        action = str(params.get("action", self.DEFAULT_ACTION)).lower()
+        action = str(params.get(Keys.action, self.DEFAULT_ACTION)).lower()
 
         if action in _READ_ACTIONS:
             return _read_events(action, params)
@@ -244,7 +245,7 @@ def _normalise_write_datetimes(params: dict) -> ToolResult | None:
     ``params``. Returns an ``invalid-time`` ToolResult (and leaves params untouched)
     when a value is present but unparseable — so the CalDAV handler only ever sees
     a valid ISO string, never the datetime.min sentinel."""
-    for field in ("dtstart", "dtend"):
+    for field in (Keys.dtstart, Keys.dtend):
         raw = params.get(field)
         if raw is None:
             continue
@@ -270,10 +271,10 @@ def _resolve_target_uid(params: dict) -> ToolResult | None:
     """For uid-addressed write actions, fill ``params['uid']`` from a fuzzy
     ``title`` match when no uid was given. Returns an error ToolResult on a
     missing target, no match, or an ambiguous (>1) match; ``None`` on success."""
-    if (params.get("uid") or "").strip():
+    if (params.get(Keys.uid) or "").strip():
         return None
 
-    title = (params.get("title") or "").strip()
+    title = (params.get(Keys.title) or "").strip()
     if not title:
         return ToolResult.err(
             "uid or title is required to address the event.",
@@ -291,7 +292,7 @@ def _resolve_target_uid(params: dict) -> ToolResult | None:
     if len(matches) > 1:
         return _ambiguous_match(title, matches, "re-issue the action with the chosen uid.")
 
-    params["uid"] = matches[0]["uid"]
+    params[Keys.uid] = matches[0]["uid"]
     return None
 
 
@@ -332,8 +333,8 @@ def _read_events(action: str, params: dict) -> ToolResult:
     from abilities.schedule import query_items
 
     if action == "get_event":
-        uid = (params.get("uid") or "").strip()
-        title = (params.get("title") or "").strip()
+        uid = (params.get(Keys.uid) or "").strip()
+        title = (params.get(Keys.title) or "").strip()
         if not uid and not title:
             return ToolResult.err(
                 "uid or title is required for get_event.",
@@ -370,7 +371,7 @@ def _read_events(action: str, params: dict) -> ToolResult:
         return ToolResult.ok(body, rich=dict(body), action="get_event")
 
     # list_events — honour the advertised default window (today → +7 days).
-    limit = min(int(params.get("limit") or 50), 200)
+    limit = min(int(params.get(Keys.limit) or 50), 200)
     date_from, date_to = _resolve_window(params)
 
     rows = query_items(
@@ -387,8 +388,8 @@ def _read_events(action: str, params: dict) -> ToolResult:
 def _resolve_window(params: dict) -> tuple[str, str]:
     """Return the (date_from, date_to) ISO bounds for list_events, applying the
     advertised defaults (today → +7 days) when the model omits them."""
-    date_from = (params.get("date_from") or "").strip()
-    date_to = (params.get("date_to") or "").strip()
+    date_from = (params.get(Keys.date_from) or "").strip()
+    date_to = (params.get(Keys.date_to) or "").strip()
 
     if not date_from:
         start = utc_now().replace(hour=0, minute=0, second=0, microsecond=0)

--- a/backend/abilities/chalie_docs.py
+++ b/backend/abilities/chalie_docs.py
@@ -26,6 +26,7 @@ from typing import ClassVar
 import requests
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult, truncate
 from services.file_mapper_service import FileMapperService
 from services.text_extractor import extract_html
@@ -80,7 +81,7 @@ class ChalieDocsAbility(Ability):
     #: Action-less tool: the canonical ``query`` is the one required input. The
     #: dispatcher's ACTION_REQUIRED pre-gate rejects a call with no query as
     #: ``code=missing-params`` BEFORE run() (and before the policy gate).
-    ACTION_REQUIRED: ClassVar[dict] = {"": ("query",)}
+    ACTION_REQUIRED: ClassVar[dict] = {"": (Keys.query,)}
 
     def get_name(self) -> str:
         return "chalie_docs"
@@ -107,7 +108,7 @@ class ChalieDocsAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "query": {
+            Keys.query: {
                 "type": "string",
                 "enum": ["basics", "tools", "releases", "code-base"],
                 "description": (
@@ -118,11 +119,11 @@ class ChalieDocsAbility(Ability):
                 ),
             },
         },
-        "required": ["query"],
+        "required": [Keys.query],
     }
 
     def run(self, params: dict) -> ToolResult:
-        raw = self.param(params, "query", required=True)
+        raw = self.param(params, Keys.query, required=True)
         query = str(raw).strip().lower()
         urls = _QUERY_URLS.get(query)
         if not urls:

--- a/backend/abilities/code_eval.py
+++ b/backend/abilities/code_eval.py
@@ -31,6 +31,7 @@ from RestrictedPython import compile_restricted, safe_builtins, safe_globals
 from RestrictedPython.PrintCollector import PrintCollector
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult, truncate
 
 logger = logging.getLogger(__name__)
@@ -56,7 +57,7 @@ class CodeEvalAbility(Ability):
     # Action-less tool: the dispatcher's ACTION_REQUIRED pre-gate rejects a
     # missing/empty ``code`` as ``code=missing-params`` BEFORE the policy gate or
     # run(). The ``""`` key covers action-less tools (precedent: vision).
-    ACTION_REQUIRED: ClassVar[dict] = {"": ("code",)}
+    ACTION_REQUIRED: ClassVar[dict] = {"": (Keys.code,)}
 
     def get_name(self) -> str:
         return "code_eval"
@@ -85,12 +86,12 @@ class CodeEvalAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "code": {
+            Keys.code: {
                 "type": "string",
                 "description": "Python code to execute. Use print() to emit results.",
             },
         },
-        "required": ["code"],
+        "required": [Keys.code],
     }
 
     # Result-contract messages. The error strings are the actionable signals the
@@ -151,7 +152,7 @@ class CodeEvalAbility(Ability):
         ACTION_REQUIRED pre-gate, which rejects it. The guard covers direct
         callers the same way the pre-gate would have.
         """
-        code = (params.get("code") or "").strip()
+        code = (params.get(Keys.code) or "").strip()
         if not code:
             return ToolResult.err(
                 self._ERR_NO_CODE,

--- a/backend/abilities/contacts.py
+++ b/backend/abilities/contacts.py
@@ -34,6 +34,7 @@ import json
 from typing import ClassVar
 
 from abilities._capability import CapabilityAbility
+from abilities._params import Keys
 from abilities._result import ToolResult
 
 # Read actions answered inline against the local index. An unknown action is
@@ -53,7 +54,7 @@ class ContactsAbility(CapabilityAbility):
     # caught inline in run() so the valid= ladder names the real read actions.
     ACTION_REQUIRED: ClassVar[dict[str, tuple[str, ...]]] = {
         "list": (),
-        "get": ("identifier",),
+        "get": (Keys.identifier,),
     }
 
     def get_name(self) -> str:
@@ -85,7 +86,7 @@ class ContactsAbility(CapabilityAbility):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "action": {
+            Keys.action: {
                 "type": "string",
                 "enum": ["list", "get"],
                 "description": (
@@ -94,26 +95,26 @@ class ContactsAbility(CapabilityAbility):
                     "get — fetch full details for a specific contact by name or email."
                 ),
             },
-            "query": {
+            Keys.query: {
                 "type": "string",
                 "description": "list: search query to filter contacts by name or other fields.",
             },
-            "limit": {
+            Keys.limit: {
                 "type": "integer",
                 "description": "list: maximum number of contacts to return.",
             },
-            "identifier": {
+            Keys.identifier: {
                 "type": "string",
                 "description": "get: name or email address identifying the contact to look up.",
             },
         },
-        "required": ["action"],
+        "required": [Keys.action],
     }
 
     # ── Entry point — both actions are inline reads against the local index ─────
 
     def run(self, params: dict) -> ToolResult:
-        action = str(params.get("action", self.DEFAULT_ACTION)).lower()
+        action = str(params.get(Keys.action, self.DEFAULT_ACTION)).lower()
 
         if action == "list":
             return self._list(params)
@@ -132,8 +133,8 @@ class ContactsAbility(CapabilityAbility):
     def _list(self, params: dict) -> ToolResult:
         from capabilities.contact_resolver import _parse_contact_row, resolve
 
-        limit = int(self.param(params, "limit", default=20, clamp=(1, 50)))
-        query = (params.get("query") or "").strip()
+        limit = int(self.param(params, Keys.limit, default=20, clamp=(1, 50)))
+        query = (params.get(Keys.query) or "").strip()
 
         if query:
             contacts = resolve(query, limit=limit)
@@ -172,7 +173,7 @@ class ContactsAbility(CapabilityAbility):
     def _get(self, params: dict) -> ToolResult:
         from capabilities.contact_resolver import resolve
 
-        identifier = (params.get("identifier") or "").strip()
+        identifier = (params.get(Keys.identifier) or "").strip()
         candidates = resolve(identifier, limit=5)
 
         if not candidates:

--- a/backend/abilities/document.py
+++ b/backend/abilities/document.py
@@ -36,6 +36,7 @@ import shutil as _shutil
 from typing import ClassVar
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult
 from services.document_chunking import create_document_artifacts
 
@@ -53,12 +54,12 @@ class DocumentAbility(Ability):
     # handlers raise the precise missing-target error. ``upload`` is mechanical
     # (not in INPUT_SCHEMA) and validated inside ingest_file.
     ACTION_REQUIRED: ClassVar[dict] = {
-        "search": ("query",),
+        "search": (Keys.query,),
         "list": (),
         "view": (),
         "delete": (),
         "restore": (),
-        "create": ("name", "content"),
+        "create": (Keys.name, Keys.content),
         "upload": (),
     }
 
@@ -89,7 +90,7 @@ class DocumentAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "action": {
+            Keys.action: {
                 "type": "string",
                 "enum": ["search", "list", "view", "delete", "restore", "create"],
                 "description": (
@@ -97,18 +98,18 @@ class DocumentAbility(Ability):
                     "create, save, write, or store a note or document."
                 ),
             },
-            "query": {
+            Keys.query: {
                 "type": "string",
                 "description": "Text to search across all documents. Required for search.",
             },
-            "id": {
+            Keys.id: {
                 "type": "string",
                 "description": (
                     "Exact document ID (view, delete, restore). Prefer this over `name`: "
                     "delete only proceeds on an exact id or a single exact-name match."
                 ),
             },
-            "name": {
+            Keys.name: {
                 "type": "string",
                 "description": (
                     "Required for `create`; use a filename like 'research-notes.md' "
@@ -116,16 +117,16 @@ class DocumentAbility(Ability):
                     "an inexact or non-unique name returns the candidate list to pick from by id."
                 ),
             },
-            "content": {
+            Keys.content: {
                 "type": "string",
                 "description": "The full text body to write. Required for `create`.",
             },
         },
-        "required": ["action"],
+        "required": [Keys.action],
     }
 
     def run(self, params: dict) -> ToolResult:
-        action = params.get("action", "search")
+        action = params.get(Keys.action, "search")
 
         from services.database_service import get_shared_db_service
         from services.document_service import DocumentService
@@ -205,7 +206,7 @@ def _resolve_unique(service, params: dict) -> "dict | ToolResult":
     single non-exact (substring) match, returns ``ambiguous-match`` with the
     candidate rows rather than silently picking the first hit.
     """
-    doc_id = (params.get("id") or "").strip()
+    doc_id = (params.get(Keys.id) or "").strip()
     if doc_id:
         doc = service.get_document(doc_id)
         if not doc:
@@ -216,7 +217,7 @@ def _resolve_unique(service, params: dict) -> "dict | ToolResult":
             )
         return doc
 
-    name = (params.get("name") or "").strip()
+    name = (params.get(Keys.name) or "").strip()
     if not name:
         return ToolResult.err(
             "id or name is required to address the document.",
@@ -263,7 +264,7 @@ def _group_results_by_doc(results: list) -> dict:
 
 
 def _handle_search(service, params: dict) -> ToolResult:
-    query = params.get("query", "").strip()
+    query = params.get(Keys.query, "").strip()
 
     from services.data_graph_service import KIND_DOCUMENT, get_data_graph_service
 
@@ -406,8 +407,8 @@ def _handle_delete(service, params: dict) -> ToolResult:
 
 
 def _handle_restore(service, params: dict) -> ToolResult:
-    doc_id = (params.get("id") or "").strip()
-    name = (params.get("name") or "").strip()
+    doc_id = (params.get(Keys.id) or "").strip()
+    name = (params.get(Keys.name) or "").strip()
 
     if doc_id:
         doc = service.get_document(doc_id)
@@ -566,8 +567,8 @@ def _handle_upload(service, params: dict) -> ToolResult:
     """
     result = ingest_file(
         service,
-        params.get("path"),
-        name=params.get("name"),
+        params.get(Keys.path),
+        name=params.get(Keys.name),
     )
     if result.get("error"):
         return ToolResult.err(result["error"], code="upload-failed", action="upload")
@@ -590,8 +591,8 @@ def _handle_upload(service, params: dict) -> ToolResult:
 
 
 def _handle_create(service, params: dict) -> ToolResult:
-    name = params.get("name", "").strip()
-    content = params.get("content", "").strip()
+    name = params.get(Keys.name, "").strip()
+    content = params.get(Keys.content, "").strip()
 
     if "." not in name:
         name = f"{name}.md"

--- a/backend/abilities/email.py
+++ b/backend/abilities/email.py
@@ -32,6 +32,7 @@ import re
 from typing import ClassVar
 
 from abilities._capability import CapabilityAbility
+from abilities._params import Keys
 from abilities._result import ToolResult, truncate
 
 logger = logging.getLogger(__name__)
@@ -73,12 +74,12 @@ class EmailAbility(CapabilityAbility):
     # empty filter set lists the recent inbox).
     ACTION_REQUIRED: ClassVar[dict[str, tuple[str, ...]]] = {
         "search": (),
-        "read": ("uid",),
-        "draft": ("to", "subject", "body"),
-        "manage": ("uid", "operation"),
-        "send": ("to", "subject", "body"),
-        "reply": ("uid", "body"),
-        "forward": ("uid", "to"),
+        "read": (Keys.uid,),
+        "draft": (Keys.to, Keys.subject, Keys.body),
+        "manage": (Keys.uid, Keys.operation),
+        "send": (Keys.to, Keys.subject, Keys.body),
+        "reply": (Keys.uid, Keys.body),
+        "forward": (Keys.uid, Keys.to),
     }
 
     def get_name(self) -> str:
@@ -112,7 +113,7 @@ class EmailAbility(CapabilityAbility):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "action": {
+            Keys.action: {
                 "type": "string",
                 "enum": list(ACTION_HANDLERS),
                 "description": (
@@ -126,64 +127,64 @@ class EmailAbility(CapabilityAbility):
                     "forward — forward an email by uid to a new recipient (needs uid, to)."
                 ),
             },
-            "uid": {
+            Keys.uid: {
                 "type": "integer",
                 "description": "read / manage / reply / forward: IMAP uid of the target email.",
             },
-            "to": {
+            Keys.to: {
                 "type": "string",
                 "description": "send / draft / forward: recipient email address.",
             },
-            "subject": {
+            Keys.subject: {
                 "type": "string",
                 "description": "send / draft: subject line. search: filter by subject keyword.",
             },
-            "body": {
+            Keys.body: {
                 "type": "string",
                 "description": "send / draft / reply: plain-text email body.",
             },
-            "operation": {
+            Keys.operation: {
                 "type": "string",
                 "enum": ["delete", "mark_read", "mark_important", "move_to_spam"],
                 "description": "manage: the operation to perform on the email.",
             },
-            "sender": {
+            Keys.sender: {
                 "type": "string",
                 "description": "search: filter by sender email address or name.",
             },
-            "keyword": {
+            Keys.keyword: {
                 "type": "string",
                 "description": "search: full-text keyword across email body and subject.",
             },
-            "date_from": {
+            Keys.date_from: {
                 "type": "string",
                 "description": "search: ISO date lower bound (YYYY-MM-DD).",
             },
-            "date_to": {
+            Keys.date_to: {
                 "type": "string",
                 "description": "search: ISO date upper bound (YYYY-MM-DD).",
             },
-            "triage": {
+            Keys.triage: {
                 "type": "string",
                 "enum": ["actionable", "informational", "noise"],
                 "description": "search: filter by triage category.",
             },
-            "unanswered": {
+            Keys.unanswered: {
                 "type": "boolean",
                 "description": "search: when true, return only unanswered emails.",
             },
-            "cc": {
+            Keys.cc: {
                 "type": "string",
                 "description": "send: CC recipient email address.",
             },
         },
-        "required": ["action"],
+        "required": [Keys.action],
     }
 
     # ── Entry point — guardrail BEFORE the base's connected gate ────────────────
 
     def run(self, params: dict) -> ToolResult:
-        action = str(params.get("action", self.DEFAULT_ACTION)).lower()
+        action = str(params.get(Keys.action, self.DEFAULT_ACTION)).lower()
 
         if action in _RECIPIENT_ACTIONS:
             err = _validate_recipient(params)
@@ -272,7 +273,7 @@ def _validate_recipient(params: dict) -> ToolResult | None:
     ACTION_REQUIRED pre-gate already reports a missing ``to`` as missing-params)
     or well-formed. Runs ahead of the base's connected gate so the error fires
     regardless of SMTP state."""
-    to = (params.get("to") or "").strip()
+    to = (params.get(Keys.to) or "").strip()
     if not to:
         return None
     if not re.match(_RECIPIENT_RE, to):

--- a/backend/abilities/file_permissions.py
+++ b/backend/abilities/file_permissions.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import ClassVar
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult
 
 logger = logging.getLogger(__name__)
@@ -64,7 +65,7 @@ class FilePermissionsAbility(Ability):
     #: ``code=missing-params`` BEFORE run(). Blank strings are invalid here, so the
     #: truthiness-based pre-gate is exactly right; run() guards the whitespace-only
     #: residue the pre-gate lets through (``"  "`` is truthy).
-    ACTION_REQUIRED: ClassVar[dict] = {"": ("path", "permissions")}
+    ACTION_REQUIRED: ClassVar[dict] = {"": (Keys.path, Keys.permissions)}
 
     def get_name(self) -> str:
         return "file_permissions"
@@ -89,11 +90,11 @@ class FilePermissionsAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "path": {
+            Keys.path: {
                 "type": "string",
                 "description": "Absolute path to the file or directory whose permissions you want to change.",
             },
-            "permissions": {
+            Keys.permissions: {
                 "type": "string",
                 "description": (
                     "How to set the permissions. Accepts three forms:"
@@ -108,15 +109,15 @@ class FilePermissionsAbility(Ability):
                 ),
             },
         },
-        "required": ["path", "permissions"],
+        "required": [Keys.path, Keys.permissions],
     }
 
     def get_parameters(self) -> dict:
         return self._PARAMETERS
 
     def run(self, params: dict) -> ToolResult:
-        path_str = (params.get("path") or "").strip()
-        perm_str = (params.get("permissions") or "").strip()
+        path_str = (params.get(Keys.path) or "").strip()
+        perm_str = (params.get(Keys.permissions) or "").strip()
 
         # The ACTION_REQUIRED pre-gate rejects a missing/blank path or
         # permissions; this guards the whitespace-only residue it lets through

--- a/backend/abilities/file_write.py
+++ b/backend/abilities/file_write.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import ClassVar
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult
 
 logger = logging.getLogger(__name__)
@@ -32,7 +33,7 @@ class FileWriteAbility(Ability):
     #: BEFORE run(). ``contents`` is deliberately NOT listed: the pre-gate check
     #: is truthiness-based, so an empty-string ``contents`` (valid user data)
     #: would be falsely rejected there. run() guards a MISSING contents key.
-    ACTION_REQUIRED: ClassVar[dict] = {"": ("path",)}
+    ACTION_REQUIRED: ClassVar[dict] = {"": (Keys.path,)}
 
     def get_name(self) -> str:
         return "file_write"
@@ -56,11 +57,11 @@ class FileWriteAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "path": {
+            Keys.path: {
                 "type": "string",
                 "description": "Absolute path to write to.",
             },
-            "contents": {
+            Keys.contents: {
                 "type": "string",
                 "description": (
                     "Content to write to the file. Pass an empty string to "
@@ -68,24 +69,24 @@ class FileWriteAbility(Ability):
                 ),
             },
         },
-        "required": ["path", "contents"],
+        "required": [Keys.path, Keys.contents],
     }
 
     def get_parameters(self) -> dict:
         return self._PARAMETERS
 
     def run(self, params: dict) -> ToolResult:
-        path_str = params.get("path", "")
+        path_str = params.get(Keys.path, "")
 
         # 'contents' is NOT pre-gated (an empty string is valid), so a MISSING
         # key is guarded here; a present "" proceeds to write a 0-byte file.
-        if "contents" not in params:
+        if Keys.contents not in params:
             return ToolResult.err(
                 "contents is required.",
                 code="missing-params",
                 hint="pass a 'contents' string (an empty string writes a 0-byte file).",
             )
-        contents = params["contents"]
+        contents = params[Keys.contents]
         if not isinstance(contents, str):
             return ToolResult.err(
                 f"contents must be a string, got {type(contents).__name__}.",

--- a/backend/abilities/find_skills.py
+++ b/backend/abilities/find_skills.py
@@ -31,6 +31,7 @@ import sqlite3
 from pathlib import Path
 from typing import ClassVar
 
+from abilities._params import Keys
 from abilities._result import ToolResult
 from abilities._search import KNN_DEPTH, SearchableAbility
 from services.embedding_utils import pack_embedding
@@ -71,16 +72,16 @@ class FindSkillsAbility(SearchableAbility):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "query": {
+            Keys.query: {
                 "type": "string",
                 "description": "Describe the task or topic you need a playbook for.",
             },
-            "limit": {
+            Keys.limit: {
                 "type": "integer",
                 "description": "Max results (default 3, max 5).",
             },
         },
-        "required": ["query"],
+        "required": [Keys.query],
     }
 
     def get_parameters(self) -> dict:
@@ -90,8 +91,8 @@ class FindSkillsAbility(SearchableAbility):
     _LOG_PREFIX = "[FIND_SKILLS]"
 
     def run(self, params: dict) -> ToolResult:
-        query = params.get("query", "").strip()
-        limit = min(params.get("limit", _DEFAULT_LIMIT) or _DEFAULT_LIMIT, _MAX_LIMIT)
+        query = params.get(Keys.query, "").strip()
+        limit = min(params.get(Keys.limit, _DEFAULT_LIMIT) or _DEFAULT_LIMIT, _MAX_LIMIT)
         logger.info(f"{self._LOG_PREFIX} query='{query}' limit={limit}")
 
         if not query:

--- a/backend/abilities/find_tools.py
+++ b/backend/abilities/find_tools.py
@@ -3,6 +3,7 @@ import logging
 from pathlib import Path
 from typing import ClassVar
 
+from abilities._params import Keys
 from abilities._result import ToolResult
 from abilities._search import KNN_DEPTH, SearchableAbility
 from services.embedding_utils import pack_embedding
@@ -23,12 +24,12 @@ class FindToolsAbility(SearchableAbility):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "select": {
+            Keys.select: {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": "Exact tool names to activate directly.",
             },
-            "query": {
+            Keys.query: {
                 "type": "string",
                 "description": "Describe what you need.",
             },
@@ -165,7 +166,7 @@ class FindToolsAbility(SearchableAbility):
         params = copy.deepcopy(self._PARAMETERS)
         tools_index = self._build_tools_index(self.mp)
         if tools_index:
-            params["properties"]["select"]["description"] = (
+            params["properties"][Keys.select]["description"] = (
                 f"Exact tool names to activate directly. Available tools: {tools_index}"
             )
         return params
@@ -180,8 +181,8 @@ class FindToolsAbility(SearchableAbility):
         ``blocked-on-channel``) with a ``valid:`` ladder of real selectable names
         — never a prose-only result that hides whether a tool was injected.
         """
-        select_names = params.get("select")
-        query = params.get("query", "").strip()
+        select_names = params.get(Keys.select)
+        query = params.get(Keys.query, "").strip()
 
         # Require at least one param.
         if not select_names and not query:

--- a/backend/abilities/home.py
+++ b/backend/abilities/home.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 from typing import ClassVar
 
 from abilities._capability import CapabilityAbility
+from abilities._params import Keys
 from abilities._result import ToolResult
 
 # Actions whose ``entity_id`` must name a real entity. ``control`` is the silent-
@@ -71,11 +72,11 @@ class HomeAbility(CapabilityAbility):
     # naming all missing params. Read/list actions have no hard requirement.
     ACTION_REQUIRED: ClassVar[dict[str, tuple[str, ...]]] = {
         "list_devices": (),
-        "get_state": ("entity_id",),
-        "control": ("entity_id", "service"),
+        "get_state": (Keys.entity_id,),
+        "control": (Keys.entity_id, Keys.service),
         "list_automations": (),
-        "trigger_automation": ("automation_id",),
-        "subscribe_events": ("entity_id",),
+        "trigger_automation": (Keys.automation_id,),
+        "subscribe_events": (Keys.entity_id,),
     }
 
     def get_name(self) -> str:
@@ -109,7 +110,7 @@ class HomeAbility(CapabilityAbility):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "action": {
+            Keys.action: {
                 "type": "string",
                 "enum": [
                     "list_devices",
@@ -128,30 +129,30 @@ class HomeAbility(CapabilityAbility):
                     "subscribe_events -- subscribe to real-time state changes for an entity."
                 ),
             },
-            "entity_id": {
+            Keys.entity_id: {
                 "type": "string",
                 "description": (
                     "HA entity ID, e.g. 'light.living_room'. Must name a real "
                     "entity — call list_devices first if unsure."
                 ),
             },
-            "domain": {
+            Keys.domain: {
                 "type": "string",
                 "description": "list_devices: filter by HA domain (light, switch, sensor, climate, lock, etc.).",
             },
-            "area": {
+            Keys.area: {
                 "type": "string",
                 "description": "list_devices: filter by area name.",
             },
-            "service": {
+            Keys.service: {
                 "type": "string",
                 "description": "control: service to call, e.g. 'turn_on', 'turn_off', 'toggle'.",
             },
-            "service_data": {
+            Keys.service_data: {
                 "type": "object",
                 "description": "control: extra service data (brightness, temperature, etc.).",
             },
-            "automation_id": {
+            Keys.automation_id: {
                 "type": "string",
                 "description": (
                     "trigger_automation: automation entity_id (e.g. "
@@ -160,24 +161,24 @@ class HomeAbility(CapabilityAbility):
                 ),
             },
         },
-        "required": ["action"],
+        "required": [Keys.action],
     }
 
     # ── Entry point — entity guardrail, then delegate to the base ──────────────
 
     def run(self, params: dict) -> ToolResult:
-        action = str(params.get("action", self.DEFAULT_ACTION)).lower()
-        params["action"] = action
+        action = str(params.get(Keys.action, self.DEFAULT_ACTION)).lower()
+        params[Keys.action] = action
 
         cap = self._connected_capability()
         if cap is not None:
             if action in _ENTITY_ACTIONS:
-                guard = self._guard_entity(cap, action, str(params.get("entity_id", "")))
+                guard = self._guard_entity(cap, action, str(params.get(Keys.entity_id, "")))
                 if guard is not None:
                     return guard
             elif action == "trigger_automation":
                 guard = self._guard_automation(
-                    cap, action, str(params.get("automation_id", ""))
+                    cap, action, str(params.get(Keys.automation_id, ""))
                 )
                 if guard is not None:
                     return guard

--- a/backend/abilities/list.py
+++ b/backend/abilities/list.py
@@ -31,6 +31,7 @@ import logging
 from typing import ClassVar, Optional
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult
 
 logger = logging.getLogger(__name__)
@@ -50,13 +51,13 @@ class ListAbility(Ability):
     # handlers raise the precise missing-target error.
     ACTION_REQUIRED: ClassVar[dict] = {
         "list_all": (),
-        "create": ("name",),
+        "create": (Keys.name,),
         "view": (),
-        "add": ("items",),
-        "check": ("items",),
-        "remove": ("items",),
+        "add": (Keys.items,),
+        "check": (Keys.items,),
+        "remove": (Keys.items,),
         "clear": (),
-        "rename": ("name",),
+        "rename": (Keys.name,),
         "delete": (),
     }
 
@@ -83,7 +84,7 @@ class ListAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "action": {
+            Keys.action: {
                 "type": "string",
                 "enum": list(_VALID_ACTIONS),
                 "description": (
@@ -98,7 +99,7 @@ class ListAbility(Ability):
                     "delete: delete a list entirely."
                 ),
             },
-            "list": {
+            Keys.list: {
                 "type": "string",
                 "description": (
                     "List name or id; addresses an existing list for "
@@ -106,11 +107,11 @@ class ListAbility(Ability):
                     "matches more than one list returns the candidates to pick from by id."
                 ),
             },
-            "name": {
+            Keys.name: {
                 "type": "string",
                 "description": "New list name; used for create and rename only.",
             },
-            "items": {
+            Keys.items: {
                 "type": "array",
                 "items": {},
                 "description": (
@@ -122,14 +123,14 @@ class ListAbility(Ability):
                 ),
             },
         },
-        "required": ["action"],
+        "required": [Keys.action],
     }
 
     def get_parameters(self) -> dict:
         return self._PARAMETERS
 
     def run(self, params: dict) -> ToolResult:
-        action = self.param(params, "action", default="list_all")
+        action = self.param(params, Keys.action, default="list_all")
 
         from services.database_service import get_shared_db_service
         from services.list_service import ListService
@@ -197,9 +198,11 @@ def _resolve_list(ability: "ListAbility", service, params: dict) -> "dict | Tool
     Resolution order: exact id → exact (case-insensitive) name → single
     case-insensitive substring match. More than one substring match returns
     ``ambiguous-match`` with the candidate rows rather than silently picking one.
-    The ``id`` alias keeps the frontend silent-action and old transcripts working.
+    The ``id`` spelling keeps the frontend silent-action and old transcripts
+    working — it is healed to the canonical ``list`` key upstream at the dispatch
+    seam via ``VARIANTS[Keys.list]``.
     """
-    target = ability.param(params, "list", aliases=("id",), default="")
+    target = ability.param(params, Keys.list, default="")
     target = str(target).strip()
     if not target:
         return ToolResult.err(
@@ -335,7 +338,7 @@ def _ok_list(service, list_id: str) -> ToolResult:
 
 
 def _normalize_string_items(params: dict) -> list:
-    items = params.get("items", [])
+    items = params.get(Keys.items, [])
     if isinstance(items, str):
         try:
             parsed = json.loads(items)
@@ -376,7 +379,7 @@ def _handle_list_all(service) -> ToolResult:
 
 
 def _handle_create(ability: "ListAbility", service, params: dict) -> ToolResult:
-    name = str(ability.param(params, "name", default="")).strip()
+    name = str(ability.param(params, Keys.name, default="")).strip()
     if not name:
         return ToolResult.err("'name' is required.", code="missing-name")
 
@@ -431,7 +434,7 @@ def _handle_check(ability: "ListAbility", service, params: dict) -> ToolResult:
     if isinstance(lst, ToolResult):
         return lst
 
-    raw = params.get("items")
+    raw = params.get(Keys.items)
     if not isinstance(raw, list) or not raw:
         return ToolResult.err(
             "'items' must be a non-empty array.",
@@ -495,7 +498,7 @@ def _handle_rename(ability: "ListAbility", service, params: dict) -> ToolResult:
     if isinstance(lst, ToolResult):
         return lst
 
-    new_name = str(ability.param(params, "name", default="")).strip()
+    new_name = str(ability.param(params, Keys.name, default="")).strip()
     if not new_name:
         return ToolResult.err("'name' is required.", code="missing-name")
 

--- a/backend/abilities/mcp_manager.py
+++ b/backend/abilities/mcp_manager.py
@@ -41,6 +41,7 @@ import logging
 from typing import ClassVar
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult
 
 logger = logging.getLogger(__name__)
@@ -98,7 +99,7 @@ class McpManagerAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "action": {
+            Keys.action: {
                 "type": "string",
                 "enum": ["list", "add", "enable", "disable"],
                 "description": (
@@ -110,7 +111,7 @@ class McpManagerAbility(Ability):
                     "its tools from discovery; by name or server_id)."
                 ),
             },
-            "name": {
+            Keys.name: {
                 "type": "string",
                 "description": (
                     "For add: required human-readable server label "
@@ -118,21 +119,21 @@ class McpManagerAbility(Ability):
                     "label to resolve the server by when no server_id is given."
                 ),
             },
-            "host": {
+            Keys.host: {
                 "type": "string",
                 "description": (
                     "For add: required full URL including port, e.g. "
                     "'https://mcp.example.com/mcp'."
                 ),
             },
-            "headers": {
+            Keys.headers: {
                 "type": "object",
                 "description": (
                     "For add: optional extra HTTP headers as a JSON object "
                     "(e.g. {'Authorization': 'Bearer …'})."
                 ),
             },
-            "server_id": {
+            Keys.server_id: {
                 "type": "string",
                 "description": (
                     "For enable/disable: the server UUID from list (takes "
@@ -140,7 +141,7 @@ class McpManagerAbility(Ability):
                 ),
             },
         },
-        "required": ["action"],
+        "required": [Keys.action],
     }
 
     def get_parameters(self) -> dict:
@@ -161,14 +162,14 @@ class McpManagerAbility(Ability):
     # under the same missing-params code.
     ACTION_REQUIRED: ClassVar[dict] = {
         "list": (),
-        "add": ("name", "host"),
+        "add": (Keys.name, Keys.host),
         "enable": (),
         "disable": (),
     }
 
     def run(self, params: dict) -> ToolResult:
         """Dispatch to the appropriate sub-action handler."""
-        action = (params.get("action") or "").strip()
+        action = (params.get(Keys.action) or "").strip()
         dispatch = {
             "list": self._do_list,
             "add": self._do_add,
@@ -209,15 +210,15 @@ class McpManagerAbility(Ability):
         failed ping is surfaced as an ERROR, never dressed up as a connection.
         """
         from services.mcp_client_service import McpClientService  # noqa: PLC0415
-        name = (params.get("name") or "").strip()
-        host = (params.get("host") or "").strip()
+        name = (params.get(Keys.name) or "").strip()
+        host = (params.get(Keys.host) or "").strip()
         if not name or not host:
             return ToolResult.err(
                 "Both 'name' and 'host' are required to add a server.",
                 code="missing-params",
                 valid=("name", "host"),
             )
-        headers = params.get("headers") or {}
+        headers = params.get(Keys.headers) or {}
 
         svc = McpClientService()
         server = svc.add_server(name=name, host=host, headers=headers, enabled=True)
@@ -318,8 +319,8 @@ class McpManagerAbility(Ability):
         (``missing-params``) or the target does not exist (``not-found``), so the
         caller only proceeds on a real server.
         """
-        server_id = (params.get("server_id") or "").strip()
-        name = (params.get("name") or "").strip()
+        server_id = (params.get(Keys.server_id) or "").strip()
+        name = (params.get(Keys.name) or "").strip()
         if not server_id and not name:
             return ToolResult.err(
                 "Provide a server to act on.",

--- a/backend/abilities/memory.py
+++ b/backend/abilities/memory.py
@@ -19,6 +19,7 @@ import logging
 from typing import ClassVar
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult
 from services import memory_retrieval
 
@@ -51,7 +52,7 @@ class MemoryAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "action": {
+            Keys.action: {
                 "type": "string",
                 "enum": ["store", "recall", "reflect", "forget"],
                 "description": (
@@ -60,7 +61,7 @@ class MemoryAbility(Ability):
                     "forget: permanently remove a memory."
                 ),
             },
-            "kind": {
+            Keys.kind: {
                 "type": "string",
                 "enum": ["user_specific", "system", "misc"],
                 "description": (
@@ -73,7 +74,7 @@ class MemoryAbility(Ability):
                     "`document` tool for that)."
                 ),
             },
-            "key": {
+            Keys.key: {
                 "type": "string",
                 "description": (
                     "For store/forget: the canonical key from the list in the "
@@ -82,7 +83,7 @@ class MemoryAbility(Ability):
                     "fits one of the 27 concepts."
                 ),
             },
-            "value": {
+            Keys.value: {
                 "type": "string",
                 "description": (
                     "For store: the fact itself, atomic — a single value. "
@@ -92,7 +93,7 @@ class MemoryAbility(Ability):
                     "multi-value key."
                 ),
             },
-            "query": {
+            Keys.query: {
                 "type": "string",
                 "description": (
                     "For recall/reflect: what to search for. One topic per "
@@ -101,7 +102,7 @@ class MemoryAbility(Ability):
                     "sparse, try searching again with more narrow queries."
                 ),
             },
-            "location": {
+            Keys.location: {
                 "type": "string",
                 "description": (
                     "A location to filter memories by. Use a city, country, "
@@ -112,7 +113,7 @@ class MemoryAbility(Ability):
                 ),
             },
         },
-        "required": ["action"],
+        "required": [Keys.action],
     }
 
     def get_parameters(self) -> dict:
@@ -131,14 +132,14 @@ class MemoryAbility(Ability):
     # ``query`` OR ``location`` (an OR the flat map cannot express), and the
     # handler validates that pair itself, returning ``code=no-query-or-location``.
     ACTION_REQUIRED: ClassVar[dict[str, tuple[str, ...]]] = {
-        "store": ("key", "value"),
+        "store": (Keys.key, Keys.value),
         "recall": (),
-        "reflect": ("query",),
-        "forget": ("key",),
+        "reflect": (Keys.query,),
+        "forget": (Keys.key,),
     }
 
     def run(self, params: dict) -> ToolResult:
-        action = params.get("action", "recall")
+        action = params.get(Keys.action, "recall")
         mp = self.mp
         channel = getattr(getattr(mp, "config", None), "channel", "") or ""
 

--- a/backend/abilities/news.py
+++ b/backend/abilities/news.py
@@ -26,6 +26,7 @@ import logging
 from typing import ClassVar, Optional
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult
 from services import news_sources
 from services.news_service import NewsFetchError, NewsService
@@ -42,7 +43,7 @@ class NewsAbility(Ability):
     # key covers action-less tools (see ToolDispatcher._prevalidate); a missing or
     # blank query is rejected as one code=missing-params error naming 'query', so
     # run() never sees a query-less call.
-    ACTION_REQUIRED: ClassVar[dict[str, tuple[str, ...]]] = {"": ("query",)}
+    ACTION_REQUIRED: ClassVar[dict[str, tuple[str, ...]]] = {"": (Keys.query,)}
 
     def get_name(self) -> str:
         return "news"
@@ -68,17 +69,17 @@ class NewsAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "query": {
+            Keys.query: {
                 "type": "string",
                 "description": "What to search for.",
             },
-            "category": {
+            Keys.category: {
                 "type": "string",
                 "enum": list(_CATEGORIES),
                 "description": "Narrow to a news category. Use only for broad topic browsing.",
             },
         },
-        "required": ["query"],
+        "required": [Keys.query],
     }
 
     def get_parameters(self) -> dict:
@@ -102,7 +103,7 @@ class NewsAbility(Ability):
     def run(self, params: dict) -> ToolResult:
         # query presence is pre-gated by ACTION_REQUIRED; .strip() guards a
         # whitespace-only value that the truthiness pre-gate lets through.
-        query = (params.get("query") or "").strip()
+        query = (params.get(Keys.query) or "").strip()
         if not query:
             return ToolResult.err(
                 "query is required and cannot be blank.",
@@ -114,7 +115,7 @@ class NewsAbility(Ability):
         # A bogus category must be rejected loudly, never silently degraded into
         # an uncategorised search — the param helper raises ToolParamError
         # (code=invalid-param) which the dispatcher renders canonically.
-        category = self.param(params, "category", default=None, choices=_CATEGORIES)
+        category = self.param(params, Keys.category, default=None, choices=_CATEGORIES)
         telemetry = self.telemetry or {}
 
         svc = self._get_service()

--- a/backend/abilities/place.py
+++ b/backend/abilities/place.py
@@ -22,6 +22,7 @@ import logging
 from typing import ClassVar
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult
 from services.data_graph_service import KIND_PLACE, get_data_graph_service
 
@@ -51,10 +52,10 @@ class PlaceAbility(Ability):
     # whose valid= names these keys; a known action missing 'name' → one
     # missing-params error. The ability's run() never sees a malformed call.
     ACTION_REQUIRED: ClassVar[dict[str, tuple[str, ...]]] = {
-        _ACTION_SAVE: ("name",),
+        _ACTION_SAVE: (Keys.name,),
         _ACTION_LIST: (),
-        _ACTION_GET: ("name",),
-        _ACTION_DELETE: ("name",),
+        _ACTION_GET: (Keys.name,),
+        _ACTION_DELETE: (Keys.name,),
     }
 
     def get_name(self) -> str:
@@ -84,7 +85,7 @@ class PlaceAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "action": {
+            Keys.action: {
                 "type": "string",
                 "enum": [_ACTION_SAVE, _ACTION_LIST, _ACTION_GET, _ACTION_DELETE],
                 "description": (
@@ -94,7 +95,7 @@ class PlaceAbility(Ability):
                     "delete — remove a saved place by name."
                 ),
             },
-            "name": {
+            Keys.name: {
                 "type": "string",
                 "description": (
                     "The label for the place (e.g. 'home', 'work', 'gym'). "
@@ -102,15 +103,15 @@ class PlaceAbility(Ability):
                 ),
             },
         },
-        "required": ["action"],
+        "required": [Keys.action],
     }
 
     def get_parameters(self) -> dict:
         return self._PARAMETERS
 
     def run(self, params: dict) -> ToolResult:
-        action = (params.get("action") or "").lower()
-        name = (params.get("name") or "").strip().lower()
+        action = (params.get(Keys.action) or "").lower()
+        name = (params.get(Keys.name) or "").strip().lower()
 
         if action == _ACTION_SAVE:
             return self._handle_save(name, self.telemetry)

--- a/backend/abilities/programming_docs_search.py
+++ b/backend/abilities/programming_docs_search.py
@@ -30,6 +30,7 @@ from typing import ClassVar
 import requests
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult, truncate
 from services.text_extractor import extract_html
 from services.web_fetch import API, FetchBlocked, fetch_text
@@ -558,25 +559,25 @@ class ProgrammingDocsSearchAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "language": {
+            Keys.language: {
                 "type": "string",
                 "enum": _LANGUAGE_ENUM,
                 "description": "Programming language or framework to search documentation for.",
             },
-            "query": {
+            Keys.query: {
                 "type": "string",
                 "description": "What to look up — function name, class, method, module, or concept in plain language.",
             },
         },
-        "required": ["language", "query"],
+        "required": [Keys.language, Keys.query],
     }
 
     def get_parameters(self) -> dict:
         return self._PARAMETERS
 
     def run(self, params: dict) -> ToolResult:
-        language = self.param(params, "language", required=True)
-        query = self.param(params, "query", required=True)
+        language = self.param(params, Keys.language, required=True)
+        query = self.param(params, Keys.query, required=True)
         language = str(language).strip()
         query = str(query).strip()
         if not language:

--- a/backend/abilities/read.py
+++ b/backend/abilities/read.py
@@ -33,6 +33,7 @@ from urllib.parse import urlparse
 import requests
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult, truncate
 from services.web_fetch import BROWSER, FetchBlocked, fetch_page
 
@@ -64,29 +65,26 @@ class ReadAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "source": {
+            Keys.source: {
                 "type": "string",
                 "description": "URL (e.g. 'https://example.com/article') or filesystem path (e.g. '/home/user/doc.pdf'). Aliases 'url' and 'path' are also accepted.",
             },
-            "max_chars": {
+            Keys.max_chars: {
                 "type": "integer",
                 "description": "Max characters to return (default 20000).",
             },
         },
-        "required": ["source"],
+        "required": [Keys.source],
     }
 
     def get_parameters(self) -> dict:
         return self._PARAMETERS
 
-    #: The keys a model naturally emits for the read target. ``source`` is the
-    #: canonical key; the rest are honoured as aliases via ``Ability.param`` so a
-    #: call like ``read({"url": …})`` or ``read({"path": …})`` resolves instead of
-    #: bouncing on ``source-required``.
-    _SOURCE_ALIASES: ClassVar[tuple[str, ...]] = (
-        "url", "uri", "link", "href", "path", "file", "filepath", "file_path",
-    )
-
+    #: The keys a model naturally emits for the read target — ``url``, ``path``,
+    #: ``link`` … — are healed to the canonical ``source`` upstream at the dispatch
+    #: seam via the shared ``abilities._params.VARIANTS[Keys.source]`` ladder, so a
+    #: call like ``read({"url": …})`` resolves instead of bouncing on
+    #: ``source-required``. No per-tool alias list lives here anymore.
     _URL_FETCH_TIMEOUT: ClassVar[int] = 15
 
     _BLOCKED_PATH_PREFIXES: ClassVar[tuple] = ("/etc", "/proc", "/dev", "/sys", "/var/run")
@@ -100,7 +98,7 @@ class ReadAbility(Ability):
     )
 
     def run(self, params: dict) -> ToolResult:
-        source = self.param(params, "source", aliases=self._SOURCE_ALIASES)
+        source = self.param(params, Keys.source)
         if not isinstance(source, str) or not source.strip():
             # No usable target under any accepted key. Echo what the model DID send
             # so it self-corrects instead of looping on the same opaque error
@@ -116,7 +114,7 @@ class ReadAbility(Ability):
             )
         source = source.strip()
 
-        max_chars = self.param(params, "max_chars", default=20000, clamp=(100, 100000))
+        max_chars = self.param(params, Keys.max_chars, default=20000, clamp=(100, 100000))
 
         if self._is_url(source):
             return self._read_url(source, max_chars)

--- a/backend/abilities/review_tool_calls.py
+++ b/backend/abilities/review_tool_calls.py
@@ -12,6 +12,7 @@ declares only the windowed ``tool_calls`` SELECT and the structured row shape.
 
 from typing import ClassVar
 
+from abilities._params import Keys
 from abilities._review_window import ReviewWindowAbility
 
 # Tool-call params summaries can be large; clip so one row stays a single readable
@@ -46,7 +47,7 @@ class ReviewToolCallsAbility(ReviewWindowAbility):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "date_time": {
+            Keys.date_time: {
                 "type": "string",
                 "description": (
                     "ISO timestamp to anchor the search "
@@ -55,7 +56,7 @@ class ReviewToolCallsAbility(ReviewWindowAbility):
                 ),
             },
         },
-        "required": ["date_time"],
+        "required": [Keys.date_time],
     }
 
     def get_parameters(self) -> dict:

--- a/backend/abilities/review_transcript.py
+++ b/backend/abilities/review_transcript.py
@@ -17,6 +17,7 @@ structured row shape.
 
 from typing import ClassVar
 
+from abilities._params import Keys
 from abilities._result import ToolResult
 from abilities._review_window import ReviewWindowAbility
 
@@ -54,7 +55,7 @@ class ReviewTranscriptAbility(ReviewWindowAbility):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "date_time": {
+            Keys.date_time: {
                 "type": "string",
                 "description": (
                     "ISO timestamp to anchor the search "
@@ -62,14 +63,14 @@ class ReviewTranscriptAbility(ReviewWindowAbility):
                     "±buffer_minutes of this time will be returned."
                 ),
             },
-            "buffer_minutes": {
+            Keys.buffer_minutes: {
                 "type": "integer",
                 "description": (
                     f"Half-window size in minutes (default {_DEFAULT_BUFFER_MINUTES}, "
                     f"max {_MAX_BUFFER_MINUTES}). Increase to widen the search."
                 ),
             },
-            "include_subagent_transcripts": {
+            Keys.include_subagent_transcripts: {
                 "type": "boolean",
                 "description": (
                     "When true, include rows from the subagent channel in addition "
@@ -78,7 +79,7 @@ class ReviewTranscriptAbility(ReviewWindowAbility):
                 ),
             },
         },
-        "required": ["date_time"],
+        "required": [Keys.date_time],
     }
 
     def get_parameters(self) -> dict:
@@ -92,7 +93,7 @@ class ReviewTranscriptAbility(ReviewWindowAbility):
         A non-int / unparseable value is a loud ``invalid-param`` naming the valid
         range (the old ``int(...)`` crashed the whole dispatch to
         ``unhandled-exception``)."""
-        raw = params.get("buffer_minutes", _DEFAULT_BUFFER_MINUTES)
+        raw = params.get(Keys.buffer_minutes, _DEFAULT_BUFFER_MINUTES)
         try:
             minutes = int(raw)
         except (TypeError, ValueError):
@@ -111,7 +112,7 @@ class ReviewTranscriptAbility(ReviewWindowAbility):
         channel when ``include_subagent_transcripts`` is truthy — oldest first."""
         from services.database_service import get_shared_db_service
 
-        include_subagent = bool(params.get("include_subagent_transcripts", False))
+        include_subagent = bool(params.get(Keys.include_subagent_transcripts, False))
         channels = ("user", "subagent") if include_subagent else ("user",)
         placeholders = ", ".join("?" for _ in channels)
 

--- a/backend/abilities/save_graph.py
+++ b/backend/abilities/save_graph.py
@@ -11,6 +11,7 @@ from any processor that opts it in.
 from typing import ClassVar
 
 from abilities._budget import BudgetCappedAbility
+from abilities._params import Keys
 from abilities._pattern_provenance import pattern_provenance
 from abilities._result import ToolResult
 from services.data_graph_service import VALID_KINDS, get_data_graph_service
@@ -33,7 +34,7 @@ class SaveGraph(BudgetCappedAbility):
     # or empty kind/key/value as code=missing-params before run() is reached
     # (precedent: _delegate.py, file_permissions.py). The pre-gate is
     # truthiness-based, so whitespace-only residue still reaches run().
-    ACTION_REQUIRED: ClassVar[dict] = {"": ("kind", "key", "value")}
+    ACTION_REQUIRED: ClassVar[dict] = {"": (Keys.kind, Keys.key, Keys.value)}
 
     def get_name(self) -> str:
         return "save_graph"
@@ -63,11 +64,11 @@ class SaveGraph(BudgetCappedAbility):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "kind": {"type": "string", "enum": ALLOWED_KINDS},
-            "key": {"type": "string"},
-            "value": {"type": "string"},
+            Keys.kind: {"type": "string", "enum": ALLOWED_KINDS},
+            Keys.key: {"type": "string"},
+            Keys.value: {"type": "string"},
         },
-        "required": ["kind", "key", "value"],
+        "required": [Keys.kind, Keys.key, Keys.value],
     }
 
     def get_parameters(self) -> dict:
@@ -79,7 +80,7 @@ class SaveGraph(BudgetCappedAbility):
             return capped
 
         proc = self.mp
-        kind = params.get("kind", "")
+        kind = params.get(Keys.kind, "")
         if kind not in ALLOWED_KINDS:
             return ToolResult.err(
                 f"Unknown kind {kind!r}; not a storable fact kind.",
@@ -91,8 +92,8 @@ class SaveGraph(BudgetCappedAbility):
         # The dispatcher pre-gate is truthiness-based, so a non-empty but
         # whitespace-only key/value slips past it and must be rejected here
         # (precedent: file_permissions.py).
-        key = params.get("key", "").strip()
-        value = params.get("value", "").strip()
+        key = params.get(Keys.key, "").strip()
+        value = params.get(Keys.value, "").strip()
         if not key or not value:
             missing = ", ".join(
                 name for name, val in (("key", key), ("value", value)) if not val

--- a/backend/abilities/save_pattern.py
+++ b/backend/abilities/save_pattern.py
@@ -14,6 +14,7 @@ import re
 from typing import ClassVar
 
 from abilities._budget import BudgetCappedAbility
+from abilities._params import Keys
 from abilities._pattern_provenance import pattern_provenance
 from abilities._result import ToolResult
 from services.database_service import get_shared_db_service
@@ -44,7 +45,7 @@ class SavePattern(BudgetCappedAbility):
     # evidence list is rejected there too, while whitespace-only name/summary
     # residue still reaches run().
     ACTION_REQUIRED: ClassVar[dict] = {
-        "": ("name", "frequency", "summary", "evidence_transcript_ids")
+        "": (Keys.name, Keys.frequency, Keys.summary, Keys.evidence_transcript_ids)
     }
 
     def get_name(self) -> str:
@@ -74,28 +75,28 @@ class SavePattern(BudgetCappedAbility):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "name": {
+            Keys.name: {
                 "type": "string",
                 "description": "snake_case identifier; mirror existing names when reinforcing.",
             },
-            "frequency": {
+            Keys.frequency: {
                 "type": "string",
                 "enum": ["daily", "weekly", "weekday", "weekend", "ad-hoc"],
             },
-            "time_anchor": {
+            Keys.time_anchor: {
                 "type": "string",
                 "description": "Optional anchor: '07:00' | 'evening' | 'weekends' | '' if not applicable.",
             },
-            "summary": {
+            Keys.summary: {
                 "type": "string",
                 "description": "One concise sentence describing the habitual behavior. Not a narrative or episode summary.",
             },
-            "evidence_transcript_ids": {
+            Keys.evidence_transcript_ids: {
                 "type": "array",
                 "items": {"type": "integer"},
             },
         },
-        "required": ["name", "frequency", "summary", "evidence_transcript_ids"],
+        "required": [Keys.name, Keys.frequency, Keys.summary, Keys.evidence_transcript_ids],
     }
 
     def get_parameters(self) -> dict:
@@ -109,7 +110,7 @@ class SavePattern(BudgetCappedAbility):
         # The validation ORDER and rules are frozen (regex → frequency set →
         # min-2 evidence); only the failure shape changes from a phantom-success
         # dict to a loud ToolResult error, in parity with save_graph.
-        name = (params.get("name") or "").strip()
+        name = (params.get(Keys.name) or "").strip()
         # The dispatcher pre-gate is truthiness-based, so a whitespace-only name
         # slips past it as a non-empty string and must be rejected here
         # (precedent: save_graph.py, file_permissions.py).
@@ -126,7 +127,7 @@ class SavePattern(BudgetCappedAbility):
                 hint=_EXAMPLE_HINT,
             )
 
-        frequency = params.get("frequency", "")
+        frequency = params.get(Keys.frequency, "")
         if frequency not in _VALID_FREQUENCIES:
             return ToolResult.err(
                 f"Unknown frequency {frequency!r}; not a recognised cadence.",
@@ -135,7 +136,7 @@ class SavePattern(BudgetCappedAbility):
                 hint=_EXAMPLE_HINT,
             )
 
-        summary = (params.get("summary") or "").strip()
+        summary = (params.get(Keys.summary) or "").strip()
         if not summary:
             return ToolResult.err(
                 "Missing required parameter(s): summary.",
@@ -143,7 +144,7 @@ class SavePattern(BudgetCappedAbility):
                 valid=("name", "frequency", "summary", "evidence_transcript_ids"),
             )
 
-        evidence = params.get("evidence_transcript_ids")
+        evidence = params.get(Keys.evidence_transcript_ids)
         n_evidence = len(evidence) if isinstance(evidence, list) else 0
         if n_evidence < 2:
             return ToolResult.err(
@@ -157,7 +158,7 @@ class SavePattern(BudgetCappedAbility):
             "frequency": frequency,
             "summary": summary,
             "evidence": evidence,
-            "time_anchor": params.get("time_anchor", "") or "",
+            "time_anchor": params.get(Keys.time_anchor, "") or "",
         }
         proc = self.mp
         source = pattern_provenance(proc)

--- a/backend/abilities/schedule.py
+++ b/backend/abilities/schedule.py
@@ -28,6 +28,7 @@ from datetime import datetime, timezone, timedelta
 from typing import ClassVar
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult
 from services.time_utils import utc_now
 
@@ -124,9 +125,9 @@ class ScheduleAbility(Ability):
     # valid= names these keys; a known action missing a required param → one
     # missing-params error. run() never sees a malformed call.
     ACTION_REQUIRED: ClassVar[dict[str, tuple[str, ...]]] = {
-        "create": ("message",),
+        "create": (Keys.message,),
         "list": (),
-        "search": ("query",),
+        "search": (Keys.query,),
         "cancel": (),
     }
 
@@ -160,7 +161,7 @@ class ScheduleAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "action": {
+            Keys.action: {
                 "type": "string",
                 "enum": ["create", "list", "search", "cancel"],
                 "description": (
@@ -171,14 +172,14 @@ class ScheduleAbility(Ability):
                     "reminders that persist across restarts."
                 ),
             },
-            "message": {
+            Keys.message: {
                 "type": "string",
                 "description": (
                     "Required for create: what to remind or prompt (max 1000 chars). "
                     "Optional for cancel: fuzzy content match when item_id is unknown."
                 ),
             },
-            "due_at": {
+            Keys.due_at: {
                 "type": "string",
                 "description": (
                     "Required for create UNLESS destination_location is provided "
@@ -191,7 +192,7 @@ class ScheduleAbility(Ability):
                     "Must resolve to a future instant."
                 ),
             },
-            "item_type": {
+            Keys.item_type: {
                 "type": "string",
                 "enum": ["notification", "prompt"],
                 "description": (
@@ -200,32 +201,32 @@ class ScheduleAbility(Ability):
                     "'prompt' = fed to Chalie as a conversational turn at the scheduled time."
                 ),
             },
-            "recurrence": {
+            Keys.recurrence: {
                 "type": "string",
                 "description": (
                     "Optional for create: 'daily', 'weekly', 'monthly', 'weekdays', "
                     "'hourly', or 'interval:N' (every N minutes, 1-1440). Omit for one-time."
                 ),
             },
-            "window_start": {
+            Keys.window_start: {
                 "type": "string",
                 "description": (
                     "Optional for create with recurrence='hourly': HH:MM start of active "
                     "window (e.g. '09:00'). Requires window_end."
                 ),
             },
-            "window_end": {
+            Keys.window_end: {
                 "type": "string",
                 "description": (
                     "Optional for create with recurrence='hourly': HH:MM end of active "
                     "window (e.g. '17:00'). Requires window_start."
                 ),
             },
-            "item_id": {
+            Keys.item_id: {
                 "type": "string",
                 "description": "Optional for cancel: exact ID returned at create time. Prefer this when known.",
             },
-            "time_range": {
+            Keys.time_range: {
                 "type": "string",
                 "enum": ["today", "tomorrow", "this_week", "next_hour", "soon", "all"],
                 "description": (
@@ -233,20 +234,20 @@ class ScheduleAbility(Ability):
                     "'soon' = next 6 hours. Default 'all'."
                 ),
             },
-            "query": {
+            Keys.query: {
                 "type": "string",
                 "description": (
                     "Required for search: semantic query to find matching scheduled items."
                 ),
             },
-            "limit": {
+            Keys.limit: {
                 "type": "integer",
                 "description": (
                     "Optional for search: maximum number of matching items to "
                     "return (default 5, clamped to 1–50)."
                 ),
             },
-            "destination_location": {
+            Keys.destination_location: {
                 "type": "string",
                 "description": (
                     "Name of a saved place or address for the destination. "
@@ -257,7 +258,7 @@ class ScheduleAbility(Ability):
                 ),
             },
         },
-        "required": ["action"],
+        "required": [Keys.action],
     }
 
     def get_parameters(self) -> dict:
@@ -266,7 +267,7 @@ class ScheduleAbility(Ability):
     _PAST_DUE_GRACE_SECONDS: ClassVar[int] = 120
 
     def run(self, params: dict) -> ToolResult:
-        action = (params.get("action") or "list").lower()
+        action = (params.get(Keys.action) or "list").lower()
 
         if action == "create":
             channel = getattr(getattr(self.mp, "config", None), "channel", "") or ""
@@ -328,7 +329,7 @@ def _build_destination_metadata(destination: str) -> dict:
 
 def _validate_message(params: dict) -> tuple[str, ToolResult | None]:
     """Validate the `message` field. Returns (message, error | None)."""
-    message = (params.get("message") or "").strip()
+    message = (params.get(Keys.message) or "").strip()
     if not message:
         return "", ToolResult.err(
             "message is required for create.",
@@ -392,9 +393,9 @@ def _normalise_due_at(text: str) -> str:
 
 def _resolve_due_at(params: dict, past_due_grace: int) -> tuple[datetime | None, ToolResult | None]:
     """Resolve due_at (NL or ISO), apply past-due grace, return (due_at, error | None)."""
-    due_at_str = (params.get("due_at") or "").strip()
+    due_at_str = (params.get(Keys.due_at) or "").strip()
     if not due_at_str:
-        if (params.get("destination_location") or "").strip():
+        if (params.get(Keys.destination_location) or "").strip():
             return utc_now() + timedelta(days=30), None
         return None, ToolResult.err(
             "due_at is required for create (unless a destination_location is given).",
@@ -436,7 +437,7 @@ _VALID_RECURRENCES = ("daily", "weekly", "monthly", "weekdays", "hourly")
 
 def _validate_recurrence(params: dict) -> tuple[str | None, ToolResult | None]:
     """Validate `recurrence`. Returns (normalized_recurrence | None, error | None)."""
-    recurrence = params.get("recurrence")
+    recurrence = params.get(Keys.recurrence)
     if not recurrence:
         return None, None
     recurrence = recurrence.lower()
@@ -470,8 +471,8 @@ def _validate_recurrence(params: dict) -> tuple[str | None, ToolResult | None]:
 
 def _validate_windows(params: dict, recurrence: str | None) -> tuple[str | None, str | None, ToolResult | None]:
     """Validate window_start/window_end pairing with hourly recurrence."""
-    window_start = params.get("window_start")
-    window_end = params.get("window_end")
+    window_start = params.get(Keys.window_start)
+    window_end = params.get(Keys.window_end)
 
     if not (window_start or window_end):
         return None, None, None
@@ -512,7 +513,7 @@ def _validate_windows(params: dict, recurrence: str | None) -> tuple[str | None,
 
 def _validate_item_type(params: dict) -> tuple[str, ToolResult | None]:
     """Validate the `item_type` field."""
-    item_type = (params.get("item_type") or "notification").lower()
+    item_type = (params.get(Keys.item_type) or "notification").lower()
     if item_type not in ("notification", "prompt"):
         return "", ToolResult.err(
             f"item_type must be 'notification' or 'prompt', got {item_type!r}.",
@@ -537,9 +538,9 @@ def _create(channel: str, params: dict, past_due_grace: int) -> ToolResult:
         from services.database_service import get_shared_db_service
 
         logger.debug(
-            f"{LOG_PREFIX} _create called — message={params.get('message', '')!r:.80}, "
-            f"due_at={params.get('due_at', '')!r}, item_type={params.get('item_type', 'notification')!r}, "
-            f"recurrence={params.get('recurrence')!r}"
+            f"{LOG_PREFIX} _create called — message={params.get(Keys.message, '')!r:.80}, "
+            f"due_at={params.get(Keys.due_at, '')!r}, item_type={params.get(Keys.item_type, 'notification')!r}, "
+            f"recurrence={params.get(Keys.recurrence)!r}"
         )
 
         message, err = _validate_message(params)
@@ -611,7 +612,7 @@ def _create(channel: str, params: dict, past_due_grace: int) -> ToolResult:
                 }
                 return _create_result(record)
 
-        destination = (params.get("destination_location") or "").strip()
+        destination = (params.get(Keys.destination_location) or "").strip()
         if destination:
             dest_meta = _build_destination_metadata(destination)
             try:
@@ -660,8 +661,8 @@ def _create_result(record: dict) -> ToolResult:
 
 
 def _search(ability: "ScheduleAbility", params: dict, mp=None) -> ToolResult:
-    query = (params.get("query") or "").strip()
-    limit = ability.param(params, "limit", default=5, clamp=(1, 50))
+    query = (params.get(Keys.query) or "").strip()
+    limit = ability.param(params, Keys.limit, default=5, clamp=(1, 50))
 
     try:
         from services.embedding_service import get_embedding_service
@@ -718,7 +719,7 @@ def _search(ability: "ScheduleAbility", params: dict, mp=None) -> ToolResult:
 
 def _list(params: dict) -> ToolResult:
     try:
-        time_range = (params.get("time_range") or "all").lower()
+        time_range = (params.get(Keys.time_range) or "all").lower()
         start_dt, end_dt, _ = _resolve_time_range(time_range)
 
         rows = query_items(
@@ -802,8 +803,8 @@ def _cancel(params: dict) -> ToolResult:
     try:
         from services.database_service import get_shared_db_service
 
-        item_id = (params.get("item_id") or "").strip()
-        message_query = (params.get("message") or "").strip()
+        item_id = (params.get(Keys.item_id) or "").strip()
+        message_query = (params.get(Keys.message) or "").strip()
 
         if not item_id and not message_query:
             return ToolResult.err(

--- a/backend/abilities/search.py
+++ b/backend/abilities/search.py
@@ -38,6 +38,7 @@ import time
 from typing import ClassVar
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult
 from services.file_mapper_service import FileMapperService
 from tools.search.fetcher import fetch_providers, fetch_ddg_fallback
@@ -55,7 +56,7 @@ class SearchAbility(Ability):
     # key covers action-less tools (see ToolDispatcher._prevalidate); a missing or
     # blank query is rejected as one code=missing-params error naming 'query', so
     # run() never sees a query-less call.
-    ACTION_REQUIRED: ClassVar[dict[str, tuple[str, ...]]] = {"": ("query",)}
+    ACTION_REQUIRED: ClassVar[dict[str, tuple[str, ...]]] = {"": (Keys.query,)}
 
     def get_name(self) -> str:
         return "search"
@@ -90,11 +91,11 @@ class SearchAbility(Ability):
         return {
             "type": "object",
             "properties": {
-                "query": {
+                Keys.query: {
                     "type": "string",
                     "description": "Plain natural language search query.",
                 },
-                "provider": {
+                Keys.provider: {
                     "type": "string",
                     "enum": sorted(self._known_providers()),
                     "description": (
@@ -104,13 +105,13 @@ class SearchAbility(Ability):
                         "not silently web-searched."
                     ),
                 },
-                "limit": {
+                Keys.limit: {
                     "type": "integer",
                     "description": "Max results per provider (default 5, max 10).",
                     "default": 5,
                 },
             },
-            "required": ["query"],
+            "required": [Keys.query],
         }
 
     _DB: ClassVar[str] = str(FileMapperService.get_search_providers_db_path())
@@ -119,7 +120,7 @@ class SearchAbility(Ability):
     def run(self, params: dict) -> ToolResult:
         # query presence is pre-gated by ACTION_REQUIRED; .strip() guards a
         # whitespace-only value that the truthiness pre-gate lets through.
-        query = (params.get("query") or "").strip()
+        query = (params.get(Keys.query) or "").strip()
         if not query:
             return ToolResult.err(
                 "query is required and cannot be blank.",
@@ -128,8 +129,8 @@ class SearchAbility(Ability):
                 valid=("query",),
             )
 
-        limit = self.param(params, "limit", default=5, clamp=(1, 10))
-        forced = (params.get("provider") or "").strip().lower()
+        limit = self.param(params, Keys.limit, default=5, clamp=(1, 10))
+        forced = (params.get(Keys.provider) or "").strip().lower()
 
         if forced:
             guard = self._reject_unknown_forced(forced)

--- a/backend/abilities/search_files.py
+++ b/backend/abilities/search_files.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import ClassVar
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult
 
 _GLOB_DEFAULT_MAX_FILES = 10
@@ -51,8 +52,8 @@ class SearchFilesAbility(Ability):
     # 'query' → a single code=missing-params error. A present-but-whitespace
     # query passes the pre-gate (the value is truthy), so run() still guards it.
     ACTION_REQUIRED: ClassVar[dict[str, tuple[str, ...]]] = {
-        "glob": ("query",),
-        "grep": ("query",),
+        "glob": (Keys.query,),
+        "grep": (Keys.query,),
     }
 
     def get_name(self) -> str:
@@ -83,7 +84,7 @@ class SearchFilesAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "action": {
+            Keys.action: {
                 "type": "string",
                 "enum": ["glob", "grep"],
                 "description": (
@@ -93,7 +94,7 @@ class SearchFilesAbility(Ability):
                     "shape, 'grep' when you know what's inside the file."
                 ),
             },
-            "query": {
+            Keys.query: {
                 "type": "string",
                 "description": (
                     "For 'glob': a filename or glob pattern (e.g. '*.md', "
@@ -101,7 +102,7 @@ class SearchFilesAbility(Ability):
                     "string or regex to search file contents for."
                 ),
             },
-            "directory": {
+            Keys.directory: {
                 "type": "string",
                 "description": (
                     "Optional directory to search under. Defaults to the "
@@ -110,7 +111,7 @@ class SearchFilesAbility(Ability):
                     "~-prefixed home-relative path."
                 ),
             },
-            "max_files": {
+            Keys.max_files: {
                 "type": "integer",
                 "description": (
                     "Maximum number of files to return. "
@@ -119,7 +120,7 @@ class SearchFilesAbility(Ability):
                     "truncated=true."
                 ),
             },
-            "context_lines": {
+            Keys.context_lines: {
                 "type": "integer",
                 "description": (
                     "Grep only. Number of lines to show above AND below "
@@ -128,16 +129,16 @@ class SearchFilesAbility(Ability):
                 ),
             },
         },
-        "required": ["action", "query"],
+        "required": [Keys.action, Keys.query],
     }
 
     def get_parameters(self) -> dict:
         return self._PARAMETERS
 
     def run(self, params: dict) -> ToolResult:
-        action = params.get("action", "")
-        query = (params.get("query") or "").strip()
-        directory = (params.get("directory") or "").strip()
+        action = params.get(Keys.action, "")
+        query = (params.get(Keys.query) or "").strip()
+        directory = (params.get(Keys.directory) or "").strip()
 
         # The dispatcher's ACTION_REQUIRED pre-gate has already rejected an
         # unknown action and a missing 'query'; this guards the residue it lets
@@ -156,7 +157,7 @@ class SearchFilesAbility(Ability):
             )
 
         default_max = _GREP_DEFAULT_MAX_FILES if action == "grep" else _GLOB_DEFAULT_MAX_FILES
-        max_files_raw = params.get("max_files")
+        max_files_raw = params.get(Keys.max_files)
         if max_files_raw is not None:
             try:
                 max_files = int(max_files_raw)
@@ -177,7 +178,7 @@ class SearchFilesAbility(Ability):
 
         context_lines = _DEFAULT_CONTEXT_LINES
         if action == "grep":
-            cl_raw = params.get("context_lines")
+            cl_raw = params.get(Keys.context_lines)
             if cl_raw is not None:
                 try:
                     context_lines = int(cl_raw)

--- a/backend/abilities/skill_builder.py
+++ b/backend/abilities/skill_builder.py
@@ -22,6 +22,7 @@ import sqlite3
 from typing import ClassVar
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult
 from services.file_mapper_service import FileMapperService
 from utils.skills_io import (
@@ -63,9 +64,9 @@ class SkillBuilderAbility(Ability):
     # one missing-params error naming ALL of them. edit/delete need only a title
     # (the existence/ownership checks live in run()); list needs nothing.
     ACTION_REQUIRED: ClassVar[dict] = {
-        "create": ("title", "use_for", "content"),
-        "edit": ("title",),
-        "delete": ("title",),
+        "create": (Keys.title, Keys.use_for, Keys.content),
+        "edit": (Keys.title,),
+        "delete": (Keys.title,),
         "list": (),
     }
 
@@ -100,7 +101,7 @@ class SkillBuilderAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "action": {
+            Keys.action: {
                 "type": "string",
                 "enum": ["create", "edit", "delete", "list"],
                 "description": (
@@ -110,7 +111,7 @@ class SkillBuilderAbility(Ability):
                     "list: list all skills (both curated and user-created)."
                 ),
             },
-            "title": {
+            Keys.title: {
                 "type": "string",
                 "description": (
                     "The skill title — a short noun phrase describing what the skill does "
@@ -118,7 +119,7 @@ class SkillBuilderAbility(Ability):
                     "Required for create, edit, and delete."
                 ),
             },
-            "use_for": {
+            Keys.use_for: {
                 "type": "string",
                 "description": (
                     "One sentence describing when to use this skill "
@@ -126,7 +127,7 @@ class SkillBuilderAbility(Ability):
                     "Required for create."
                 ),
             },
-            "content": {
+            Keys.content: {
                 "type": "string",
                 "description": (
                     "The skill body as numbered steps (1. 2. 3. …). "
@@ -141,7 +142,7 @@ class SkillBuilderAbility(Ability):
                     "Required for create."
                 ),
             },
-            "tags": {
+            Keys.tags: {
                 "type": "string",
                 "description": (
                     "Comma-separated keywords that describe the skill's domain "
@@ -149,7 +150,7 @@ class SkillBuilderAbility(Ability):
                 ),
             },
         },
-        "required": ["action"],
+        "required": [Keys.action],
     }
 
     def get_parameters(self) -> dict:
@@ -161,7 +162,7 @@ class SkillBuilderAbility(Ability):
         # four real actions and its required params are present. No try/except
         # swallow: an unexpected failure bubbles to the dispatcher's _run, which
         # renders it as code=unhandled-exception (errors must surface).
-        action = params.get("action", "list")
+        action = params.get(Keys.action, "list")
         config = getattr(self.mp, "config", None)
         channel = getattr(config, "channel", None)
         logger.info("%s action=%s channel=%s", _LOG_PREFIX, action, channel)
@@ -203,9 +204,9 @@ def _find_user_skill_by_title(conn: sqlite3.Connection, title: str) -> dict | No
 def _handle_create(params: dict) -> ToolResult:
     # title / use_for / content presence is guaranteed by the ACTION_REQUIRED
     # pre-gate; here we only normalise.
-    title = (params.get("title") or "").strip()
-    use_for = (params.get("use_for") or "").strip()
-    content = (params.get("content") or "").strip()
+    title = (params.get(Keys.title) or "").strip()
+    use_for = (params.get(Keys.use_for) or "").strip()
+    content = (params.get(Keys.content) or "").strip()
 
     if not SKILLS_DB_PATH.exists():
         return ToolResult.err(
@@ -225,7 +226,7 @@ def _handle_create(params: dict) -> ToolResult:
                 action="create",
             )
 
-        tags = (params.get("tags") or "").strip()
+        tags = (params.get(Keys.tags) or "").strip()
         meta = {
             "title": title,
             "use_for": use_for,
@@ -263,7 +264,7 @@ def _handle_create(params: dict) -> ToolResult:
 
 
 def _handle_edit(params: dict) -> ToolResult:
-    title = (params.get("title") or "").strip()  # presence guaranteed by pre-gate
+    title = (params.get(Keys.title) or "").strip()  # presence guaranteed by pre-gate
 
     if not SKILLS_DB_PATH.exists():
         return ToolResult.err(
@@ -286,9 +287,9 @@ def _handle_edit(params: dict) -> ToolResult:
         skill_id = existing["id"]
         updated_meta = {
             "title": title,
-            "use_for": (params.get("use_for") or "").strip() or existing["use_for"],
-            "content": (params.get("content") or "").strip() or existing["content"],
-            "tags": (params.get("tags") or "").strip() if params.get("tags") is not None else (existing["tags"] or ""),
+            "use_for": (params.get(Keys.use_for) or "").strip() or existing["use_for"],
+            "content": (params.get(Keys.content) or "").strip() or existing["content"],
+            "tags": (params.get(Keys.tags) or "").strip() if params.get(Keys.tags) is not None else (existing["tags"] or ""),
             "version": existing["version"] + 1,
         }
 
@@ -327,7 +328,7 @@ def _handle_edit(params: dict) -> ToolResult:
 
 
 def _handle_delete(params: dict) -> ToolResult:
-    title = (params.get("title") or "").strip()  # presence guaranteed by pre-gate
+    title = (params.get(Keys.title) or "").strip()  # presence guaranteed by pre-gate
 
     if not SKILLS_DB_PATH.exists():
         return ToolResult.err(

--- a/backend/abilities/timer.py
+++ b/backend/abilities/timer.py
@@ -26,6 +26,7 @@ from datetime import datetime, timezone
 from typing import ClassVar
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult
 from services.time_utils import parse_utc
 
@@ -41,7 +42,7 @@ class TimerAbility(Ability):
     # title + duration_seconds are both required; presence is enforced by the
     # dispatcher pre-gate (ACTION_REQUIRED) BEFORE run(). Key "" — action-less.
     ACTION_REQUIRED: ClassVar[dict[str, tuple[str, ...]]] = {
-        "": ("title", "duration_seconds"),
+        "": (Keys.title, Keys.duration_seconds),
     }
 
     def get_name(self) -> str:
@@ -66,26 +67,26 @@ class TimerAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "title": {
+            Keys.title: {
                 "type": "string",
                 "description": "Short label for the timer (max 80 chars). E.g. 'Focus block', 'Pasta', 'Breath hold'.",
             },
-            "duration_seconds": {
+            Keys.duration_seconds: {
                 "type": "integer",
                 "description": "Total countdown length in seconds. Must be between 1 and 86400 (24 hours).",
                 "minimum": _MIN_DURATION_SECONDS,
                 "maximum": _MAX_DURATION_SECONDS,
             },
         },
-        "required": ["title", "duration_seconds"],
+        "required": [Keys.title, Keys.duration_seconds],
     }
 
     def get_parameters(self) -> dict:
         return self._PARAMETERS
 
     def run(self, params: dict) -> ToolResult:
-        title = (params.get("title") or "").strip()
-        duration_seconds = params.get("duration_seconds")
+        title = (params.get(Keys.title) or "").strip()
+        duration_seconds = params.get(Keys.duration_seconds)
 
         # bool is an int subclass — exclude it so a literal True/False is rejected
         # rather than coerced into a 1-second / 0-second timer.

--- a/backend/abilities/ubiquiti.py
+++ b/backend/abilities/ubiquiti.py
@@ -30,6 +30,7 @@ import logging
 from typing import ClassVar, NamedTuple
 
 from abilities._capability import CapabilityAbility
+from abilities._params import Keys
 from abilities._result import ToolResult
 
 logger = logging.getLogger(__name__)
@@ -119,18 +120,18 @@ class UbiquitiAbility(CapabilityAbility):
         "list_wifi": (),
         "list_port_forwards": (),
         "list_traffic_rules": (),
-        "block_client": ("target",),
-        "unblock_client": ("target",),
-        "disconnect_client": ("target",),
-        "restart_device": ("target",),
-        "locate_device": ("target",),
-        "stop_locate_device": ("target",),
-        "power_cycle_port": ("target", "port_idx"),
-        "update_wifi": ("wlan_id", "updates"),
-        "create_port_forward": ("rule",),
-        "update_port_forward": ("rule_id", "updates"),
-        "update_traffic_rule": ("rule_id", "updates"),
-        "authorize_guest": ("target",),
+        "block_client": (Keys.target,),
+        "unblock_client": (Keys.target,),
+        "disconnect_client": (Keys.target,),
+        "restart_device": (Keys.target,),
+        "locate_device": (Keys.target,),
+        "stop_locate_device": (Keys.target,),
+        "power_cycle_port": (Keys.target, Keys.port_idx),
+        "update_wifi": (Keys.wlan_id, Keys.updates),
+        "create_port_forward": (Keys.rule,),
+        "update_port_forward": (Keys.rule_id, Keys.updates),
+        "update_traffic_rule": (Keys.rule_id, Keys.updates),
+        "authorize_guest": (Keys.target,),
     }
 
     def get_name(self) -> str:
@@ -166,7 +167,7 @@ class UbiquitiAbility(CapabilityAbility):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "action": {
+            Keys.action: {
                 "type": "string",
                 "enum": list(ACTION_HANDLERS),
                 "description": (
@@ -185,7 +186,7 @@ class UbiquitiAbility(CapabilityAbility):
                     "authorize_guest — authorize a guest device by target MAC."
                 ),
             },
-            "target": {
+            Keys.target: {
                 "type": "string",
                 "description": (
                     "MAC address of the device or client to act on, e.g. "
@@ -193,7 +194,7 @@ class UbiquitiAbility(CapabilityAbility):
                     "control, device control, and authorize_guest."
                 ),
             },
-            "active_only": {
+            Keys.active_only: {
                 "type": "boolean",
                 "description": (
                     "list_clients: when true (default) only currently connected "
@@ -201,22 +202,22 @@ class UbiquitiAbility(CapabilityAbility):
                 ),
                 "default": True,
             },
-            "port_idx": {
+            Keys.port_idx: {
                 "type": "integer",
                 "description": "power_cycle_port: the switch PoE port index to cycle.",
             },
-            "wlan_id": {
+            Keys.wlan_id: {
                 "type": "string",
                 "description": "update_wifi: id of the WiFi network to change (from list_wifi).",
             },
-            "rule_id": {
+            Keys.rule_id: {
                 "type": "string",
                 "description": (
                     "update_port_forward / update_traffic_rule: id of the rule to "
                     "change (from the matching list action)."
                 ),
             },
-            "updates": {
+            Keys.updates: {
                 "type": "object",
                 "description": (
                     "update_wifi / update_port_forward / update_traffic_rule: the "
@@ -224,36 +225,36 @@ class UbiquitiAbility(CapabilityAbility):
                     "{'x_passphrase': 'newpass'} to change a WiFi password."
                 ),
             },
-            "rule": {
+            Keys.rule: {
                 "type": "object",
                 "description": "create_port_forward: the full port-forward rule definition.",
             },
-            "minutes": {
+            Keys.minutes: {
                 "type": "integer",
                 "description": "authorize_guest: session duration in minutes (default 60).",
                 "default": 60,
             },
-            "up_kbps": {
+            Keys.up_kbps: {
                 "type": "integer",
                 "description": "authorize_guest: upload bandwidth cap in Kbps (optional).",
             },
-            "down_kbps": {
+            Keys.down_kbps: {
                 "type": "integer",
                 "description": "authorize_guest: download bandwidth cap in Kbps (optional).",
             },
-            "quota_mb": {
+            Keys.quota_mb: {
                 "type": "integer",
                 "description": "authorize_guest: total data quota in MB (optional).",
             },
         },
-        "required": ["action"],
+        "required": [Keys.action],
     }
 
     # ── Entry point — translate the flat action, then delegate to the base ─────
 
     def run(self, params: dict) -> ToolResult:
-        action = str(params.get("action", self.DEFAULT_ACTION)).lower()
-        params["action"] = action
+        action = str(params.get(Keys.action, self.DEFAULT_ACTION)).lower()
+        params[Keys.action] = action
 
         spec = _ACTION_SPEC.get(action)
         if spec is not None:
@@ -264,10 +265,10 @@ class UbiquitiAbility(CapabilityAbility):
             # so it never leaks into a REST body; ``device_status`` keeps it because
             # its handler (get_info) reads ``target`` directly.
             if action in _TARGET_TO_MAC:
-                target = (params.get("target") or "").strip()
+                target = (params.get(Keys.target) or "").strip()
                 if target and action != "device_status":
                     params["mac"] = target
-                    params.pop("target", None)
+                    params.pop(Keys.target, None)
             for key, value in spec.inject.items():
                 params.setdefault(key, value)
 

--- a/backend/abilities/vision.py
+++ b/backend/abilities/vision.py
@@ -25,6 +25,7 @@ import logging
 from typing import ClassVar
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult
 from configs.channels.vision import VisionConfig
 
@@ -107,24 +108,24 @@ class VisionAbility(Ability):
     # or empty image/query as code=missing-params before run() is reached
     # (precedent: save_graph.py, save_pattern.py, file_permissions.py). The
     # pre-gate is truthiness-based, so whitespace-only residue still reaches run().
-    ACTION_REQUIRED: ClassVar[dict] = {"": ("image", "query")}
+    ACTION_REQUIRED: ClassVar[dict] = {"": (Keys.image, Keys.query)}
 
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "image": {
+            Keys.image: {
                 "type": "string",
                 "description": (
                     "The 8-character document id (doc_id). If this is not available "
                     "in context, use the `document.search` tool to look it up."
                 ),
             },
-            "query": {
+            Keys.query: {
                 "type": "string",
                 "description": "What to find out about the image, in natural language.",
             },
         },
-        "required": ["image", "query"],
+        "required": [Keys.image, Keys.query],
     }
 
     def get_parameters(self) -> dict:
@@ -134,8 +135,8 @@ class VisionAbility(Ability):
         # The dispatcher pre-gate is truthiness-based, so a non-empty but
         # whitespace-only image/query slips past it and must be rejected here
         # (precedent: save_graph.py, file_permissions.py).
-        doc_id = (params.get("image") or "").strip()
-        query = (params.get("query") or "").strip()
+        doc_id = (params.get(Keys.image) or "").strip()
+        query = (params.get(Keys.query) or "").strip()
         if not doc_id or not query:
             missing = ", ".join(
                 name for name, val in (("image", doc_id), ("query", query)) if not val

--- a/backend/abilities/weather.py
+++ b/backend/abilities/weather.py
@@ -25,6 +25,7 @@ from typing import ClassVar
 import requests
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult
 from services.time_utils import utc_now
 
@@ -79,7 +80,7 @@ class WeatherAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "location": {
+            Keys.location: {
                 "type": "string",
                 "description": (
                     "City or place name (e.g. 'Malta', 'London'). Omit to "
@@ -104,7 +105,7 @@ class WeatherAbility(Ability):
         success — the dispatcher pairs the weather card when this turn broadcasts
         to the user — or ``ToolResult.err`` when every source is unavailable.
         """
-        location_param = params.get("location", "").strip()
+        location_param = params.get(Keys.location, "").strip()
         lat, lon, location_name = _extract_location(self.telemetry)
 
         # Guardrail: with no device coordinates AND no location param there is no

--- a/backend/abilities/web_browse.py
+++ b/backend/abilities/web_browse.py
@@ -29,6 +29,7 @@ from typing import ClassVar
 
 from abilities._ability import Ability
 from abilities._delegate import delegate_goal, delegate_result
+from abilities._params import Keys
 from abilities._result import ToolResult
 from configs.channels.web_browse import WebBrowseConfig
 
@@ -64,7 +65,7 @@ class WebBrowseAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "goal": {
+            Keys.goal: {
                 "type": "string",
                 "description": (
                     "What to accomplish in the browser. Include everything the "
@@ -73,14 +74,14 @@ class WebBrowseAbility(Ability):
                 ),
             },
         },
-        "required": ["goal"],
+        "required": [Keys.goal],
     }
 
     # An action-less delegate: the dispatcher's ACTION_REQUIRED pre-gate (the
     # ``""`` key covers action-less tools) rejects a missing/empty ``goal`` with
     # ``code=missing-params`` BEFORE the policy gate and BEFORE run() — so an empty
     # goal never spawns an expensive browser delegate on nothing.
-    ACTION_REQUIRED: ClassVar[dict] = {"": ("goal",)}
+    ACTION_REQUIRED: ClassVar[dict] = {"": (Keys.goal,)}
 
     def get_parameters(self) -> dict:
         return self._PARAMETERS

--- a/backend/abilities/web_download.py
+++ b/backend/abilities/web_download.py
@@ -31,6 +31,7 @@ from urllib.parse import urlparse
 import requests
 
 from abilities._ability import Ability
+from abilities._params import Keys
 from abilities._result import ToolResult
 from services.web_fetch import DOWNLOAD, DownloadTooLarge, FetchBlocked, stream_to_file
 
@@ -49,7 +50,9 @@ class WebDownloadAbility(Ability):
     #: Action-less tool — the ``""`` key drives the dispatcher's ACTION_REQUIRED
     #: pre-gate to reject a missing/blank url with ``code=missing-params`` BEFORE
     #: run() (instead of run() returning a status=success "url required" prose).
-    ACTION_REQUIRED: ClassVar[dict] = {"": ("url",)}
+    #: Runs AFTER seam key-healing, so a model's ``uri``/``source``/etc. has already
+    #: been canonicalised to ``url`` via ``VARIANTS[Keys.url]`` before this fires.
+    ACTION_REQUIRED: ClassVar[dict] = {"": (Keys.url,)}
 
     def get_name(self) -> str:
         return "web_download"
@@ -73,23 +76,23 @@ class WebDownloadAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "url": {
+            Keys.url: {
                 "type": "string",
                 "description": "URL of the file to download",
             },
-            "timeout": {
+            Keys.timeout: {
                 "type": "number",
                 "description": "Download timeout in minutes (default: 15, max: 120)",
             },
         },
-        "required": ["url"],
+        "required": [Keys.url],
     }
 
     def get_parameters(self) -> dict:
         return self._PARAMETERS
 
     def run(self, params: dict) -> ToolResult:
-        url = self.param(params, "url", required=True)
+        url = self.param(params, Keys.url, required=True)
         url = str(url).strip()
 
         scheme = urlparse(url).scheme
@@ -101,7 +104,7 @@ class WebDownloadAbility(Ability):
                 source=url,
             )
 
-        timeout_min = self.param(params, "timeout", default=15, clamp=(1, 120))
+        timeout_min = self.param(params, Keys.timeout, default=15, clamp=(1, 120))
         timeout_sec = float(timeout_min) * 60
 
         dest_path = _build_dest_path(url)

--- a/backend/abilities/web_search.py
+++ b/backend/abilities/web_search.py
@@ -40,6 +40,7 @@ from typing import ClassVar
 
 from abilities._ability import Ability
 from abilities._delegate import delegate_goal, delegate_result
+from abilities._params import Keys
 from abilities._result import ToolResult
 from configs.channels.web_search import WebSearchConfig
 
@@ -72,19 +73,19 @@ class WebSearchAbility(Ability):
     _PARAMETERS: ClassVar[dict] = {
         "type": "object",
         "properties": {
-            "query": {
+            Keys.query: {
                 "type": "string",
                 "description": "What to research on the web.",
             },
         },
-        "required": ["query"],
+        "required": [Keys.query],
     }
 
     # An action-less delegate: the dispatcher's ACTION_REQUIRED pre-gate (the
     # ``""`` key covers action-less tools) rejects a missing/empty ``query`` with
     # ``code=missing-params`` BEFORE the policy gate and BEFORE run() — so an empty
     # query never spawns an expensive delegate on an empty goal.
-    ACTION_REQUIRED: ClassVar[dict] = {"": ("query",)}
+    ACTION_REQUIRED: ClassVar[dict] = {"": (Keys.query,)}
 
     def get_parameters(self) -> dict:
         return self._PARAMETERS

--- a/backend/tests/test_param_key_resilience.py
+++ b/backend/tests/test_param_key_resilience.py
@@ -1,0 +1,362 @@
+# Copyright 2026 Chalie AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Feature tests — argument-key resilience at the dispatch seam (TKT-963 / TKT-964).
+
+A weak model mangles the argument KEYS it emits: a stray escaped quote
+(``source"``), a capital (``URL``, ``MAX_CHARS``), or a synonym (``url`` for the
+read target, ``source`` for a download). Before the seam, ``json.loads`` decoded
+the corrupt key faithfully, it never matched the tool's schema, and the call
+bounced on a spurious required-field error — TKT-963 (``read`` returning
+``source-required`` for every URL/file a model passed under ``url``/``path``).
+
+These are ZERO-MOCK feature tests: each drives the live
+``ToolDispatcher(mp).dispatch()`` chokepoint exactly as ``MessageProcessor._loop``
+does — real ``AbilityRegistry`` resolution, the real ``PolicyManager.wrap`` gate
+(reading the real ``policy`` table the ``db`` fixture binds), the real
+``Ability.run`` with real file I/O / the real SSRF guard, and the real
+``ActTrail`` write. The healing under test happens at the seam
+(``abilities._params.canonicalize_keys``), so a corrupt key is canonicalised
+BEFORE the ACTION_REQUIRED pre-gate, the policy gate, or ``run()`` ever sees it.
+
+The discriminator in every case is a downstream effect that can ONLY be reached
+if the key healed: ``read`` reaching its URL/file branch instead of
+``source-required``, ``web_download`` reaching its SSRF guard
+(``blocked-url``) instead of the ``missing-params`` pre-gate, ``list`` resolving
+a real service-backed list by its ``id`` alias. The registry-level tests assert
+the structural invariants the design rests on against the REAL registry.
+"""
+
+import pytest
+
+from abilities._ability import Ability
+from abilities._dispatcher import ToolDispatcher
+from abilities._params import (
+    Keys,
+    RegistryOverlapError,
+    validate_registry,
+)
+from abilities._registry import AbilityRegistry
+from abilities._result import ToolResult
+from configs.channels import DmnConfig, UserConfig
+from services.act_trail import ActTrail
+from tests._tool_result_harness import MP, allow_policy, parse_body, seed_transcript
+
+pytestmark = pytest.mark.unit
+
+
+def _chat_mp(db, *, allow: "tuple[str, ...]" = ()) -> MP:
+    """A real user-channel mp bound to the test db, with each *allow* permission
+    flipped to ``allow`` in the real policy table (so a gate that ships ``ask`` on
+    a headless channel passes through to the production ``run()``)."""
+    for permission in allow:
+        allow_policy(db, permission, "chat")
+    return MP(seed_transcript(db, "chat", "do a thing"), UserConfig({}))
+
+
+def _list_service():
+    """A real ``ListService`` bound to the test db — built off the same
+    ``get_shared_db_service()`` singleton ``ListAbility.run`` builds it from."""
+    from services.database_service import get_shared_db_service
+    from services.list_service import ListService
+
+    return ListService(get_shared_db_service())
+
+
+# ── read: the TKT-963 regression — a mangled/aliased key heals to ``source`` ─────
+
+
+def test_read_mangled_source_key_heals_not_source_required(db):
+    """The exact TKT-963 defect: a model stored ``{'source"': <url>}`` (a stray
+    escaped quote on the KEY). The seam strips the junk char so the key matches the
+    declared ``source`` and the call reaches the URL branch (a deterministic,
+    network-free SSRF block) instead of bouncing on ``source-required``."""
+    mp = _chat_mp(db, allow=("read",))
+
+    result = ToolDispatcher(mp).dispatch("read", {'source"': "http://localhost", "act_summary": "x"})
+
+    assert "source-required" not in result, result
+    assert "private-or-internal-url-blocked" in result, result
+
+    # The real trail recorded the healed read against the anchor.
+    rows = ActTrail().fetch_by_transcript_id(mp.uid)
+    assert [r["tool_name"] for r in rows] == ["read"], rows
+    assert "private-or-internal-url-blocked" in rows[0]["result"], rows
+
+
+def test_read_uppercase_url_composes_normalize_and_variant(db):
+    """``{'URL': …}`` exercises BOTH layers in one key: normalise (lower-case
+    ``URL`` → ``url``) THEN variant resolution (``url`` is read's ``source`` alias).
+    It must reach the URL branch, not ``source-required``."""
+    mp = _chat_mp(db, allow=("read",))
+
+    result = ToolDispatcher(mp).dispatch("read", {"URL": "http://localhost", "act_summary": "x"})
+
+    assert "source-required" not in result, result
+    assert "private-or-internal-url-blocked" in result, result
+
+
+def test_read_mangled_max_chars_heals_and_truncates_downstream(db, tmp_path):
+    """``MAX_CHARS`` (capitalised) must heal to the declared ``max_chars`` — proven
+    by a DOWNSTREAM effect: the file is clipped to the healed cap (100) and the
+    envelope carries ``truncated=true``. If the key did NOT heal, ``max_chars``
+    would fall back to its 20000 default, the 200-char file would NOT be clipped,
+    and ``truncated`` would be absent. The compound call also heals ``path`` →
+    ``source`` in the same dict."""
+    mp = _chat_mp(db, allow=("read",))
+    target = tmp_path / "big.txt"
+    target.write_text("A" * 200, encoding="utf-8")
+
+    result = ToolDispatcher(mp).dispatch(
+        "read", {"path": str(target), "MAX_CHARS": 100, "act_summary": "x"}
+    )
+
+    assert "source-required" not in result, result
+    assert "[read(status=success" in result, result
+    # The healed cap took effect: the body was clipped, so the meta flags it.
+    assert "truncated=true" in result, result
+    assert "AAAA" in result, result
+
+
+def test_read_genuinely_unknown_key_passes_through_and_still_bounces(db):
+    """Healing must NOT over-reach: a key that is neither a declared param nor a
+    known variant (``foobar``) passes through VERBATIM, so ``read`` still bounces on
+    ``source-required`` and echoes the received key for the model to self-correct.
+    This guards against a future over-broad variant ladder silently absorbing junk."""
+    mp = _chat_mp(db, allow=("read",))
+
+    result = ToolDispatcher(mp).dispatch(
+        "read", {"foobar": "https://example.com", "act_summary": "x"}
+    )
+
+    assert "source-required" in result, result
+    assert "foobar" in result, result
+
+
+# ── web_download: the ladder, scoped — ``source`` heals to ``url`` ───────────────
+
+
+def test_web_download_source_alias_heals_to_url(db):
+    """``web_download({'source': …})`` — a model reusing read's key — must heal to
+    the canonical ``url`` and reach the SSRF guard (``blocked-url``), NOT bounce on
+    the ACTION_REQUIRED ``missing-params`` pre-gate (which fires when ``url`` is
+    absent). ``localhost`` makes the SSRF block deterministic and network-free."""
+    mp = _chat_mp(db, allow=("web_download",))
+
+    result = ToolDispatcher(mp).dispatch(
+        "web_download", {"source": "http://localhost/file.pdf", "act_summary": "x"}
+    )
+
+    assert "missing-params" not in result, result
+    assert "blocked-url" in result, result
+
+
+def test_web_download_url_stays_canonical(db):
+    """The same call under the canonical ``url`` resolves identically — proving the
+    variant resolution is per-tool scoped (``url`` is canonical for ``web_download``
+    even though it is a ``source`` ALIAS for ``read``)."""
+    mp = _chat_mp(db, allow=("web_download",))
+
+    result = ToolDispatcher(mp).dispatch(
+        "web_download", {"url": "http://localhost/file.pdf", "act_summary": "x"}
+    )
+
+    assert "missing-params" not in result, result
+    assert "blocked-url" in result, result
+
+
+# ── list: the historical ``id`` alias heals to the ``list`` selector ─────────────
+
+
+def test_list_id_alias_heals_to_list_selector_and_returns_contents(db):
+    """``list({'action':'view', 'id': <id>})`` — the frontend silent-action key —
+    must heal ``id`` → the declared ``list`` selector and resolve the REAL
+    service-backed list, returning its actual contents (not ``missing-target`` /
+    ``list-not-found``). A non-broadcast channel drops the card so the body head is
+    the model-facing rows."""
+    mp = MP(seed_transcript(db, "subconscious", "show my list"), DmnConfig())
+    service = _list_service()
+    list_id = service.create_list("groceries")
+    service.add_items(list_id, ["milk", "eggs"])
+
+    result = ToolDispatcher(mp).dispatch(
+        "list", {"action": "view", "id": list_id, "act_summary": "x"}
+    )
+
+    assert "[list(status=success" in result, result
+    assert "missing-target" not in result and "list-not-found" not in result, result
+    body = parse_body(result, "list", rich=True)
+    texts = [row["text"] for row in body["items"]]
+    assert "milk" in texts and "eggs" in texts, body
+
+
+def test_list_mangled_action_key_heals_before_action_required_pre_gate(db):
+    """A mangled ACTION key (``{'action"': 'list_all'}``) must heal to ``action``
+    BEFORE the ACTION_REQUIRED pre-gate reads it. Without the heal the pre-gate
+    sees no ``action`` and returns ``unknown-action`` (\"requires an 'action'\");
+    with it, ``list_all`` runs and returns a ``count=0`` success."""
+    mp = _chat_mp(db)
+
+    result = ToolDispatcher(mp).dispatch("list", {'action"': "list_all", "act_summary": "x"})
+
+    assert "unknown-action" not in result, result
+    assert "[list(status=success" in result, result
+    assert "count=0" in result, result
+
+
+# ── Registry-level structural invariants (driven against the REAL registry) ──────
+
+
+def _shipping_abilities() -> list:
+    """The abilities that actually ship — those defined in the ``abilities``
+    package. ``AbilityRegistry.all()`` walks EVERY ``Ability`` subclass, which
+    during a full-suite pytest run also sweeps up the throwaway test abilities
+    other modules define (``_tr_param`` & friends). The production registry only
+    ever holds the ``abilities.*`` classes — no test module is imported in prod —
+    so we assert the invariants against that real, shipping set, not the
+    test-contaminated global subclass walk."""
+    return [a for a in AbilityRegistry.all() if type(a).__module__.startswith("abilities.")]
+
+
+def test_real_registry_has_no_variant_overlaps():
+    """The whole design rests on this: within every shipping tool, no variant of
+    one declared parameter may collide with another declared parameter or a
+    framework key. ``validate_registry`` over the real registry must not raise."""
+    validate_registry(_shipping_abilities())
+
+
+def test_every_native_param_is_a_keys_constant():
+    """Schema-completeness — the single-source-of-truth invariant the sweep
+    establishes: every property key every shipping ability declares MUST be a
+    :class:`Keys` constant, so the wire keys and the variant registry can never
+    drift from the schema. A new ability that hard-codes a bare string key fails
+    here."""
+    allowed = Keys.values()
+    offenders = []
+    for ability in _shipping_abilities():
+        properties = (ability.get_parameters() or {}).get("properties") or {}
+        offenders += [
+            (ability.get_name(), key) for key in properties if key not in allowed
+        ]
+    assert not offenders, f"non-Keys param keys declared: {offenders}"
+
+
+def test_overlap_validator_rejects_a_tool_declaring_two_aliased_params():
+    """The validator must actually FIRE when an overlap exists, not vacuously pass.
+    A synthetic probe declaring BOTH ``source`` and ``url`` — whose real VARIANTS
+    ladders name each other — is the canonical overlap: ``source``'s ``url`` alias
+    collides with the declared ``url`` (and vice-versa). ``_SYNTHETIC`` keeps the
+    probe out of the real registry while still exercising the real validator."""
+
+    class _OverlapProbe(Ability):
+        _SYNTHETIC = True
+
+        def get_name(self) -> str:
+            return "overlap_probe"
+
+        def get_summary(self) -> str:
+            return "probe"
+
+        def get_examples(self) -> list[str]:
+            return []
+
+        def get_search_tooltip(self) -> str:
+            return "probe"
+
+        def get_parameters(self) -> dict:
+            return {
+                "type": "object",
+                "properties": {
+                    Keys.source: {"type": "string"},
+                    Keys.url: {"type": "string"},
+                    Keys.list: {"type": "string"},
+                },
+                "required": [],
+            }
+
+        def run(self, params: dict) -> ToolResult:
+            return ToolResult.ok("x")
+
+    with pytest.raises(RegistryOverlapError) as excinfo:
+        validate_registry([_OverlapProbe()])
+
+    message = str(excinfo.value)
+    assert "source" in message and "url" in message, message
+    assert "collides" in message, message
+
+
+# ── First-write-wins collision: both ``source`` and ``url`` present for read ──────
+
+
+def test_read_collision_first_key_wins_and_warning_emitted(db, tmp_path, caplog):
+    """When a model sends BOTH ``source`` and ``url`` to ``read``, both resolve to
+    the same canonical ``source``.  First dict-iteration entry wins; the loser's
+    VALUE is dropped entirely.  Proven by a DOWNSTREAM discriminator: the first key
+    carries ``http://localhost`` (SSRF block → ``private-or-internal-url-blocked``)
+    and the second carries a real file path that would succeed.  The SSRF error
+    proves the first value survived; ``[read(status=success`` NOT in result proves
+    the file value was dropped.  The warning log proves the collision was surfaced."""
+    mp = _chat_mp(db, allow=("read",))
+    real_file = tmp_path / "winner.txt"
+    real_file.write_text("content if the wrong key won", encoding="utf-8")
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="abilities._params"):
+        result = ToolDispatcher(mp).dispatch(
+            "read",
+            {
+                "source": "http://localhost",   # first → wins → SSRF block
+                "url": str(real_file),          # second → dropped
+                "act_summary": "x",
+            },
+        )
+
+    # The SSRF winner reached run() — not a source-required bounce, not a file read.
+    assert "private-or-internal-url-blocked" in result, result
+    assert "[read(status=success" not in result, result
+
+    # The warning must name both original keys and the resolved canonical.
+    warn_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert warn_messages, "expected a canonicalize_keys collision warning, got none"
+    combined = " ".join(str(m) for m in warn_messages)
+    assert "source" in combined and "url" in combined, combined
+    assert "source" in combined, combined   # the canonical that both map to
+
+
+def test_read_collision_order_decides_winner_not_key_identity(db, tmp_path, caplog):
+    """Flipping the dict order reverses the outcome — the file path is now FIRST so
+    its value wins, and the ``http://localhost`` SSRF value is dropped.  The
+    ``[read(status=success`` in the result (the file read succeeds) proves the
+    iteration-order rule, not key identity, decides which value survives."""
+    mp = _chat_mp(db, allow=("read",))
+    real_file = tmp_path / "order_proof.txt"
+    real_file.write_text("MARKER_CONTENT", encoding="utf-8")
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="abilities._params"):
+        result = ToolDispatcher(mp).dispatch(
+            "read",
+            {
+                "url": str(real_file),          # first → wins → file read succeeds
+                "source": "http://localhost",   # second → dropped
+                "act_summary": "x",
+            },
+        )
+
+    # The file-read winner reached run() — not a blocked URL.
+    assert "[read(status=success" in result, result
+    assert "private-or-internal-url-blocked" not in result, result
+    assert "MARKER_CONTENT" in result, result
+
+    # Collision warning fires regardless of which key wins.
+    warn_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert warn_messages, "expected a canonicalize_keys collision warning, got none"
+    combined = " ".join(str(m) for m in warn_messages)
+    assert "source" in combined and "url" in combined, combined

--- a/backend/tests/test_tool_result_contract.py
+++ b/backend/tests/test_tool_result_contract.py
@@ -21,8 +21,11 @@ The contract under test:
     JSON; str body → verbatim; meta in the open tag; hint/valid lines on errors).
   * ``ACTION_REQUIRED`` pre-validation reports an unknown action with ``valid=``
     and ALL missing params in ONE ``missing-params`` error.
-  * ``Ability.param`` resolves aliases / validates choices / clamps numerics and
-    raises ``ToolParamError`` which the dispatcher renders canonically.
+  * Argument-key aliasing is healed at the dispatch seam
+    (``abilities._params.canonicalize_keys`` — ``url``/``path`` → ``source``)
+    BEFORE ``run()``; ``Ability.param`` then matches the canonical key, validates
+    choices, clamps numerics, and raises ``ToolParamError`` which the dispatcher
+    renders canonically.
   * Rich-media: an ``ok(rich=…)`` result dispatched on a ``broadcast_to=='user'``
     mp carries the ordinal + the card instruction; on a non-user channel it does
     NOT (the entire card path is gated on user broadcast).
@@ -139,9 +142,21 @@ class _ParamAbility(Ability):
     def get_summary(self): return "throwaway: exercises Ability.param"
     def get_examples(self): return ["a", "b", "c", "d", "e", "f"]
     def get_search_tooltip(self): return "x"
-    def get_parameters(self): return {"type": "object", "properties": {}, "required": []}
+    def get_parameters(self):
+        # Declares the canonical 'source'; the seam (canonicalize_keys) heals the
+        # model's 'url'/'path' onto it via the shared VARIANTS[source] ladder BEFORE
+        # run() — param() itself no longer carries a per-tool alias list.
+        return {
+            "type": "object",
+            "properties": {
+                "source": {"type": "string"},
+                "limit": {"type": "integer"},
+                "mode": {"type": "string"},
+            },
+            "required": ["source"],
+        }
     def run(self, params):
-        source = self.param(params, "source", aliases=("url", "path"), required=True)
+        source = self.param(params, "source", required=True)
         limit = self.param(params, "limit", default=10, clamp=(1, 100))
         mode = self.param(params, "mode", default="fast", choices=("fast", "slow"))
         return ToolResult.ok({"source": source, "limit": limit, "mode": mode})
@@ -267,12 +282,12 @@ def test_action_required_missing_params_reported_in_one_error(db, registered):
     assert "name" in out and "value" in out
 
 
-# ── (e) Ability.param aliases / choices / clamp through the real chokepoint ───
+# ── (e) seam-healed alias + Ability.param choices / clamp through the chokepoint ─
 
 def test_param_alias_clamp_choice_happy_path(db, registered):
     mp = _MP(_seed_transcript(db, "dmn"), DmnConfig())
     out = ToolDispatcher(mp).dispatch("_tr_param", {"url": "x", "limit": 999})
-    # alias url→source; limit clamped 999→100; mode default 'fast'.
+    # seam heals url→source; limit clamped 999→100; mode default 'fast'.
     assert '"source":"x"' in out
     assert '"limit":100' in out
     assert '"mode":"fast"' in out


### PR DESCRIPTION
## Problem (TKT-963)

A weak model emits malformed argument **keys** — a stray escaped quote (`source"`), a capital (`URL`), or a synonym (`url` for read's `source`). `json.loads` decoded the corrupt key faithfully, it never matched the tool schema, and the call bounced on a spurious required-field error. The headline symptom: `read` returned `source-required` for every URL/file a model passed under `url`/`path`.

## Fix

A **key-healing seam** in `ToolDispatcher.dispatch()`, applied to every tool call **before** the `ACTION_REQUIRED` pre-gate, the policy gate, and `run()`:

1. **Generic sanitisation (all tools).** Each incoming key is lower-cased and stripped to `[a-z0-9_-]` — heals `source"` → `source`, `MAX_CHARS` → `max_chars` with zero per-tool knowledge.
2. **Per-tool variant resolution.** A sanitised key that isn't one of the tool's declared parameters is matched against the shared `VARIANTS` ladders, scoped to *that tool's own* declared keys — so `read({"url": …})` resolves to `source` while `url` stays canonical for `web_download`.

### Single source of truth

`abilities/_params.py` is new and holds:
- **`Keys`** — a constant for every native parameter name. All 38 abilities migrated to reference `Keys.<name>` in their schema and reads, so the wire keys and the variant registry can never drift. **Wire schemas are byte-identical** (verified across all 39 tools).
- **`VARIANTS`** — the alias ladders (`source`/`url`/`list`). The old per-tool `param(aliases=…)` mechanism is removed; read's source-aliases and list's `id`-alias are re-expressed here, and `web_download` gains the `source`/`url` ladder.
- **`validate_registry()`** — a no-overlap invariant (no variant may collide with another declared parameter or a framework key), run as a feature test, not at import.

## Safety

- **Healing only ever makes a policy permission *more specific*** (`<tool>.<action>`), and a permission miss defaults to `ask` — so it can never make a decision *more permissive*. The risk class is still derived via `classify_action` from the real (healed) value, never trusted from a model-declared action.
- **First-write-wins** collisions (a model sending both a canonical key and its alias) are logged, never silently dropped.
- **Fail-open:** a registry/schema fault logs and proceeds with raw params — a healer bug degrades to the pre-fix behaviour (a retryable bounce), never a hard tool outage.

## Tests

`tests/test_param_key_resilience.py` — 13 zero-mock feature tests driving the real `ToolDispatcher.dispatch()` chokepoint (real registry, real `PolicyManager` gate, real `run()`/SSRF guard/file I/O, real `ActTrail`). Each discriminator is a downstream effect only reachable if the key healed (SSRF block vs `source-required`; `blocked-url` vs `missing-params`; real list contents vs `missing-target`; downstream truncation). Includes the first-write-wins collision behaviour (both orders) and the registry invariants asserted against the live shipping registry.

Full unit gate: **1503 passed, 0 failed**. Ruff clean. Rebased onto the current `rc-0.9.0` tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)