### PR TITLE
refactor(abilities): KeyHealer/KeyNormalizer OOP; move registry invariants to tests (TKT-973)

### DIFF
--- a/backend/abilities/_ability.py
+++ b/backend/abilities/_ability.py
@@ -252,7 +252,7 @@ class Ability(ABC):
         matched; the first key present with a non-None value wins. Argument-key
         healing — a model addressing the parameter by a mangled (``source"``) or
         alias (``url`` for ``source``) spelling — happens ONCE upstream at the
-        dispatch seam (``abilities._params.canonicalize_keys``, fed by the shared
+        dispatch seam (``abilities._params.KeyHealer.heal``, fed by the shared
         :data:`abilities._params.VARIANTS` ladders), so by the time ``run()`` calls
         ``param`` the key is already canonical and this method only matches *name*.
         Missing → *default* (or a ``ToolParamError`` when *required* / no default).

--- a/backend/abilities/_dispatcher.py
+++ b/backend/abilities/_dispatcher.py
@@ -32,7 +32,7 @@ from uuid import uuid4
 # Neither imports this module, so both import normally — no alias/patch hack.
 from abilities._event_emitter import ActEventEmitter
 from abilities._mcp_ability import _MCPAbility
-from abilities._params import canonicalize_keys
+from abilities._params import KeyHealer
 from abilities._registry import AbilityRegistry
 from abilities._result import ToolParamError, ToolResult
 # ClientContext owns the per-request client-telemetry snapshot that _run()
@@ -58,8 +58,12 @@ class ToolDispatcher:
     Spec §5 / AC-4.
     """
 
-    def __init__(self, mp: object) -> None:
+    def __init__(self, mp: object, key_healer: "KeyHealer | None" = None) -> None:
         self._mp = mp
+        # The key healer is injected (DIP); the shared default heals against the
+        # production VARIANTS registry. A test can supply a probe healer without
+        # touching the registry.
+        self._key_healer = key_healer or KeyHealer()
 
     # ── The single tool-call entry point ──────────────────────────────────────
 
@@ -92,7 +96,7 @@ class ToolDispatcher:
             # registry/schema fault must never break dispatch — on failure the raw
             # params flow through unchanged.
             try:
-                params = canonicalize_keys(params, ability.get_parameters())
+                params = self._key_healer.heal(params, ability.get_parameters())
             except Exception:  # noqa: BLE001
                 logger.exception(
                     "[ToolDispatcher] key canonicalisation failed for %s — "

--- a/backend/abilities/_params.py
+++ b/backend/abilities/_params.py
@@ -10,7 +10,8 @@ the ACTION_REQUIRED pre-gate, the policy gate, or ``run()`` ever sees the params
    e.g. ``source"`` → ``source`` and ``MAX_CHARS`` → ``max_chars`` — with zero
    per-tool knowledge. (This is the class of breakage TKT-963 root-caused: a
    model stored ``{"source\"": "https://…"}`` and ``read`` bounced on
-   ``source-required`` because the corrupt KEY never matched.)
+   ``source-required`` because the corrupt KEY never matched.) This layer is
+   :class:`KeyNormalizer`.
 
 2. **Variant resolution (registry-driven, per-tool).** A sanitised key that is
    not one of the tool's declared parameters is matched against the variant
@@ -18,7 +19,7 @@ the ACTION_REQUIRED pre-gate, the policy gate, or ``run()`` ever sees the params
    own* declared parameters it is rewritten to that parameter's canonical key.
    This is what lets ``read({"url": …})`` resolve to ``source`` while ``url``
    stays canonical for ``web_download`` — resolution is scoped to the tool's
-   declared keys, never a global rename.
+   declared keys, never a global rename. This layer is :class:`KeyHealer`.
 
 Resolution is two-pass and **declared-canonical-first**, so a parameter that is
 itself a synonym of another (calendar's ``summary`` vs ``title``; ``document``'s
@@ -29,11 +30,12 @@ survive intact for the tool or framework to handle.
 
 :class:`Keys` is the single source of truth for every native parameter name: each
 ability references ``Keys.<name>`` in its schema and its reads, so the registry
-keys and the wire keys can never drift. :func:`validate_registry` enforces the
-no-overlap invariant the whole design rests on — that no variant of one parameter
-can collide with another parameter (or a framework key) within the same tool. It
-runs as a feature test, NOT at import: importing every ability here would be a
-circular import, and the invariant is a property of the live registry.
+keys and the wire keys can never drift. The no-overlap invariant the whole design
+rests on — that no variant of one parameter can collide with another parameter (or
+a framework key) within the same tool — is enforced as a feature test by
+``tests/_registry_invariants.py`` (``RegistryInvariant``), NOT at import:
+importing every ability here would be a circular import, and the invariant is a
+property of the live registry, not of this module.
 """
 
 from __future__ import annotations
@@ -42,12 +44,6 @@ import logging
 import re
 
 logger = logging.getLogger(__name__)
-
-# The two keys the framework injects into / strips from every call (see
-# Ability.get_input_schema and ToolDispatcher.dispatch/_execute). No parameter and
-# no variant may ever collide with these, or a model key could hijack a framework
-# slot. Compared on the squeezed form (see ``squeeze``).
-_FRAMEWORK_KEYS = ("act_summary", "async")
 
 
 class Keys:
@@ -149,15 +145,6 @@ class Keys:
     window_start = "window_start"
     wlan_id = "wlan_id"
 
-    @classmethod
-    def values(cls) -> "frozenset[str]":
-        """Every canonical wire key declared on this class (for schema-completeness
-        checks: a registered ability's property keys MUST be a subset of these)."""
-        return frozenset(
-            v for k, v in vars(cls).items()
-            if not k.startswith("_") and isinstance(v, str)
-        )
-
 
 # ── The variant registry ──────────────────────────────────────────────────────
 #
@@ -166,20 +153,21 @@ class Keys:
 # failure, never a guess. The sanitisation layer (squeeze/lower) already gives
 # EVERY parameter junk/case resilience for free; these ladders add only the
 # semantic synonyms we have proof a model reaches for. Adding a ladder later is a
-# one-line edit — :func:`validate_registry` (a feature test) guarantees the
-# no-overlap invariant holds before the change can ship.
+# one-line edit — ``RegistryInvariant`` (a feature test in
+# ``tests/_registry_invariants.py``) guarantees the no-overlap invariant holds
+# before the change can ship.
 #
-# Variants are matched on the squeezed form (see ``squeeze``), so listing both
-# ``filepath`` and ``file_path`` is redundant — one covers both.
+# Variants are matched on the squeezed form (see ``KeyNormalizer.squeeze``), so
+# listing both ``filepath`` and ``file_path`` is redundant — one covers both.
 VARIANTS: "dict[str, frozenset[str]]" = {
-    # read's historical source-alias ladder (TKT-834 / TKT-899): a model addresses
-    # the read target by many names. Canonical = source.
+    # read's historical source-alias ladder: a model addresses the read target by
+    # many names. Canonical = source.
     Keys.source: frozenset({
         Keys.url, "uri", "link", "href", Keys.path, "file", "filepath", "file_path",
     }),
-    # web_download earns the SAME family on its canonical 'url' (TKT-964): the keys
-    # a model uses for a fetch target are identical to read's. 'source' is included
-    # so a model that learned read's key still lands. Canonical = url.
+    # web_download earns the SAME family on its canonical 'url': the keys a model
+    # uses for a fetch target are identical to read's. 'source' is included so a
+    # model that learned read's key still lands. Canonical = url.
     Keys.url: frozenset({
         "uri", "link", "href", Keys.source, "address", "file_url", "download_url",
     }),
@@ -188,170 +176,125 @@ VARIANTS: "dict[str, frozenset[str]]" = {
 }
 
 
-class RegistryOverlapError(Exception):
-    """Raised by :func:`validate_registry` when a tool's variant ladders overlap
-    with another of its parameters or a framework key — the invariant that keeps
-    key healing unambiguous."""
+class KeyNormalizer:
+    """Reduce a raw argument key to the canonical form keys are matched on.
 
-
-# ── Normalisation primitives ──────────────────────────────────────────────────
-
-_DROP = re.compile(r"[^a-z0-9_-]")
-
-
-def normalize(key: str) -> str:
-    """Lower-case *key* and drop every character outside ``[a-z0-9_-]``.
-
-    This is the generic sanitisation layer: ``source"`` → ``source``,
-    ``"URL"`` → ``url``, ``max chars`` → ``maxchars`` (space dropped). Separators
-    ``-`` / ``_`` are preserved so ``max_chars`` keeps its shape for the exact
-    match; :func:`squeeze` removes them for the loose match.
+    One responsibility: the character-level sanitisation that gives every tool
+    junk/case/separator resilience for free, independent of any registry.
+    Stateless; injected into :class:`KeyHealer` so the healer never hard-codes its
+    own matching rule and either layer can be swapped or tested in isolation.
     """
-    return _DROP.sub("", str(key).lower())
+
+    _DROP = re.compile(r"[^a-z0-9_-]")
+
+    def normalize(self, key: str) -> str:
+        """Lower-case *key* and drop every character outside ``[a-z0-9_-]``.
+
+        The generic sanitisation layer: ``source"`` → ``source``, ``"URL"`` →
+        ``url``, ``max chars`` → ``maxchars`` (space dropped). Separators ``-`` /
+        ``_`` are preserved so ``max_chars`` keeps its shape for the exact match;
+        :meth:`squeeze` removes them for the loose match.
+        """
+        return self._DROP.sub("", str(key).lower())
+
+    def squeeze(self, key: str) -> str:
+        """:meth:`normalize` then drop ``-`` / ``_`` — the form keys are matched on.
+
+        Collapses every spelling of one key to a single token, so ``MAX_CHARS``,
+        ``max-chars`` and ``maxchars`` all compare equal (``maxchars``). Used for
+        both the exact (declared-param) match and the variant match.
+        """
+        return self.normalize(key).replace("-", "").replace("_", "")
 
 
-def squeeze(key: str) -> str:
-    """:func:`normalize` then drop ``-`` / ``_`` — the form keys are matched on.
+class KeyHealer:
+    """Heal a tool call's argument KEYS against the tool's declared schema.
 
-    Collapses every spelling of one key to a single token, so ``MAX_CHARS``,
-    ``max-chars`` and ``maxchars`` all compare equal (``maxchars``). Used for both
-    the exact (declared-param) match and the variant match.
+    One responsibility: turn the keys a weak model emitted into the tool's
+    canonical parameter keys, so a stray quote, a capital, a separator, or a known
+    synonym never bounces an otherwise-valid call.
+
+    Dependencies are injected (DIP): the :data:`VARIANTS` registry and the
+    :class:`KeyNormalizer` both default to the shared module values but can be
+    supplied — for a test with a probe registry, or an alternative normalisation
+    policy — without touching this class.
     """
-    return normalize(key).replace("-", "").replace("_", "")
 
+    def __init__(
+        self,
+        variants: "dict[str, frozenset[str]]" = VARIANTS,
+        normalizer: "KeyNormalizer | None" = None,
+    ) -> None:
+        self._variants = variants
+        self._normalizer = normalizer or KeyNormalizer()
 
-# ── The per-tool key healer (called at the dispatch seam) ──────────────────────
+    def heal(self, params: dict, schema: dict) -> dict:
+        """Return *params* with its keys healed against a tool's declared *schema*.
 
-def canonicalize_keys(params: dict, schema: dict) -> dict:
-    """Return *params* with its keys healed against a tool's declared *schema*.
+        For each incoming key, in order:
+          1. **exact** — if its squeezed form matches a declared parameter, emit
+             that parameter's canonical key (heals quotes/case/separators, e.g.
+             ``source"`` → ``source``, ``MAX_CHARS`` → ``max_chars``).
+          2. **variant** — else if its squeezed form is a variant of exactly one
+             declared parameter (via :data:`VARIANTS`), emit that parameter's key
+             (e.g. ``url`` → ``source`` for ``read``).
+          3. **passthrough** — else emit the ORIGINAL key verbatim, so MCP
+             camelCase and any unknown key survive untouched.
 
-    For each incoming key, in order:
-      1. **exact** — if its squeezed form matches a declared parameter, emit that
-         parameter's canonical key (heals quotes/case/separators, e.g.
-         ``source"`` → ``source``, ``MAX_CHARS`` → ``max_chars``).
-      2. **variant** — else if its squeezed form is a variant of exactly one
-         declared parameter (via :data:`VARIANTS`), emit that parameter's key
-         (e.g. ``url`` → ``source`` for ``read``).
-      3. **passthrough** — else emit the ORIGINAL key verbatim, so MCP camelCase
-         and any unknown key survive untouched.
+        First write wins if two incoming keys resolve to the same canonical,
+        mirroring the historical alias-ladder's "first key present wins". *schema*
+        is the bare ``get_parameters()`` body (no framework fields); an
+        empty/parameterless schema or empty params is returned unchanged.
+        """
+        properties = schema.get("properties") if schema else None
+        if not properties or not params:
+            return dict(params)
 
-    First write wins if two incoming keys resolve to the same canonical, mirroring
-    the historical alias-ladder's "first key present wins". *schema* is the bare
-    ``get_parameters()`` body (no framework fields); an empty/parameterless schema
-    or empty params is returned unchanged.
-    """
-    properties = schema.get("properties") if schema else None
-    if not properties or not params:
-        return dict(params)
-
-    declared = list(properties.keys())
-    by_squeeze = {squeeze(k): k for k in declared}      # squeezed form → canonical key
-    variant_map = _variant_map(declared, by_squeeze)    # squeezed variant → canonical key
-
-    healed: dict = {}
-    source_key: dict = {}                               # canonical → the raw key that filled it
-    for key, value in params.items():
-        sq = squeeze(key)
-        canonical = by_squeeze.get(sq) or variant_map.get(sq) or key
-        if canonical not in healed:
-            healed[canonical] = value
-            source_key[canonical] = key
-        elif key != source_key[canonical]:
-            # Two DISTINCT incoming keys resolved to one canonical (e.g. a model sent
-            # both ``source`` and its ``url`` alias). First write wins — mirroring the
-            # historical alias ladder — but the dropped value is never silent: a weak
-            # model double-emitting a key is exactly the confusion worth surfacing.
-            logger.warning(
-                "[canonicalize_keys] %r and %r both map to %r — keeping %r, dropping %r",
-                source_key[canonical], key, canonical, source_key[canonical], key,
-            )
-    return healed
-
-
-def _variant_map(declared: "list[str]", by_squeeze: "dict[str, str]") -> "dict[str, str]":
-    """Build ``squeezed variant → canonical key`` for one tool's declared params.
-
-    A variant that squeezes onto a declared parameter is dropped (the real
-    parameter always wins as itself), and a variant claimed by two declared
-    parameters is dropped as ambiguous. :func:`validate_registry` forbids both for
-    the real registry, so this is defensive: a future bad edit degrades to "no
-    aliasing for that key", never silent mis-routing.
-    """
-    out: "dict[str, str | None]" = {}
-    for canonical in declared:
-        for variant in VARIANTS.get(canonical, ()):
-            sq = squeeze(variant)
-            if sq in by_squeeze:
-                continue                       # a real parameter owns this form
-            if sq in out and out[sq] != canonical:
-                out[sq] = None                 # ambiguous across two params → drop
-            elif sq not in out:
-                out[sq] = canonical
-    return {sq: c for sq, c in out.items() if c is not None}
-
-
-# ── The invariant enforcer (run as a feature test, never at import) ────────────
-
-def validate_registry(abilities: "list") -> None:
-    """Assert the no-overlap invariant for every ability, or raise.
-
-    For each tool, every variant of every declared parameter must:
-      * not squeeze onto a DIFFERENT declared parameter of the same tool, and
-      * not be claimed by two declared parameters of the same tool, and
-      * not collide with a framework key.
-
-    No declared parameter may collide with a framework key either. Every
-    :data:`VARIANTS` key must be a real parameter of at least one ability (catches
-    a typo'd canonical). Raises :class:`RegistryOverlapError` listing EVERY
-    violation found (not just the first), so one run fixes the whole registry.
-    """
-    framework_sq = {squeeze(k) for k in _FRAMEWORK_KEYS}
-    problems: "list[str]" = []
-    all_declared: "set[str]" = set()
-
-    for ability in abilities:
-        name = ability.get_name()
-        try:
-            properties = (ability.get_parameters() or {}).get("properties") or {}
-        except Exception as exc:  # noqa: BLE001
-            problems.append(f"{name}: get_parameters() raised {exc!r}")
-            continue
+        squeeze = self._normalizer.squeeze
         declared = list(properties.keys())
-        all_declared.update(declared)
-        by_squeeze = {squeeze(k): k for k in declared}
+        by_squeeze = {squeeze(k): k for k in declared}     # squeezed form → canonical key
+        variant_map = self._variant_map(declared, by_squeeze)  # squeezed variant → canonical key
 
-        for param in declared:
-            if squeeze(param) in framework_sq:
-                problems.append(f"{name}: parameter {param!r} collides with a framework key")
+        healed: dict = {}
+        source_key: dict = {}                              # canonical → the raw key that filled it
+        for key, value in params.items():
+            sq = squeeze(key)
+            canonical = by_squeeze.get(sq) or variant_map.get(sq) or key
+            if canonical not in healed:
+                healed[canonical] = value
+                source_key[canonical] = key
+            elif key != source_key[canonical]:
+                # Two DISTINCT incoming keys resolved to one canonical (e.g. a model
+                # sent both ``source`` and its ``url`` alias). First write wins —
+                # mirroring the historical alias ladder — but the dropped value is
+                # never silent: a weak model double-emitting a key is exactly the
+                # confusion worth surfacing.
+                logger.warning(
+                    "[KeyHealer] %r and %r both map to %r — keeping %r, dropping %r",
+                    source_key[canonical], key, canonical, source_key[canonical], key,
+                )
+        return healed
 
-        seen: "dict[str, str]" = {}
+    def _variant_map(
+        self, declared: "list[str]", by_squeeze: "dict[str, str]"
+    ) -> "dict[str, str]":
+        """Build ``squeezed variant → canonical key`` for one tool's declared params.
+
+        A variant that squeezes onto a declared parameter is dropped (the real
+        parameter always wins as itself), and a variant claimed by two declared
+        parameters is dropped as ambiguous. ``RegistryInvariant`` forbids both for
+        the real registry, so this is defensive: a future bad edit degrades to "no
+        aliasing for that key", never silent mis-routing.
+        """
+        squeeze = self._normalizer.squeeze
+        out: "dict[str, str | None]" = {}
         for canonical in declared:
-            for variant in VARIANTS.get(canonical, ()):
+            for variant in self._variants.get(canonical, ()):
                 sq = squeeze(variant)
-                if sq in framework_sq:
-                    problems.append(
-                        f"{name}: variant {variant!r} of {canonical!r} collides with a framework key"
-                    )
-                other = by_squeeze.get(sq)
-                if other is not None and other != canonical:
-                    problems.append(
-                        f"{name}: variant {variant!r} of {canonical!r} collides with declared "
-                        f"parameter {other!r}"
-                    )
-                if sq in seen and seen[sq] != canonical:
-                    problems.append(
-                        f"{name}: variant {variant!r} is claimed by both {seen[sq]!r} and "
-                        f"{canonical!r}"
-                    )
-                seen[sq] = canonical
-
-    unknown = [k for k in VARIANTS if k not in all_declared]
-    if unknown:
-        problems.append(
-            f"VARIANTS keys are not declared parameters of any ability: {sorted(unknown)}"
-        )
-
-    if problems:
-        raise RegistryOverlapError(
-            "Parameter-key registry overlap(s):\n  " + "\n  ".join(problems)
-        )
+                if sq in by_squeeze:
+                    continue                       # a real parameter owns this form
+                if sq in out and out[sq] != canonical:
+                    out[sq] = None                 # ambiguous across two params → drop
+                elif sq not in out:
+                    out[sq] = canonical
+        return {sq: c for sq, c in out.items() if c is not None}

--- a/backend/tests/_registry_invariants.py
+++ b/backend/tests/_registry_invariants.py
@@ -1,0 +1,139 @@
+# Copyright 2026 Chalie AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Registry invariants for the parameter-key healer — a TEST-ONLY surface.
+
+The production healer (``abilities._params``) carries only what every live tool
+call needs: the :class:`~abilities._params.Keys` registry, the :data:`VARIANTS`
+ladders, and the :class:`~abilities._params.KeyHealer` /
+:class:`~abilities._params.KeyNormalizer` pair. The *checks* that the registry is
+internally consistent — that no variant of one parameter collides with another
+parameter (or a framework key) within the same tool, and that every declared key
+is a ``Keys`` constant — are properties asserted by the feature suite, never run
+on the hot path. They live here so production code never imports a validator it
+never calls.
+
+This module is plumbing only: it imports the real registry from
+``abilities._params`` and reflects over the real ``AbilityRegistry`` (the caller
+supplies the shipping abilities). It re-implements NO production logic, adds NO
+mocks, and creates NO alternative code path. The ``_`` prefix keeps pytest from
+collecting it as a test module while ``test_param_key_resilience`` imports it.
+"""
+
+from __future__ import annotations
+
+from abilities._params import VARIANTS, KeyNormalizer, Keys
+
+# The two keys the framework injects into / strips from every call (see
+# Ability.get_input_schema and ToolDispatcher.dispatch/_execute). No parameter and
+# no variant may ever collide with these, or a model key could hijack a framework
+# slot. Compared on the squeezed form (see ``KeyNormalizer.squeeze``).
+FRAMEWORK_KEYS = ("act_summary", "async")
+
+
+class RegistryOverlapError(Exception):
+    """Raised by :meth:`RegistryInvariant.check_no_overlaps` when a tool's variant
+    ladders overlap with another of its parameters or a framework key — the
+    invariant that keeps key healing unambiguous."""
+
+
+class RegistryInvariant:
+    """Asserts the structural invariants the key-healing design rests on.
+
+    Holds the same dependencies as the production healer — the variant registry,
+    the framework keys, and a :class:`KeyNormalizer` — injected (DIP) so a test can
+    drive the checks against a probe registry. Stateless across calls.
+    """
+
+    def __init__(
+        self,
+        variants: "dict[str, frozenset[str]]" = VARIANTS,
+        framework_keys: "tuple[str, ...]" = FRAMEWORK_KEYS,
+        normalizer: "KeyNormalizer | None" = None,
+    ) -> None:
+        self._variants = variants
+        self._framework_keys = framework_keys
+        self._normalizer = normalizer or KeyNormalizer()
+
+    def canonical_keys(self) -> "frozenset[str]":
+        """Every canonical wire key declared on :class:`Keys`.
+
+        Schema-completeness check: a registered ability's property keys MUST be a
+        subset of these, so the wire keys and the variant registry can never drift
+        from the schema.
+        """
+        return frozenset(
+            v for k, v in vars(Keys).items()
+            if not k.startswith("_") and isinstance(v, str)
+        )
+
+    def check_no_overlaps(self, abilities: "list") -> None:
+        """Assert the no-overlap invariant for every ability, or raise.
+
+        For each tool, every variant of every declared parameter must:
+          * not squeeze onto a DIFFERENT declared parameter of the same tool, and
+          * not be claimed by two declared parameters of the same tool, and
+          * not collide with a framework key.
+
+        No declared parameter may collide with a framework key either. Every
+        :data:`VARIANTS` key must be a real parameter of at least one ability
+        (catches a typo'd canonical). Raises :class:`RegistryOverlapError` listing
+        EVERY violation found (not just the first), so one run fixes the whole
+        registry.
+        """
+        squeeze = self._normalizer.squeeze
+        framework_sq = {squeeze(k) for k in self._framework_keys}
+        problems: "list[str]" = []
+        all_declared: "set[str]" = set()
+
+        for ability in abilities:
+            name = ability.get_name()
+            try:
+                properties = (ability.get_parameters() or {}).get("properties") or {}
+            except Exception as exc:  # noqa: BLE001
+                problems.append(f"{name}: get_parameters() raised {exc!r}")
+                continue
+            declared = list(properties.keys())
+            all_declared.update(declared)
+            by_squeeze = {squeeze(k): k for k in declared}
+
+            for param in declared:
+                if squeeze(param) in framework_sq:
+                    problems.append(f"{name}: parameter {param!r} collides with a framework key")
+
+            seen: "dict[str, str]" = {}
+            for canonical in declared:
+                for variant in self._variants.get(canonical, ()):
+                    sq = squeeze(variant)
+                    if sq in framework_sq:
+                        problems.append(
+                            f"{name}: variant {variant!r} of {canonical!r} collides with a framework key"
+                        )
+                    other = by_squeeze.get(sq)
+                    if other is not None and other != canonical:
+                        problems.append(
+                            f"{name}: variant {variant!r} of {canonical!r} collides with declared "
+                            f"parameter {other!r}"
+                        )
+                    if sq in seen and seen[sq] != canonical:
+                        problems.append(
+                            f"{name}: variant {variant!r} is claimed by both {seen[sq]!r} and "
+                            f"{canonical!r}"
+                        )
+                    seen[sq] = canonical
+
+        unknown = [k for k in self._variants if k not in all_declared]
+        if unknown:
+            problems.append(
+                f"VARIANTS keys are not declared parameters of any ability: {sorted(unknown)}"
+            )
+
+        if problems:
+            raise RegistryOverlapError(
+                "Parameter-key registry overlap(s):\n  " + "\n  ".join(problems)
+            )

--- a/backend/tests/test_param_key_resilience.py
+++ b/backend/tests/test_param_key_resilience.py
@@ -21,7 +21,7 @@ does — real ``AbilityRegistry`` resolution, the real ``PolicyManager.wrap`` ga
 (reading the real ``policy`` table the ``db`` fixture binds), the real
 ``Ability.run`` with real file I/O / the real SSRF guard, and the real
 ``ActTrail`` write. The healing under test happens at the seam
-(``abilities._params.canonicalize_keys``), so a corrupt key is canonicalised
+(``abilities._params.KeyHealer.heal``), so a corrupt key is canonicalised
 BEFORE the ACTION_REQUIRED pre-gate, the policy gate, or ``run()`` ever sees it.
 
 The discriminator in every case is a downstream effect that can ONLY be reached
@@ -36,15 +36,12 @@ import pytest
 
 from abilities._ability import Ability
 from abilities._dispatcher import ToolDispatcher
-from abilities._params import (
-    Keys,
-    RegistryOverlapError,
-    validate_registry,
-)
+from abilities._params import Keys
 from abilities._registry import AbilityRegistry
 from abilities._result import ToolResult
 from configs.channels import DmnConfig, UserConfig
 from services.act_trail import ActTrail
+from tests._registry_invariants import RegistryInvariant, RegistryOverlapError
 from tests._tool_result_harness import MP, allow_policy, parse_body, seed_transcript
 
 pytestmark = pytest.mark.unit
@@ -226,8 +223,8 @@ def _shipping_abilities() -> list:
 def test_real_registry_has_no_variant_overlaps():
     """The whole design rests on this: within every shipping tool, no variant of
     one declared parameter may collide with another declared parameter or a
-    framework key. ``validate_registry`` over the real registry must not raise."""
-    validate_registry(_shipping_abilities())
+    framework key. ``check_no_overlaps`` over the real registry must not raise."""
+    RegistryInvariant().check_no_overlaps(_shipping_abilities())
 
 
 def test_every_native_param_is_a_keys_constant():
@@ -236,7 +233,7 @@ def test_every_native_param_is_a_keys_constant():
     :class:`Keys` constant, so the wire keys and the variant registry can never
     drift from the schema. A new ability that hard-codes a bare string key fails
     here."""
-    allowed = Keys.values()
+    allowed = RegistryInvariant().canonical_keys()
     offenders = []
     for ability in _shipping_abilities():
         properties = (ability.get_parameters() or {}).get("properties") or {}
@@ -283,7 +280,7 @@ def test_overlap_validator_rejects_a_tool_declaring_two_aliased_params():
             return ToolResult.ok("x")
 
     with pytest.raises(RegistryOverlapError) as excinfo:
-        validate_registry([_OverlapProbe()])
+        RegistryInvariant().check_no_overlaps([_OverlapProbe()])
 
     message = str(excinfo.value)
     assert "source" in message and "url" in message, message
@@ -323,7 +320,7 @@ def test_read_collision_first_key_wins_and_warning_emitted(db, tmp_path, caplog)
 
     # The warning must name both original keys and the resolved canonical.
     warn_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
-    assert warn_messages, "expected a canonicalize_keys collision warning, got none"
+    assert warn_messages, "expected a KeyHealer collision warning, got none"
     combined = " ".join(str(m) for m in warn_messages)
     assert "source" in combined and "url" in combined, combined
     assert "source" in combined, combined   # the canonical that both map to
@@ -357,6 +354,6 @@ def test_read_collision_order_decides_winner_not_key_identity(db, tmp_path, capl
 
     # Collision warning fires regardless of which key wins.
     warn_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
-    assert warn_messages, "expected a canonicalize_keys collision warning, got none"
+    assert warn_messages, "expected a KeyHealer collision warning, got none"
     combined = " ".join(str(m) for m in warn_messages)
     assert "source" in combined and "url" in combined, combined

--- a/backend/tests/test_tool_result_contract.py
+++ b/backend/tests/test_tool_result_contract.py
@@ -22,7 +22,7 @@ The contract under test:
   * ``ACTION_REQUIRED`` pre-validation reports an unknown action with ``valid=``
     and ALL missing params in ONE ``missing-params`` error.
   * Argument-key aliasing is healed at the dispatch seam
-    (``abilities._params.canonicalize_keys`` — ``url``/``path`` → ``source``)
+    (``abilities._params.KeyHealer.heal`` — ``url``/``path`` → ``source``)
     BEFORE ``run()``; ``Ability.param`` then matches the canonical key, validates
     choices, clamps numerics, and raises ``ToolParamError`` which the dispatcher
     renders canonically.
@@ -143,7 +143,7 @@ class _ParamAbility(Ability):
     def get_examples(self): return ["a", "b", "c", "d", "e", "f"]
     def get_search_tooltip(self): return "x"
     def get_parameters(self):
-        # Declares the canonical 'source'; the seam (canonicalize_keys) heals the
+        # Declares the canonical 'source'; the seam (KeyHealer.heal) heals the
         # model's 'url'/'path' onto it via the shared VARIANTS[source] ladder BEFORE
         # run() — param() itself no longer carries a per-tool alias list.
         return {


### PR DESCRIPTION
## Why

A code review of the just-shipped TKT-964 raised two valid coding-standards concerns about `backend/abilities/_params.py`:

1. It was filled with **procedural free functions** (`normalize`/`squeeze`/`canonicalize_keys`/`_variant_map`) where the standards require **OOP & SRP**.
2. It carried **test-only helpers in production code** — `Keys.values()`, `validate_registry()`, `RegistryOverlapError`, and `_FRAMEWORK_KEYS` had **zero production callers** (they exist only to assert registry invariants in the test suite).

This is a pure internal refactor of the TKT-964 key-healing seam. **No tool contract, schema, wire key, or runtime behaviour changes.**

## What

- **`KeyNormalizer`** — char-level key sanitisation (`normalize`/`squeeze`). One responsibility, no registry knowledge.
- **`KeyHealer`** — per-tool variant resolution (`heal` + private `_variant_map`). Dependencies **injected (DIP)**: `variants=VARIANTS`, `normalizer=KeyNormalizer()`.
- **`ToolDispatcher`** now takes `key_healer: KeyHealer | None = None` and calls `self._key_healer.heal(...)` at the seam. The fail-open `try/except` wrapper is unchanged.
- The four **test-only symbols moved** to a new `backend/tests/_registry_invariants.py` (`RegistryInvariant` with `canonical_keys()` + `check_no_overlaps()`, plus `RegistryOverlapError`, `FRAMEWORK_KEYS`). It is underscore-prefixed so pytest does not collect it, and it **imports the real registry** — re-implements no production logic.
- `Keys` and `VARIANTS` are unchanged as the single source of truth. Docstring/comment references updated (`canonicalize_keys` → `KeyHealer.heal`).

## Verification

- **Unit gate: 1503 passed / 137 deselected** — byte-identical to the TKT-964 baseline (zero regressions).
- **ruff: clean** on all six changed files.
- The 13 zero-mock dispatch-seam feature tests (`test_param_key_resilience.py`) — the behaviour-preservation net — all pass, still driving the real `ToolDispatcher(mp).dispatch()` chokepoint with a real DB.
- **4-lens adversarial review** (behaviour-equivalence · coding-standards · bug-hunt · feature-test-integrity), each finding verified: **all CLEAN, 0 confirmed defects**. Behaviour-equivalence lens ran both implementations side-by-side over every branch and confirmed byte-identical output; the only intended change is the log-message prefix `[canonicalize_keys]` → `[KeyHealer]` (logger name unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)