### PR TITLE
P2 — Brain admin app on Vue 3 (TKT-954)

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -312,6 +312,44 @@ def _register_static_routes(app: Flask) -> None:
             return send_from_directory(str(_NEXT_INTERFACE_DIR), filename)
         return send_from_directory(str(_NEXT_INTERFACE_DIR), 'index.html')
 
+    # ── Vue Brain build (P2 migration) ───────────────────────────
+    # Served verbatim (no legacy version-injection). Auth-gated like /brain/.
+    _NEXT_BRAIN_DIR = FileMapperService.get_frontend_path("apps", "brain", "dist")
+
+    @app.route('/brain-next', methods=["GET"])
+    def brain_next_index_no_slash():
+        """Canonicalize /brain-next → /brain-next/ so relative asset paths resolve."""
+        return redirect('/brain-next/', code=301)
+
+    @app.route('/brain-next/', methods=["GET"])
+    def brain_next_index():
+        """Serve Vue Brain SPA index. Redirects to login if unauthenticated."""
+        from services.auth_session_service import validate_session
+        from flask import request
+        if not validate_session(request):
+            return redirect('/login/?next=/brain-next/')
+        return send_from_directory(str(_NEXT_BRAIN_DIR), 'index.html')
+
+    @app.route('/brain-next/<path:filename>', methods=["GET"])
+    def brain_next_static(filename):
+        """Serve a Vue Brain asset, or SPA history-fallback to index.html.
+
+        Auth-gated: unauthenticated requests redirect to /login/.
+        Static assets (JS/CSS hashed by Vite) can be served without auth;
+        only deep-link / reload paths that map to index.html need the gate so the
+        SPA itself can run its own auth check. We gate all paths for consistency and
+        simplicity, matching the /brain/ pattern.
+        """
+        from services.auth_session_service import validate_session
+        from flask import request
+        if not validate_session(request):
+            next_path = f'/brain-next/{filename}'
+            return redirect(f'/login/?next={next_path}')
+        candidate = _NEXT_BRAIN_DIR / filename
+        if candidate.is_file():
+            return send_from_directory(str(_NEXT_BRAIN_DIR), filename)
+        return send_from_directory(str(_NEXT_BRAIN_DIR), 'index.html')
+
     # Main interface SPA — catch-all (must be last)
     @app.route('/<path:filename>', methods=["GET"])
     def interface_static(filename):

--- a/backend/tests/test_brain_next_static_serving.py
+++ b/backend/tests/test_brain_next_static_serving.py
@@ -1,0 +1,95 @@
+"""Feature test: the Vue Brain build is served at /brain-next/ alongside legacy /brain/.
+
+Real Flask app via create_app(), real on-disk dist, no mocks for the
+filesystem. Auth is bypassed with a patch on validate_session exactly as
+every other auth-gated route test in this suite does (see conftest.authed_client,
+test_api_system.py, test_policies_api.py — all patch
+``services.auth_session_service.validate_session``).
+"""
+
+import pytest
+from unittest.mock import patch
+from services.file_mapper_service import FileMapperService
+
+
+@pytest.fixture
+def brain_next_dist():
+    """Provide a minimal Vite-style dist for /brain-next/, restoring any
+    real on-disk build afterward so the test never clobbers build output.
+
+    Mirrors the built_dist fixture in test_next_static_serving.py.
+    """
+    dist = FileMapperService.get_frontend_path("apps", "brain", "dist")
+    assets = dist / "assets"
+    assets.mkdir(parents=True, exist_ok=True)
+    index = dist / "index.html"
+    app_js = assets / "brain.abc.js"
+    original_index = index.read_bytes() if index.exists() else None
+    app_js_preexisting = app_js.exists()
+    index.write_text(
+        '<!doctype html><html><body><div id="app"></div>'
+        '<script type="module" src="/brain-next/assets/brain.abc.js"></script></body></html>',
+        encoding="utf-8",
+    )
+    app_js.write_text("export const brain = true;\n", encoding="utf-8")
+    try:
+        yield dist
+    finally:
+        if original_index is not None:
+            index.write_bytes(original_index)
+        else:
+            index.unlink(missing_ok=True)
+        if not app_js_preexisting:
+            app_js.unlink(missing_ok=True)
+
+
+@pytest.mark.unit
+def test_brain_next_bare_path_redirects_301(brain_next_dist):
+    """/brain-next → /brain-next/ with 301 (no auth needed for redirect)."""
+    from api import create_app
+
+    app = create_app()
+    r = app.test_client().get("/brain-next", follow_redirects=False)
+    assert r.status_code == 301
+    assert r.headers["Location"].endswith("/brain-next/")
+
+
+@pytest.mark.unit
+def test_brain_next_unauth_redirects_to_login(brain_next_dist):
+    """/brain-next/ without a session → 302 to /login/?next=/brain-next/."""
+    from api import create_app
+
+    with patch("services.auth_session_service.validate_session", return_value=False):
+        app = create_app()
+        r = app.test_client().get("/brain-next/", follow_redirects=False)
+
+    assert r.status_code == 302
+    location = r.headers["Location"]
+    assert "/login/" in location
+    assert "next=/brain-next/" in location
+
+
+@pytest.mark.unit
+def test_brain_next_authed_serves_index(brain_next_dist):
+    """/brain-next/ with a valid session → 200 + SPA index.html."""
+    from api import create_app
+
+    with patch("services.auth_session_service.validate_session", return_value=True):
+        app = create_app()
+        r = app.test_client().get("/brain-next/")
+
+    assert r.status_code == 200
+    assert b'<div id="app">' in r.data
+
+
+@pytest.mark.unit
+def test_brain_next_authed_unknown_deep_path_spa_fallback(brain_next_dist):
+    """/brain-next/providers/some-deep-link → 200 SPA fallback (history mode reload)."""
+    from api import create_app
+
+    with patch("services.auth_session_service.validate_session", return_value=True):
+        app = create_app()
+        r = app.test_client().get("/brain-next/providers/some-deep-link")
+
+    assert r.status_code == 200
+    assert b'<div id="app">' in r.data

--- a/frontend/apps/brain/package.json
+++ b/frontend/apps/brain/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview",
-    "typecheck": "vue-tsc --noEmit"
+    "typecheck": "vue-tsc --noEmit",
+    "test": "playwright test"
   },
   "dependencies": {
     "@chalie/shared": "workspace:*",
@@ -17,6 +18,7 @@
     "vue-router": "^4.4.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@vitejs/plugin-vue": "^5.1.0",
     "sass": "^1.80.0",
     "vite": "^5.4.0",

--- a/frontend/apps/brain/package.json
+++ b/frontend/apps/brain/package.json
@@ -11,12 +11,14 @@
   },
   "dependencies": {
     "@chalie/shared": "workspace:*",
+    "@fontsource/inter": "^5.2.8",
     "pinia": "^2.2.0",
     "vue": "^3.5.0",
     "vue-router": "^4.4.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.1.0",
+    "sass": "^1.80.0",
     "vite": "^5.4.0",
     "vue-tsc": "^2.1.0"
   }

--- a/frontend/apps/brain/playwright.config.ts
+++ b/frontend/apps/brain/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+const BASE = process.env.CHALIE_BASE_URL;
+if (!BASE) throw new Error('CHALIE_BASE_URL must point at a running Chalie instance');
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  globalSetup: './tests/global-setup.ts',
+  // retain-on-failure (not on-first-retry): retries default to 0 — we want the
+  // trace on the very first failure, and retries would mask real flakiness.
+  use: { baseURL: BASE, storageState: '.auth/state.json', trace: 'retain-on-failure' },
+  reporter: [['list'], ['html', { open: 'never' }]],
+});

--- a/frontend/apps/brain/src/App.vue
+++ b/frontend/apps/brain/src/App.vue
@@ -7,6 +7,7 @@ import { useHeartbeat } from './composables/useHeartbeat';
 import BrainSidebar from './ui/BrainSidebar.vue';
 import BrainTopbar from './ui/BrainTopbar.vue';
 import CommandPalette from './ui/CommandPalette.vue';
+import ConfirmDialog from './ui/ConfirmDialog.vue';
 import ToastHost from './ui/ToastHost.vue';
 
 const { init: initTheme } = useTheme();
@@ -61,4 +62,7 @@ function closeMobileScrim(): void {
 
   <!-- Command palette overlay -->
   <CommandPalette id="cpOverlay" />
+
+  <!-- Confirm dialog (singleton, always mounted so useConfirm() resolves) -->
+  <ConfirmDialog />
 </template>

--- a/frontend/apps/brain/src/App.vue
+++ b/frontend/apps/brain/src/App.vue
@@ -41,7 +41,7 @@ function closeMobileScrim(): void {
     :data-providers-only="shell.providersOnly || undefined"
   >
     <!-- Mobile scrim -->
-    <div class="scrim" id="mobileScrim" @click="closeMobileScrim"></div>
+    <div id="mobileScrim" class="scrim" @click="closeMobileScrim"></div>
 
     <!-- Sidebar -->
     <BrainSidebar id="sidebar" />
@@ -51,7 +51,7 @@ function closeMobileScrim(): void {
 
     <!-- Main content with panel root -->
     <main class="main">
-      <div class="main-inner" id="panelRoot">
+      <div id="panelRoot" class="main-inner">
         <RouterView />
       </div>
     </main>

--- a/frontend/apps/brain/src/App.vue
+++ b/frontend/apps/brain/src/App.vue
@@ -1,13 +1,64 @@
 <script setup lang="ts">
-import { onMounted } from 'vue';
+import { onMounted, onBeforeUnmount } from 'vue';
+import { RouterView } from 'vue-router';
 import { useTheme } from '@chalie/shared';
-const { init } = useTheme();
-onMounted(() => init());
+import { useShellStore } from './stores/shell';
+import { useHeartbeat } from './composables/useHeartbeat';
+import BrainSidebar from './ui/BrainSidebar.vue';
+import BrainTopbar from './ui/BrainTopbar.vue';
+import CommandPalette from './ui/CommandPalette.vue';
+import ToastHost from './ui/ToastHost.vue';
+
+const { init: initTheme } = useTheme();
+const shell = useShellStore();
+const heartbeat = useHeartbeat();
+
+onMounted(() => {
+  initTheme();
+  heartbeat.start();
+});
+
+onBeforeUnmount(() => {
+  heartbeat.stop();
+});
+
+function closeMobileScrim(): void {
+  shell.mobileOpen = false;
+}
 </script>
 
 <template>
-  <main style="padding: 2rem">
-    <h1>Brain — Vue scaffold</h1>
-    <p>Panels migrate in P2 (TKT-954).</p>
-  </main>
+  <!-- Grain overlay (decorative, matches legacy .grain) -->
+  <div class="grain"></div>
+
+  <!-- Main app shell — grid: sidebar | topbar / main -->
+  <div
+    id="appShell"
+    class="app-shell"
+    :data-collapsed="shell.sidebarCollapsed || undefined"
+    :data-mobile-open="shell.mobileOpen || undefined"
+    :data-providers-only="shell.providersOnly || undefined"
+  >
+    <!-- Mobile scrim -->
+    <div class="scrim" id="mobileScrim" @click="closeMobileScrim"></div>
+
+    <!-- Sidebar -->
+    <BrainSidebar id="sidebar" />
+
+    <!-- Topbar -->
+    <BrainTopbar id="topbar" />
+
+    <!-- Main content with panel root -->
+    <main class="main">
+      <div class="main-inner" id="panelRoot">
+        <RouterView />
+      </div>
+    </main>
+  </div>
+
+  <!-- Toast host (outside the grid, fixed-position) -->
+  <ToastHost id="toastHost" />
+
+  <!-- Command palette overlay -->
+  <CommandPalette id="cpOverlay" />
 </template>

--- a/frontend/apps/brain/src/api/brain.ts
+++ b/frontend/apps/brain/src/api/brain.ts
@@ -3,20 +3,47 @@
  *
  * These are the ONLY /brain/-prefixed endpoints (confirmed in backend/api/brain.py):
  *   GET  /brain/info                → { db_size_human, document_count, ... }
- *   POST /brain/export              → binary octet-stream download
+ *   POST /brain/export              → binary octet-stream download (raw Response)
  *   POST /brain/import              → multipart import
- *   POST /brain/export/upload       → multipart export-to-cloud
- *   POST /brain/github/test         → test github connection { token, repo, ... }
+ *   POST /brain/export/upload       → JSON export-to-cloud (github)
+ *   POST /brain/github/test         → test github connection { github_token }
  *
  * NOTE: timestamps are rendered AS-IS from the backend (spec requirement).
  * No date formatting is performed here.
  */
 import { useApiClient } from '@chalie/shared';
-import { withAuth, redirectToLogin } from './http';
+import { withAuth } from './http';
 
 export interface BrainInfo {
   db_size_human?: string | null;
   document_count?: number | null;
+  [key: string]: unknown;
+}
+
+export interface BrainExportBody {
+  include_files: boolean;
+  encrypt: boolean;
+  password: string | null;
+}
+
+export interface BrainUploadBody extends BrainExportBody {
+  github_repo: string;
+  github_token: string;
+}
+
+export interface BrainImportResult {
+  db_size: number;
+  files_restored: number;
+  [key: string]: unknown;
+}
+
+export interface BrainUploadResult {
+  commit_url?: string;
+  [key: string]: unknown;
+}
+
+export interface GithubTestResult {
+  username?: string;
   [key: string]: unknown;
 }
 
@@ -27,32 +54,26 @@ export const brain = {
   },
 
   /**
-   * POST /brain/export → triggers a binary download.
-   * Returns the Response so the caller can handle the blob.
+   * POST /brain/export → returns the raw Response so the caller can handle the blob.
+   * Throws AuthError on 401 (via withAuth); does NOT throw on other non-ok statuses —
+   * the caller inspects res.ok and reads .blob()/.json() itself.
    */
-  async export(): Promise<Response> {
-    const res = await fetch('/brain/export', {
-      method: 'POST',
-      credentials: 'same-origin',
-      headers: { 'Content-Type': 'application/json' },
-    });
-    if (res.status === 401) {
-      redirectToLogin();
-    }
-    return res;
+  export(body: BrainExportBody): Promise<Response> {
+    const api = useApiClient();
+    return withAuth(() => api.download('/brain/export', body));
   },
 
-  import(formData: FormData): Promise<unknown> {
+  import(formData: FormData): Promise<BrainImportResult> {
     const api = useApiClient();
     return withAuth(() => api.upload('/brain/import', formData));
   },
 
-  exportUpload(formData: FormData): Promise<unknown> {
+  exportUpload(body: BrainUploadBody): Promise<BrainUploadResult> {
     const api = useApiClient();
-    return withAuth(() => api.upload('/brain/export/upload', formData));
+    return withAuth(() => api.post('/brain/export/upload', body));
   },
 
-  testGithub(body: Record<string, unknown>): Promise<{ success: boolean; error?: string }> {
+  testGithub(body: { github_token: string }): Promise<GithubTestResult> {
     const api = useApiClient();
     return withAuth(() => api.post('/brain/github/test', body));
   },

--- a/frontend/apps/brain/src/api/brain.ts
+++ b/frontend/apps/brain/src/api/brain.ts
@@ -40,6 +40,7 @@ export const brain = {
       window.location.replace(
         '/login/?next=' + encodeURIComponent(window.location.pathname),
       );
+      throw new Error('redirecting to login');
     }
     return res;
   },

--- a/frontend/apps/brain/src/api/brain.ts
+++ b/frontend/apps/brain/src/api/brain.ts
@@ -1,0 +1,61 @@
+/**
+ * Brain API — endpoints derived from frontend/brain/brain.js.
+ *
+ * These are the ONLY /brain/-prefixed endpoints (confirmed in backend/api/brain.py):
+ *   GET  /brain/info                → { db_size_human, document_count, ... }
+ *   POST /brain/export              → binary octet-stream download
+ *   POST /brain/import              → multipart import
+ *   POST /brain/export/upload       → multipart export-to-cloud
+ *   POST /brain/github/test         → test github connection { token, repo, ... }
+ *
+ * NOTE: timestamps are rendered AS-IS from the backend (spec requirement).
+ * No date formatting is performed here.
+ */
+import { useApiClient } from '@chalie/shared';
+import { withAuth } from './http';
+
+export interface BrainInfo {
+  db_size_human?: string | null;
+  document_count?: number | null;
+  [key: string]: unknown;
+}
+
+export const brain = {
+  info(): Promise<BrainInfo> {
+    const api = useApiClient();
+    return withAuth(() => api.get('/brain/info'));
+  },
+
+  /**
+   * POST /brain/export → triggers a binary download.
+   * Returns the Response so the caller can handle the blob.
+   */
+  async export(): Promise<Response> {
+    const res = await fetch('/brain/export', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    if (res.status === 401) {
+      window.location.replace(
+        '/login/?next=' + encodeURIComponent(window.location.pathname),
+      );
+    }
+    return res;
+  },
+
+  import(formData: FormData): Promise<unknown> {
+    const api = useApiClient();
+    return withAuth(() => api.upload('/brain/import', formData));
+  },
+
+  exportUpload(formData: FormData): Promise<unknown> {
+    const api = useApiClient();
+    return withAuth(() => api.upload('/brain/export/upload', formData));
+  },
+
+  testGithub(body: Record<string, unknown>): Promise<{ success: boolean; error?: string }> {
+    const api = useApiClient();
+    return withAuth(() => api.post('/brain/github/test', body));
+  },
+};

--- a/frontend/apps/brain/src/api/brain.ts
+++ b/frontend/apps/brain/src/api/brain.ts
@@ -12,7 +12,7 @@
  * No date formatting is performed here.
  */
 import { useApiClient } from '@chalie/shared';
-import { withAuth } from './http';
+import { withAuth, redirectToLogin } from './http';
 
 export interface BrainInfo {
   db_size_human?: string | null;
@@ -37,10 +37,7 @@ export const brain = {
       headers: { 'Content-Type': 'application/json' },
     });
     if (res.status === 401) {
-      window.location.replace(
-        '/login/?next=' + encodeURIComponent(window.location.pathname),
-      );
-      throw new Error('redirecting to login');
+      redirectToLogin();
     }
     return res;
   },

--- a/frontend/apps/brain/src/api/capabilities.ts
+++ b/frontend/apps/brain/src/api/capabilities.ts
@@ -1,0 +1,40 @@
+/**
+ * Capabilities API — endpoints derived from frontend/brain/capabilities.js.
+ *
+ * GET  /api/capabilities              → { capabilities: Capability[] }
+ * GET  /api/capabilities/:id          → { capability: Capability }
+ * POST /api/capabilities/:id/setup    → configure a capability
+ * POST /api/capabilities/:id/disconnect → disconnect a capability
+ */
+import { useApiClient } from '@chalie/shared';
+import { withAuth } from './http';
+
+export interface Capability {
+  id: string;
+  name: string;
+  enabled?: boolean;
+  connected?: boolean;
+  [key: string]: unknown;
+}
+
+export const capabilities = {
+  list(): Promise<{ capabilities: Capability[] }> {
+    const api = useApiClient();
+    return withAuth(() => api.get('/api/capabilities'));
+  },
+
+  get(id: string): Promise<{ capability: Capability }> {
+    const api = useApiClient();
+    return withAuth(() => api.get(`/api/capabilities/${id}`));
+  },
+
+  setup(id: string, body: Record<string, unknown>): Promise<unknown> {
+    const api = useApiClient();
+    return withAuth(() => api.post(`/api/capabilities/${id}/setup`, body));
+  },
+
+  disconnect(id: string): Promise<unknown> {
+    const api = useApiClient();
+    return withAuth(() => api.post(`/api/capabilities/${id}/disconnect`, {}));
+  },
+};

--- a/frontend/apps/brain/src/api/capabilities.ts
+++ b/frontend/apps/brain/src/api/capabilities.ts
@@ -1,19 +1,40 @@
 /**
  * Capabilities API — endpoints derived from frontend/brain/capabilities.js.
  *
- * GET  /api/capabilities              → { capabilities: Capability[] }
- * GET  /api/capabilities/:id          → { capability: Capability }
- * POST /api/capabilities/:id/setup    → configure a capability
+ * GET  /api/capabilities                → { capabilities: Capability[] }
+ * GET  /api/capabilities/:id            → flat Capability (id, name, version, connected, last_sync_at, config)
+ * POST /api/capabilities/:id/setup      → configure a capability
  * POST /api/capabilities/:id/disconnect → disconnect a capability
  */
 import { useApiClient } from '@chalie/shared';
 import { withAuth } from './http';
 
+export interface CapabilityFieldOption {
+  value: string;
+  label: string;
+}
+
+export interface CapabilityField {
+  name: string;
+  label: string;
+  type: string; // 'checkbox' | 'select' | 'textarea' | 'text' | 'password'
+  placeholder?: string;
+  default?: unknown;
+  required?: boolean;
+  options?: CapabilityFieldOption[];
+  show_when?: Record<string, unknown>;
+}
+
 export interface Capability {
   id: string;
   name: string;
-  enabled?: boolean;
+  version?: string | null;
   connected?: boolean;
+  status?: string | null;
+  platform?: string | null;
+  last_sync_at?: string | null;
+  fields?: CapabilityField[];
+  config?: Record<string, unknown> | null;
   [key: string]: unknown;
 }
 
@@ -23,7 +44,8 @@ export const capabilities = {
     return withAuth(() => api.get('/api/capabilities'));
   },
 
-  get(id: string): Promise<{ capability: Capability }> {
+  // Backend returns a FLAT object (no { capability } wrapper): { id, name, version, connected, last_sync_at, config }.
+  get(id: string): Promise<Capability> {
     const api = useApiClient();
     return withAuth(() => api.get(`/api/capabilities/${id}`));
   },

--- a/frontend/apps/brain/src/api/cognition.ts
+++ b/frontend/apps/brain/src/api/cognition.ts
@@ -1,0 +1,107 @@
+/**
+ * Cognition API — endpoints derived from frontend/brain/cognition.js fetch calls.
+ *
+ * GET  /system/observability/records?source=&limit=&offset=&q=  → memory records
+ * GET  /system/observability/tools                               → tool list
+ * GET  /system/observability/world-state                         → world state
+ * GET  /settings/personality                                     → personality tuple + voice
+ * PUT  /settings/personality                                     → update personality
+ * GET  /system/observability/errors                              → recent errors
+ * GET  /system/observability/token-usage?window=                 → token usage
+ * GET  /system/observability/compaction                          → compaction summary
+ */
+import { useApiClient } from '@chalie/shared';
+import { withAuth } from './http';
+
+export interface MemoryRecord {
+  created: string | null;
+  last_accessed: string | null;
+  location?: string | null;
+  key?: string | null;
+  value: string | null;
+}
+
+export interface MemoryResponse {
+  rows: MemoryRecord[];
+  has_more: boolean;
+  generated_at: string | null;
+}
+
+export interface Tool {
+  name: string;
+  description?: string | null;
+  [key: string]: unknown;
+}
+
+export interface WorldState {
+  [key: string]: unknown;
+}
+
+export interface Personality {
+  tuple: [number, number, number, number, number];
+  voice: string;
+}
+
+export interface ErrorEntry {
+  [key: string]: unknown;
+}
+
+export interface UsageResponse {
+  [key: string]: unknown;
+}
+
+export interface CompactionEntry {
+  [key: string]: unknown;
+}
+
+export const cognition = {
+  memory(params: {
+    source?: string;
+    limit?: number;
+    offset?: number;
+    q?: string;
+  }): Promise<MemoryResponse> {
+    const api = useApiClient();
+    const p = new URLSearchParams();
+    if (params.source) p.set('source', params.source);
+    if (params.limit != null) p.set('limit', String(params.limit));
+    if (params.offset != null) p.set('offset', String(params.offset));
+    if (params.q) p.set('q', params.q);
+    return withAuth(() => api.get(`/system/observability/records?${p.toString()}`));
+  },
+
+  tools(): Promise<{ tools: Tool[] }> {
+    const api = useApiClient();
+    return withAuth(() => api.get('/system/observability/tools'));
+  },
+
+  worldState(): Promise<WorldState> {
+    const api = useApiClient();
+    return withAuth(() => api.get('/system/observability/world-state'));
+  },
+
+  personality(): Promise<Personality> {
+    const api = useApiClient();
+    return withAuth(() => api.get('/settings/personality'));
+  },
+
+  setPersonality(data: Partial<Personality>): Promise<unknown> {
+    const api = useApiClient();
+    return withAuth(() => api.put('/settings/personality', data));
+  },
+
+  errors(): Promise<{ errors: ErrorEntry[] }> {
+    const api = useApiClient();
+    return withAuth(() => api.get('/system/observability/errors'));
+  },
+
+  tokenUsage(window: string = 'day'): Promise<UsageResponse> {
+    const api = useApiClient();
+    return withAuth(() => api.get(`/system/observability/token-usage?window=${encodeURIComponent(window)}`));
+  },
+
+  compaction(): Promise<{ compaction: CompactionEntry | null }> {
+    const api = useApiClient();
+    return withAuth(() => api.get('/system/observability/compaction'));
+  },
+};

--- a/frontend/apps/brain/src/api/cognition.ts
+++ b/frontend/apps/brain/src/api/cognition.ts
@@ -27,13 +27,44 @@ export interface MemoryResponse {
   generated_at: string | null;
 }
 
+// Fields are derived from what the legacy cognition.js render code reads off each
+// response (production-proven); an index signature keeps each shape forward-compatible.
+
 export interface Tool {
-  name: string;
-  description?: string | null;
+  tool_name: string;
+  count?: number | null;
+  last_used_at?: string | null;
   [key: string]: unknown;
 }
 
+export interface WorldTelemetry {
+  device?: { class?: string; platform?: string; screen_w?: number; screen_h?: number } | null;
+  battery?: { level?: number; charging?: boolean } | null;
+  location_name?: string | null;
+  local_time?: string | null;
+  timezone?: string | null;
+  connection?: string | null;
+  preferences?: { color_scheme?: string; [k: string]: unknown } | null;
+  [k: string]: unknown;
+}
+
+export interface WorldSchedule {
+  status?: string;
+  message?: string;
+  due_at?: string | null;
+  recurrence?: string | null;
+  [k: string]: unknown;
+}
+
 export interface WorldState {
+  inputs?: {
+    telemetry?: WorldTelemetry | null;
+    schedule?: WorldSchedule[] | null;
+    signals?: Record<string, { label?: string; [k: string]: unknown }> | null;
+    bg_processes?: (string | Record<string, unknown>)[] | null;
+    [k: string]: unknown;
+  } | null;
+  rendered?: string | null;
   [key: string]: unknown;
 }
 
@@ -43,14 +74,39 @@ export interface Personality {
 }
 
 export interface ErrorEntry {
+  time?: string | null;
+  timestamp?: string | null;
+  message?: string;
+  [key: string]: unknown;
+}
+
+export interface UsageSummary {
+  total_tokens?: number;
+  cache_hit_pct?: number | null;
+  tokens_today?: number;
+  most_active_model?: string;
+  [key: string]: unknown;
+}
+
+export interface UsageEntry {
+  bucket: string;
+  tokens_input?: number;
+  tokens_cache_read?: number;
+  tokens_output?: number;
+  tokens_thinking?: number;
   [key: string]: unknown;
 }
 
 export interface UsageResponse {
+  summary?: UsageSummary | null;
+  entries?: UsageEntry[] | null;
   [key: string]: unknown;
 }
 
 export interface CompactionEntry {
+  compacted_at?: string | null;
+  compacted_up_to_id?: number | null;
+  summary: string;
   [key: string]: unknown;
 }
 

--- a/frontend/apps/brain/src/api/documents.ts
+++ b/frontend/apps/brain/src/api/documents.ts
@@ -1,0 +1,55 @@
+/**
+ * Documents API — endpoints derived from frontend/brain/documents.js fetch calls.
+ *
+ * GET    /documents                       → { items: Document[] }
+ * GET    /documents?include_deleted=true  → include deleted docs
+ * GET    /documents/watched-folders       → { items: WatchedFolder[] }
+ * GET    /documents/:id                   → { document: Document }
+ * DELETE /documents/:id                   → delete document
+ * POST   /documents/upload                → multipart upload
+ */
+import { useApiClient } from '@chalie/shared';
+import { withAuth } from './http';
+
+export interface Document {
+  id: string | number;
+  title?: string | null;
+  filename?: string | null;
+  status?: string | null;
+  deleted?: boolean;
+  [key: string]: unknown;
+}
+
+export interface WatchedFolder {
+  id: string | number;
+  path: string;
+  [key: string]: unknown;
+}
+
+export const documents = {
+  list(includeDeleted = false): Promise<{ items: Document[] }> {
+    const api = useApiClient();
+    const url = includeDeleted ? '/documents?include_deleted=true' : '/documents';
+    return withAuth(() => api.get(url));
+  },
+
+  watchedFolders(): Promise<{ items: WatchedFolder[] }> {
+    const api = useApiClient();
+    return withAuth(() => api.get('/documents/watched-folders'));
+  },
+
+  get(id: string | number): Promise<{ document: Document }> {
+    const api = useApiClient();
+    return withAuth(() => api.get(`/documents/${id}`));
+  },
+
+  delete(id: string | number): Promise<unknown> {
+    const api = useApiClient();
+    return withAuth(() => api.del(`/documents/${id}`));
+  },
+
+  upload(formData: FormData): Promise<unknown> {
+    const api = useApiClient();
+    return withAuth(() => api.upload('/documents/upload', formData));
+  },
+};

--- a/frontend/apps/brain/src/api/documents.ts
+++ b/frontend/apps/brain/src/api/documents.ts
@@ -4,7 +4,7 @@
  * GET    /documents                       → { items: Document[] }
  * GET    /documents?include_deleted=true  → include deleted docs
  * GET    /documents/watched-folders       → { items: WatchedFolder[] }
- * GET    /documents/:id                   → { document: Document }
+ * GET    /documents/:id                   → { item: Document }
  * DELETE /documents/:id                   → delete document
  * POST   /documents/upload                → multipart upload
  */
@@ -38,7 +38,7 @@ export const documents = {
     return withAuth(() => api.get('/documents/watched-folders'));
   },
 
-  get(id: string | number): Promise<{ document: Document }> {
+  get(id: string | number): Promise<{ item: Document }> {
     const api = useApiClient();
     return withAuth(() => api.get(`/documents/${id}`));
   },

--- a/frontend/apps/brain/src/api/documents.ts
+++ b/frontend/apps/brain/src/api/documents.ts
@@ -20,9 +20,16 @@ export interface Document {
   [key: string]: unknown;
 }
 
+// Fields mirror the raw `watched_folders` columns — GET /documents/watched-folders
+// returns `dict(zip(cols, row))` from `FolderWatcherService.get_all_folders()`
+// (no serialization layer), so the keys are the DB column names verbatim.
 export interface WatchedFolder {
   id: string | number;
-  path: string;
+  folder_path: string;
+  label?: string | null;
+  enabled?: number | boolean;
+  last_scan_at?: string | null;
+  last_scan_files?: number;
   [key: string]: unknown;
 }
 

--- a/frontend/apps/brain/src/api/http.ts
+++ b/frontend/apps/brain/src/api/http.ts
@@ -6,7 +6,7 @@
  * Port of legacy BrainApp.apiFetch()'s `if (res.status === 401)` branch
  * (app.js:68) — but targeted at /brain-next/ (not /brain/).
  */
-import { AuthError } from '@chalie/shared';
+import { AuthError, HttpError } from '@chalie/shared';
 
 /** Redirect to /login/ preserving the current path and query string as `next`. */
 export function redirectToLogin(): never {
@@ -29,4 +29,15 @@ export async function withAuth<T>(fn: () => Promise<T>): Promise<T> {
   } catch (err) {
     return handle401(err);
   }
+}
+
+/**
+ * Resolve a user-facing message for a thrown API error.
+ * - HTTP (non-2xx) error → the server's {error} message if present, else `httpFallback`.
+ * - anything else (network/unexpected) → `networkFallback`.
+ * Mirrors the legacy panels' `data.error || '<fallback>'` (non-ok) vs catch-branch message split.
+ */
+export function apiErrorMessage(e: unknown, httpFallback: string, networkFallback = 'Network error'): string {
+  if (e instanceof HttpError) return e.error || httpFallback;
+  return networkFallback;
 }

--- a/frontend/apps/brain/src/api/http.ts
+++ b/frontend/apps/brain/src/api/http.ts
@@ -8,11 +8,16 @@
  */
 import { AuthError } from '@chalie/shared';
 
+/** Redirect to /login/ preserving the current path and query string as `next`. */
+export function redirectToLogin(): never {
+  const next = window.location.pathname + window.location.search;
+  window.location.replace('/login/?next=' + encodeURIComponent(next));
+  throw new Error('redirecting to login');
+}
+
 export function handle401(err: unknown): never {
   if (err instanceof AuthError) {
-    window.location.replace(
-      '/login/?next=' + encodeURIComponent(window.location.pathname + window.location.search),
-    );
+    redirectToLogin();
   }
   throw err;
 }

--- a/frontend/apps/brain/src/api/http.ts
+++ b/frontend/apps/brain/src/api/http.ts
@@ -1,0 +1,27 @@
+/**
+ * Brain API HTTP helper.
+ *
+ * Centralises 401 handling: the shared ApiClient throws AuthError on 401
+ * without redirecting. This module catches it and redirects to /login/.
+ * Port of legacy BrainApp.apiFetch()'s `if (res.status === 401)` branch
+ * (app.js:68) — but targeted at /brain-next/ (not /brain/).
+ */
+import { AuthError } from '@chalie/shared';
+
+export function handle401(err: unknown): never {
+  if (err instanceof AuthError) {
+    window.location.replace(
+      '/login/?next=' + encodeURIComponent(window.location.pathname + window.location.search),
+    );
+  }
+  throw err;
+}
+
+/** Wrap an api call and redirect on 401. */
+export async function withAuth<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    return handle401(err);
+  }
+}

--- a/frontend/apps/brain/src/api/index.ts
+++ b/frontend/apps/brain/src/api/index.ts
@@ -15,5 +15,6 @@ export { policies } from './policies';
 export { skills } from './skills';
 export { mcp } from './mcp';
 export { brain } from './brain';
+export { vision } from './vision';
 
 export { getHost } from '@chalie/shared';

--- a/frontend/apps/brain/src/api/index.ts
+++ b/frontend/apps/brain/src/api/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Brain API barrel — domain endpoint wrappers over the shared ApiClient.
+ *
+ * Each module wraps a domain's endpoints with typed request/response shapes.
+ * All modules use withAuth() from http.ts to handle 401 → /login/ redirect.
+ */
+export { system } from './system';
+export { providers } from './providers';
+export { cognition } from './cognition';
+export { scheduler } from './scheduler';
+export { lists } from './lists';
+export { documents } from './documents';
+export { capabilities } from './capabilities';
+export { policies } from './policies';
+export { skills } from './skills';
+export { mcp } from './mcp';
+export { brain } from './brain';
+
+export { getHost } from '@chalie/shared';

--- a/frontend/apps/brain/src/api/lists.ts
+++ b/frontend/apps/brain/src/api/lists.ts
@@ -2,8 +2,8 @@
  * Lists API — endpoints derived from frontend/brain/lists.js fetch calls.
  *
  * GET    /lists                          → { items: List[] }
- * GET    /lists/:id                      → { list: ListDetail }
- * POST   /lists                          → { list: List } create with { name }
+ * GET    /lists/:id                      → { item: List }
+ * POST   /lists                          → { item: List } create with { name }
  * DELETE /lists/:id                      → delete list
  * PUT    /lists/:id/rename               → rename list { name }
  * POST   /lists/:id/items                → add items { items: string[] }
@@ -32,12 +32,12 @@ export const lists = {
     return withAuth(() => api.get('/lists'));
   },
 
-  get(listId: string | number): Promise<{ list: List }> {
+  get(listId: string | number): Promise<{ item: List }> {
     const api = useApiClient();
     return withAuth(() => api.get(`/lists/${listId}`));
   },
 
-  create(name: string): Promise<{ list: List }> {
+  create(name: string): Promise<{ item: List }> {
     const api = useApiClient();
     return withAuth(() => api.post('/lists', { name }));
   },

--- a/frontend/apps/brain/src/api/lists.ts
+++ b/frontend/apps/brain/src/api/lists.ts
@@ -1,0 +1,64 @@
+/**
+ * Lists API — endpoints derived from frontend/brain/lists.js fetch calls.
+ *
+ * GET    /lists                          → { items: List[] }
+ * GET    /lists/:id                      → { list: ListDetail }
+ * POST   /lists                          → { list: List } create with { name }
+ * DELETE /lists/:id                      → delete list
+ * PUT    /lists/:id/rename               → rename list { name }
+ * POST   /lists/:id/items                → add items { items: string[] }
+ * PUT    /lists/:id/items/:endpoint      → toggle item (check/uncheck) { items }
+ */
+import { useApiClient } from '@chalie/shared';
+import { withAuth } from './http';
+
+export interface ListItem {
+  id: string | number;
+  content: string;
+  checked: boolean;
+}
+
+export interface List {
+  id: string | number;
+  name: string;
+  item_count?: number;
+  checked_count?: number;
+  items?: ListItem[];
+}
+
+export const lists = {
+  list(): Promise<{ items: List[] }> {
+    const api = useApiClient();
+    return withAuth(() => api.get('/lists'));
+  },
+
+  get(listId: string | number): Promise<{ list: List }> {
+    const api = useApiClient();
+    return withAuth(() => api.get(`/lists/${listId}`));
+  },
+
+  create(name: string): Promise<{ list: List }> {
+    const api = useApiClient();
+    return withAuth(() => api.post('/lists', { name }));
+  },
+
+  delete(listId: string | number): Promise<unknown> {
+    const api = useApiClient();
+    return withAuth(() => api.del(`/lists/${listId}`));
+  },
+
+  rename(listId: string | number, name: string): Promise<unknown> {
+    const api = useApiClient();
+    return withAuth(() => api.put(`/lists/${listId}/rename`, { name }));
+  },
+
+  addItems(listId: string | number, items: string[]): Promise<unknown> {
+    const api = useApiClient();
+    return withAuth(() => api.post(`/lists/${listId}/items`, { items }));
+  },
+
+  toggleItem(listId: string | number, endpoint: string, item: { content: string }): Promise<unknown> {
+    const api = useApiClient();
+    return withAuth(() => api.put(`/lists/${listId}/items/${endpoint}`, { items: [item.content] }));
+  },
+};

--- a/frontend/apps/brain/src/api/mcp.ts
+++ b/frontend/apps/brain/src/api/mcp.ts
@@ -1,0 +1,85 @@
+/**
+ * MCP API — endpoints derived from frontend/brain/mcp.js.
+ *
+ * Inbound (server side — Chalie as MCP server):
+ *   GET  /api/mcp-server                          → config
+ *   PUT  /api/mcp-server                          → update config
+ *   POST /api/mcp-server/regenerate-token         → regenerate token
+ *
+ * Outbound (client side — Chalie connecting to external MCP servers):
+ *   GET    /api/mcp-clients/       → list client servers
+ *   POST   /api/mcp-clients/       → add client server
+ *   PUT    /api/mcp-clients/:id    → update client server
+ *   DELETE /api/mcp-clients/:id    → delete client server
+ *   POST   /api/mcp-clients/:id/test → test connection
+ */
+import { useApiClient } from '@chalie/shared';
+import { withAuth } from './http';
+
+export interface McpServerConfig {
+  enabled?: boolean;
+  port?: number;
+  token?: string | null;
+  [key: string]: unknown;
+}
+
+export interface McpClient {
+  id: string | number;
+  name: string;
+  url: string;
+  enabled?: boolean;
+  [key: string]: unknown;
+}
+
+export interface McpClientInput {
+  name: string;
+  url: string;
+  enabled?: boolean;
+  [key: string]: unknown;
+}
+
+export const mcp = {
+  // ── Inbound ──────────────────────────────────────────────────────────────
+
+  getServerConfig(): Promise<McpServerConfig> {
+    const api = useApiClient();
+    return withAuth(() => api.get('/api/mcp-server'));
+  },
+
+  updateServerConfig(body: Partial<McpServerConfig>): Promise<McpServerConfig> {
+    const api = useApiClient();
+    return withAuth(() => api.put('/api/mcp-server', body));
+  },
+
+  regenerateToken(): Promise<{ token: string }> {
+    const api = useApiClient();
+    return withAuth(() => api.post('/api/mcp-server/regenerate-token', {}));
+  },
+
+  // ── Outbound ─────────────────────────────────────────────────────────────
+
+  listClients(): Promise<{ servers?: McpClient[]; clients?: McpClient[] }> {
+    const api = useApiClient();
+    return withAuth(() => api.get('/api/mcp-clients/'));
+  },
+
+  createClient(body: McpClientInput): Promise<{ server?: McpClient; client?: McpClient }> {
+    const api = useApiClient();
+    return withAuth(() => api.post('/api/mcp-clients/', body));
+  },
+
+  updateClient(id: string | number, body: Partial<McpClientInput>): Promise<unknown> {
+    const api = useApiClient();
+    return withAuth(() => api.put(`/api/mcp-clients/${id}`, body));
+  },
+
+  deleteClient(id: string | number): Promise<unknown> {
+    const api = useApiClient();
+    return withAuth(() => api.del(`/api/mcp-clients/${id}`));
+  },
+
+  testClient(id: string | number): Promise<{ success: boolean; error?: string }> {
+    const api = useApiClient();
+    return withAuth(() => api.post(`/api/mcp-clients/${id}/test`, {}));
+  },
+};

--- a/frontend/apps/brain/src/api/mcp.ts
+++ b/frontend/apps/brain/src/api/mcp.ts
@@ -7,7 +7,7 @@
  *   POST /api/mcp-server/regenerate-token         → regenerate token
  *
  * Outbound (client side — Chalie connecting to external MCP servers):
- *   GET    /api/mcp-clients/       → list client servers
+ *   GET    /api/mcp-clients/       → list client servers (bare array)
  *   POST   /api/mcp-clients/       → add client server
  *   PUT    /api/mcp-clients/:id    → update client server
  *   DELETE /api/mcp-clients/:id    → delete client server
@@ -26,14 +26,17 @@ export interface McpServerConfig {
 export interface McpClient {
   id: string | number;
   name: string;
-  url: string;
+  host: string;
+  status?: string;
   enabled?: boolean;
+  headers?: Record<string, string>;
   [key: string]: unknown;
 }
 
 export interface McpClientInput {
   name: string;
-  url: string;
+  host: string;
+  headers: Record<string, string>;
   enabled?: boolean;
   [key: string]: unknown;
 }
@@ -46,7 +49,7 @@ export const mcp = {
     return withAuth(() => api.get('/api/mcp-server'));
   },
 
-  updateServerConfig(body: Partial<McpServerConfig>): Promise<McpServerConfig> {
+  updateServerConfig(body: Partial<McpServerConfig>): Promise<unknown> {
     const api = useApiClient();
     return withAuth(() => api.put('/api/mcp-server', body));
   },
@@ -58,12 +61,12 @@ export const mcp = {
 
   // ── Outbound ─────────────────────────────────────────────────────────────
 
-  listClients(): Promise<{ servers?: McpClient[]; clients?: McpClient[] }> {
+  listClients(): Promise<McpClient[]> {
     const api = useApiClient();
     return withAuth(() => api.get('/api/mcp-clients/'));
   },
 
-  createClient(body: McpClientInput): Promise<{ server?: McpClient; client?: McpClient }> {
+  createClient(body: McpClientInput): Promise<unknown> {
     const api = useApiClient();
     return withAuth(() => api.post('/api/mcp-clients/', body));
   },
@@ -78,7 +81,7 @@ export const mcp = {
     return withAuth(() => api.del(`/api/mcp-clients/${id}`));
   },
 
-  testClient(id: string | number): Promise<{ success: boolean; error?: string }> {
+  testClient(id: string | number): Promise<{ reachable: boolean; tool_count?: number; status?: string }> {
     const api = useApiClient();
     return withAuth(() => api.post(`/api/mcp-clients/${id}/test`, {}));
   },

--- a/frontend/apps/brain/src/api/policies.ts
+++ b/frontend/apps/brain/src/api/policies.ts
@@ -12,9 +12,14 @@ export interface PolicyRow {
   channel: string;
   permission: string;
   setting: string;
+  label?: string;
+  group?: string;
 }
 
 export interface BlockedEntry {
+  action_id?: string | null;
+  context?: string | null;
+  created_at?: string | null;
   [key: string]: unknown;
 }
 

--- a/frontend/apps/brain/src/api/policies.ts
+++ b/frontend/apps/brain/src/api/policies.ts
@@ -1,0 +1,42 @@
+/**
+ * Policies API — endpoints derived from frontend/brain/policies.js.
+ *
+ * GET /api/policies              → { policies: PolicyRow[] }
+ * GET /api/policies/blocked      → { entries: BlockedEntry[] }
+ * PUT /api/policies              → update one policy { channel, permission, setting }
+ */
+import { useApiClient } from '@chalie/shared';
+import { withAuth } from './http';
+
+export interface PolicyRow {
+  channel: string;
+  permission: string;
+  setting: string;
+}
+
+export interface BlockedEntry {
+  [key: string]: unknown;
+}
+
+export interface PolicyUpdate {
+  channel: string;
+  permission: string;
+  setting: string;
+}
+
+export const policies = {
+  list(): Promise<{ policies: PolicyRow[] }> {
+    const api = useApiClient();
+    return withAuth(() => api.get('/api/policies'));
+  },
+
+  blocked(): Promise<{ entries: BlockedEntry[] }> {
+    const api = useApiClient();
+    return withAuth(() => api.get('/api/policies/blocked'));
+  },
+
+  update(body: PolicyUpdate): Promise<unknown> {
+    const api = useApiClient();
+    return withAuth(() => api.put('/api/policies', body));
+  },
+};

--- a/frontend/apps/brain/src/api/providers.ts
+++ b/frontend/apps/brain/src/api/providers.ts
@@ -1,0 +1,105 @@
+/**
+ * Providers API — endpoints derived from frontend/brain/providers.js fetch calls.
+ *
+ * GET  /providers               → list all providers
+ * GET  /providers/selected      → get the selected provider
+ * PUT  /providers/selected      → select a provider { provider_id }
+ * GET  /providers/catalog       → get the provider catalog
+ * GET  /providers/vision        → get the vision provider
+ * PUT  /providers/vision        → set vision provider { provider_id }
+ * POST /providers               → create provider
+ * PUT  /providers/:id           → update provider
+ * DELETE /providers/:id         → delete provider
+ * POST /providers/list-models   → list models for credentials
+ * POST /providers/test          → test connection
+ */
+import { useApiClient } from '@chalie/shared';
+import { withAuth } from './http';
+
+export interface Provider {
+  id: number;
+  name: string;
+  platform: string;
+  model: string | null;
+  host: string | null;
+  supports_vision: boolean;
+  decrypt_failed?: boolean;
+  role?: string | null;
+}
+
+export interface CatalogEntry {
+  id: string;
+  name: string;
+  platform: string;
+  host: string;
+  needs_key: boolean;
+}
+
+export interface ProviderInput {
+  name: string;
+  platform: string;
+  model: string;
+  host?: string;
+  api_key?: string;
+}
+
+export interface TestInput extends ProviderInput {
+  provider_id?: number;
+}
+
+export const providers = {
+  list(): Promise<{ providers: Provider[] }> {
+    const api = useApiClient();
+    return withAuth(() => api.get('/providers'));
+  },
+
+  getSelected(): Promise<{ provider: Provider | null }> {
+    const api = useApiClient();
+    return withAuth(() => api.get('/providers/selected'));
+  },
+
+  setSelected(providerId: number): Promise<unknown> {
+    const api = useApiClient();
+    return withAuth(() => api.put('/providers/selected', { provider_id: providerId }));
+  },
+
+  getCatalog(): Promise<{ catalog: CatalogEntry[] }> {
+    const api = useApiClient();
+    return withAuth(() => api.get('/providers/catalog'));
+  },
+
+  getVision(): Promise<{ provider: Provider | null; source: string }> {
+    const api = useApiClient();
+    return withAuth(() => api.get('/providers/vision'));
+  },
+
+  setVision(providerId: number): Promise<unknown> {
+    const api = useApiClient();
+    return withAuth(() => api.put('/providers/vision', { provider_id: providerId }));
+  },
+
+  create(input: ProviderInput): Promise<{ provider: Provider }> {
+    const api = useApiClient();
+    return withAuth(() => api.post('/providers', input));
+  },
+
+  update(id: number, input: Partial<ProviderInput>): Promise<{ provider: Provider }> {
+    const api = useApiClient();
+    return withAuth(() => api.put(`/providers/${id}`, input));
+  },
+
+  delete(id: number): Promise<unknown> {
+    const api = useApiClient();
+    return withAuth(() => api.del(`/providers/${id}`));
+  },
+
+  listModels(body: { platform: string; host?: string; api_key?: string }): Promise<{ models: (string | { id: string })[] }> {
+    const api = useApiClient();
+    return withAuth(() => api.post('/providers/list-models', body));
+  },
+
+  test(body: TestInput): Promise<{ success: boolean; message?: string; error?: string }> {
+    const api = useApiClient();
+    return withAuth(() => api.post('/providers/test', body));
+  },
+};

--- a/frontend/apps/brain/src/api/scheduler.ts
+++ b/frontend/apps/brain/src/api/scheduler.ts
@@ -1,0 +1,52 @@
+/**
+ * Scheduler API — endpoints derived from frontend/brain/scheduler.js fetch calls.
+ *
+ * GET    /scheduler              → list schedules { schedules: [...] }
+ * POST   /scheduler              → create schedule
+ * PUT    /scheduler/:id          → update schedule
+ * DELETE /scheduler/:id          → delete/cancel schedule
+ */
+import { useApiClient } from '@chalie/shared';
+import { withAuth } from './http';
+
+export interface ScheduleItem {
+  id: string | number;
+  message?: string | null;
+  prompt?: string | null;
+  status: string;
+  due_at?: string | null;
+  due?: string | null;
+  recurrence?: string | null;
+  type?: string | null;
+  item_type?: string | null;
+  [key: string]: unknown;
+}
+
+export interface ScheduleInput {
+  message: string;
+  due_at: string;
+  type?: string;
+  recurrence?: string | null;
+}
+
+export const scheduler = {
+  list(): Promise<{ schedules?: ScheduleItem[]; items?: ScheduleItem[] }> {
+    const api = useApiClient();
+    return withAuth(() => api.get('/scheduler'));
+  },
+
+  create(body: ScheduleInput): Promise<{ schedule?: ScheduleItem }> {
+    const api = useApiClient();
+    return withAuth(() => api.post('/scheduler', body));
+  },
+
+  update(id: string | number, body: Partial<ScheduleInput>): Promise<{ schedule?: ScheduleItem }> {
+    const api = useApiClient();
+    return withAuth(() => api.put(`/scheduler/${id}`, body));
+  },
+
+  delete(id: string | number): Promise<unknown> {
+    const api = useApiClient();
+    return withAuth(() => api.del(`/scheduler/${id}`));
+  },
+};

--- a/frontend/apps/brain/src/api/skills.ts
+++ b/frontend/apps/brain/src/api/skills.ts
@@ -1,0 +1,64 @@
+/**
+ * Skills API — endpoints derived from frontend/brain/skills.js.
+ *
+ * GET    /api/skills              → { skills: Skill[], associations: Association[] }
+ * POST   /api/skills              → create skill
+ * PUT    /api/skills/:id          → update skill
+ * DELETE /api/skills/:id          → delete skill
+ * PUT    /api/skills/:id/toggle   → toggle skill enabled
+ * POST   /api/skills/:id/copy     → duplicate skill
+ */
+import { useApiClient } from '@chalie/shared';
+import { withAuth } from './http';
+
+export interface Association {
+  skill_id: string | number;
+  [key: string]: unknown;
+}
+
+export interface Skill {
+  id: string | number;
+  name: string;
+  trigger?: string | null;
+  instructions?: string | null;
+  enabled?: boolean;
+  [key: string]: unknown;
+}
+
+export interface SkillInput {
+  name: string;
+  trigger?: string;
+  instructions?: string;
+}
+
+export const skills = {
+  list(): Promise<{ skills: Skill[]; associations: Association[] }> {
+    const api = useApiClient();
+    return withAuth(() => api.get('/api/skills'));
+  },
+
+  create(body: SkillInput): Promise<{ skill: Skill }> {
+    const api = useApiClient();
+    return withAuth(() => api.post('/api/skills', body));
+  },
+
+  update(id: string | number, body: Partial<SkillInput>): Promise<{ skill: Skill }> {
+    const api = useApiClient();
+    return withAuth(() => api.put(`/api/skills/${id}`, body));
+  },
+
+  delete(id: string | number): Promise<unknown> {
+    const api = useApiClient();
+    return withAuth(() => api.del(`/api/skills/${id}`));
+  },
+
+  toggle(id: string | number): Promise<unknown> {
+    const api = useApiClient();
+    return withAuth(() => api.put(`/api/skills/${id}/toggle`, {}));
+  },
+
+  copy(id: string | number): Promise<{ skill: Skill }> {
+    const api = useApiClient();
+    return withAuth(() => api.post(`/api/skills/${id}/copy`, {}));
+  },
+};

--- a/frontend/apps/brain/src/api/skills.ts
+++ b/frontend/apps/brain/src/api/skills.ts
@@ -12,23 +12,30 @@ import { useApiClient } from '@chalie/shared';
 import { withAuth } from './http';
 
 export interface Association {
-  skill_id: string | number;
+  pattern_name: string;
+  skill_title: string;
+  rule: string;
+  created_at?: string | null;
   [key: string]: unknown;
 }
 
 export interface Skill {
   id: string | number;
-  name: string;
-  trigger?: string | null;
-  instructions?: string | null;
+  title: string;
+  use_for: string;
+  content: string;
+  tags?: string | null;
+  version?: string | number;
+  source?: string;
   enabled?: boolean;
   [key: string]: unknown;
 }
 
 export interface SkillInput {
-  name: string;
-  trigger?: string;
-  instructions?: string;
+  title: string;
+  use_for: string;
+  content: string;
+  tags?: string;
 }
 
 export const skills = {
@@ -52,7 +59,7 @@ export const skills = {
     return withAuth(() => api.del(`/api/skills/${id}`));
   },
 
-  toggle(id: string | number): Promise<unknown> {
+  toggle(id: string | number): Promise<{ enabled: boolean }> {
     const api = useApiClient();
     return withAuth(() => api.put(`/api/skills/${id}/toggle`, {}));
   },

--- a/frontend/apps/brain/src/api/system.ts
+++ b/frontend/apps/brain/src/api/system.ts
@@ -1,0 +1,18 @@
+import { useApiClient } from '@chalie/shared';
+
+/** Response from GET /auth/status. */
+export interface AuthStatus {
+  has_master_account: boolean;
+  has_providers: boolean;
+  has_session: boolean;
+  vault_state: 'unlocked' | 'locked' | 'uninitialized';
+  has_vision_provider: boolean;
+}
+
+export const system = {
+  /** GET /auth/status — used by the router auth gate. */
+  authStatus(): Promise<AuthStatus> {
+    const api = useApiClient();
+    return api.get('/auth/status');
+  },
+};

--- a/frontend/apps/brain/src/api/vision.ts
+++ b/frontend/apps/brain/src/api/vision.ts
@@ -1,0 +1,8 @@
+/**
+ * Vision API — re-exports from providers (same endpoints).
+ * Derived from frontend/brain/vision.js:
+ *   GET  /providers           → list all providers (with supports_vision flag)
+ *   GET  /providers/vision    → get current vision provider
+ *   PUT  /providers/vision    → set vision provider { provider_id }
+ */
+export { providers as vision } from './providers';

--- a/frontend/apps/brain/src/composables/useConfirm.ts
+++ b/frontend/apps/brain/src/composables/useConfirm.ts
@@ -1,0 +1,47 @@
+/**
+ * Promise-based confirm dialog composable.
+ *
+ * Replaces native confirm() calls in legacy JS panels.
+ * ConfirmDialog.vue listens to the reactive state exposed here.
+ */
+import { ref, shallowRef } from 'vue';
+
+export interface ConfirmOptions {
+  title: string;
+  desc: string;
+  confirmLabel?: string;
+  confirmClass?: string;
+}
+
+interface PendingConfirm extends ConfirmOptions {
+  resolve: (value: boolean) => void;
+}
+
+const pending = shallowRef<PendingConfirm | null>(null);
+const visible = ref(false);
+
+export function useConfirm() {
+  function confirm(opts: ConfirmOptions): Promise<boolean> {
+    return new Promise((resolve) => {
+      pending.value = { ...opts, resolve };
+      visible.value = true;
+    });
+  }
+
+  function accept(): void {
+    pending.value?.resolve(true);
+    close();
+  }
+
+  function cancel(): void {
+    pending.value?.resolve(false);
+    close();
+  }
+
+  function close(): void {
+    visible.value = false;
+    pending.value = null;
+  }
+
+  return { visible, pending, confirm, accept, cancel };
+}

--- a/frontend/apps/brain/src/composables/useHeartbeat.ts
+++ b/frontend/apps/brain/src/composables/useHeartbeat.ts
@@ -1,0 +1,61 @@
+/**
+ * Session heartbeat composable.
+ *
+ * Port of legacy app.js _checkSession / _startHeartbeat (lines 311-333):
+ *   - Polls GET /auth/status every 5 minutes.
+ *   - Also fires on visibilitychange → visible (tab comes back to foreground).
+ *   - On a non-authed response (has_master_account && !has_session) → hard
+ *     redirect to /login/?next=<path>.
+ *
+ * One singleton instance is shared across calls (useHeartbeat() always returns
+ * the same object, matching the legacy single-instance pattern).
+ */
+
+let _intervalId: ReturnType<typeof setInterval> | null = null;
+let _redirected = false;
+
+async function _checkSession(): Promise<void> {
+  if (_redirected) return;
+  try {
+    const res = await fetch('/auth/status', { credentials: 'same-origin' });
+    if (!res.ok) return;
+    const data = (await res.json()) as {
+      has_master_account: boolean;
+      has_session: boolean;
+    };
+    if (data.has_master_account && !data.has_session) {
+      _redirected = true;
+      stop();
+      window.location.replace(
+        '/login/?next=' +
+          encodeURIComponent(window.location.pathname + window.location.search),
+      );
+    }
+  } catch {
+    // Transient network error — ignore, try again next tick.
+  }
+}
+
+function _onVisibility(): void {
+  if (document.visibilityState === 'visible') {
+    void _checkSession();
+  }
+}
+
+function start(): void {
+  if (_intervalId !== null) return;
+  _intervalId = setInterval(() => void _checkSession(), 5 * 60 * 1000);
+  document.addEventListener('visibilitychange', _onVisibility);
+}
+
+function stop(): void {
+  if (_intervalId !== null) {
+    clearInterval(_intervalId);
+    _intervalId = null;
+  }
+  document.removeEventListener('visibilitychange', _onVisibility);
+}
+
+export function useHeartbeat() {
+  return { start, stop };
+}

--- a/frontend/apps/brain/src/composables/useToast.ts
+++ b/frontend/apps/brain/src/composables/useToast.ts
@@ -1,0 +1,48 @@
+/**
+ * Toast notification composable.
+ *
+ * Port of legacy BrainApp.showToast() (app.js:73-91).
+ * Reactive list consumed by ToastHost.vue.
+ */
+import { ref } from 'vue';
+
+export type ToastType = 'info' | 'success' | 'error' | 'warning';
+
+export interface Toast {
+  id: number;
+  message: string;
+  type: ToastType;
+  action?: string;
+  onAction?: () => void;
+  duration: number;
+}
+
+let _nextId = 0;
+const toasts = ref<Toast[]>([]);
+
+export function useToast() {
+  function show(
+    message: string,
+    type: ToastType = 'info',
+    opts: { action?: string; onAction?: () => void; duration?: number } = {},
+  ): void {
+    const id = ++_nextId;
+    const duration = opts.duration ?? 3200;
+    toasts.value.push({
+      id,
+      message,
+      type,
+      action: opts.action,
+      onAction: opts.onAction,
+      duration,
+    });
+    setTimeout(() => dismiss(id), duration + 300); // +300 for fade-out
+  }
+
+  function dismiss(id: number): void {
+    const idx = toasts.value.findIndex((t) => t.id === id);
+    if (idx !== -1) toasts.value.splice(idx, 1);
+  }
+
+  return { toasts, show, dismiss };
+}

--- a/frontend/apps/brain/src/main.ts
+++ b/frontend/apps/brain/src/main.ts
@@ -1,6 +1,21 @@
+import '@fontsource/inter/300.css';
+import '@fontsource/inter/400.css';
+import '@fontsource/inter/500.css';
+import '@fontsource/inter/600.css';
+import '@chalie/shared/styles/main.scss';
+import './styles/brain.scss';
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import App from './App.vue';
-import '@chalie/shared/styles/main.scss';
+import { router, authGateRedirected } from './router';
 
-createApp(App).use(createPinia()).mount('#app');
+const app = createApp(App).use(createPinia()).use(router);
+
+// Gate the mount behind the auth gate. router.isReady() resolves once the
+// initial navigation — including the async beforeEach guard — has settled.
+// If the gate issued a hard redirect, do not mount so the SPA shell does not
+// flash before the page navigates away.
+// Parity with legacy app.js:351 (`await chalieGateReady; if (!gate.stay) return;`).
+router.isReady().finally(() => {
+  if (!authGateRedirected()) app.mount('#app');
+});

--- a/frontend/apps/brain/src/router.ts
+++ b/frontend/apps/brain/src/router.ts
@@ -1,0 +1,189 @@
+import { createRouter, createWebHistory } from 'vue-router';
+import { AuthError, HttpError } from '@chalie/shared';
+import { system } from './api/system';
+
+// ── Views ────────────────────────────────────────────────────────────────────
+import ProvidersView from './views/ProvidersView.vue';
+import VisionView from './views/VisionView.vue';
+import CognitionView from './views/CognitionView.vue';
+import SchedulerView from './views/SchedulerView.vue';
+import ListsView from './views/ListsView.vue';
+import DocumentsView from './views/DocumentsView.vue';
+import CapabilitiesView from './views/CapabilitiesView.vue';
+import PoliciesView from './views/PoliciesView.vue';
+import SkillsView from './views/SkillsView.vue';
+import McpView from './views/McpView.vue';
+import BrainView from './views/BrainView.vue';
+
+// ── Cognition sub-views ──────────────────────────────────────────────────────
+import MemorySub from './views/cognition/MemorySub.vue';
+import ToolsSub from './views/cognition/ToolsSub.vue';
+import WorldSub from './views/cognition/WorldSub.vue';
+import PersonalitySub from './views/cognition/PersonalitySub.vue';
+import ErrorsSub from './views/cognition/ErrorsSub.vue';
+import UsageSub from './views/cognition/UsageSub.vue';
+import CompactionSub from './views/cognition/CompactionSub.vue';
+
+// ── Scheduler sub-views (filter tabs — routed for deep-link / breadcrumb) ───
+import SchedulerAllSub from './views/scheduler/AllSub.vue';
+import SchedulerPendingSub from './views/scheduler/PendingSub.vue';
+import SchedulerFiredSub from './views/scheduler/FiredSub.vue';
+import SchedulerFailedSub from './views/scheduler/FailedSub.vue';
+import SchedulerCancelledSub from './views/scheduler/CancelledSub.vue';
+
+// ── Documents sub-views ──────────────────────────────────────────────────────
+import DocumentsActiveSub from './views/documents/ActiveSub.vue';
+import DocumentsProcessingSub from './views/documents/ProcessingSub.vue';
+import DocumentsUploadsSub from './views/documents/UploadsSub.vue';
+import DocumentsDeletedSub from './views/documents/DeletedSub.vue';
+
+// ── Policies sub-views ───────────────────────────────────────────────────────
+import PoliciesChatSub from './views/policies/ChatSub.vue';
+import PoliciesBackgroundSub from './views/policies/BackgroundSub.vue';
+import PoliciesExternalSub from './views/policies/ExternalSub.vue';
+
+export const router = createRouter({
+  history: createWebHistory(import.meta.env.BASE_URL),
+  routes: [
+    // Default redirect: match legacy app.js _readHash() which defaults to 'providers'.
+    { path: '/', redirect: '/providers' },
+
+    { path: '/providers', name: 'providers', component: ProvidersView },
+    { path: '/vision', name: 'vision', component: VisionView },
+
+    {
+      path: '/cognition',
+      name: 'cognition',
+      component: CognitionView,
+      redirect: '/cognition/memory',
+      children: [
+        { path: 'memory', name: 'cognition-memory', component: MemorySub },
+        { path: 'tools', name: 'cognition-tools', component: ToolsSub },
+        { path: 'world', name: 'cognition-world', component: WorldSub },
+        { path: 'personality', name: 'cognition-personality', component: PersonalitySub },
+        { path: 'errors', name: 'cognition-errors', component: ErrorsSub },
+        { path: 'usage', name: 'cognition-usage', component: UsageSub },
+        // FIX: legacy SUB_ROUTES.cognition omits 'compaction', silently coercing
+        // #/cognition/compaction to memory. Registered here so the route resolves.
+        { path: 'compaction', name: 'cognition-compaction', component: CompactionSub },
+      ],
+    },
+
+    {
+      path: '/scheduler',
+      name: 'scheduler',
+      component: SchedulerView,
+      redirect: '/scheduler/all',
+      children: [
+        { path: 'all', name: 'scheduler-all', component: SchedulerAllSub },
+        { path: 'pending', name: 'scheduler-pending', component: SchedulerPendingSub },
+        { path: 'fired', name: 'scheduler-fired', component: SchedulerFiredSub },
+        { path: 'failed', name: 'scheduler-failed', component: SchedulerFailedSub },
+        { path: 'cancelled', name: 'scheduler-cancelled', component: SchedulerCancelledSub },
+      ],
+    },
+
+    { path: '/lists', name: 'lists', component: ListsView },
+
+    {
+      path: '/documents',
+      name: 'documents',
+      component: DocumentsView,
+      redirect: '/documents/active',
+      children: [
+        { path: 'active', name: 'documents-active', component: DocumentsActiveSub },
+        { path: 'processing', name: 'documents-processing', component: DocumentsProcessingSub },
+        { path: 'uploads', name: 'documents-uploads', component: DocumentsUploadsSub },
+        { path: 'deleted', name: 'documents-deleted', component: DocumentsDeletedSub },
+      ],
+    },
+
+    { path: '/capabilities', name: 'capabilities', component: CapabilitiesView },
+
+    {
+      path: '/policies',
+      name: 'policies',
+      component: PoliciesView,
+      redirect: '/policies/chat',
+      children: [
+        { path: 'chat', name: 'policies-chat', component: PoliciesChatSub },
+        { path: 'background', name: 'policies-background', component: PoliciesBackgroundSub },
+        { path: 'external', name: 'policies-external', component: PoliciesExternalSub },
+      ],
+    },
+
+    { path: '/skills', name: 'skills', component: SkillsView },
+    { path: '/mcp', name: 'mcp', component: McpView },
+    { path: '/brain', name: 'brain', component: BrainView },
+
+    // Catch-all → providers (matches legacy _readHash() fallback to 'providers').
+    { path: '/:pathMatch(.*)*', redirect: '/providers' },
+  ],
+});
+
+/**
+ * Whether the auth gate issued a hard redirect on the initial navigation.
+ *
+ * main.ts reads this after `router.isReady()` to decide whether to mount the
+ * app at all. Parity with legacy app.js:351 (`await chalieGateReady; if (!gate.stay) return;`).
+ */
+let _gateRedirected = false;
+export function authGateRedirected(): boolean {
+  return _gateRedirected;
+}
+
+function hardRedirect(to: string): false {
+  _gateRedirected = true;
+  window.location.replace(to);
+  return false;
+}
+
+/**
+ * Auth gate — port of frontend/shared/auth-gate.js `brain` page branch.
+ *
+ * Brain rules (from auth-gate.js:65-67):
+ *   !account → hard-redirect /on-boarding/
+ *   !session → hard-redirect /login/?next=<path>
+ *   !providers → providersOnly LOCK (stay in Brain, force Providers panel, no hard redirect)
+ *
+ * Network failure → stay (server guards the real API endpoints anyway).
+ */
+router.beforeEach(async () => {
+  const { useShellStore } = await import('./stores/shell');
+  const shell = useShellStore();
+
+  let status;
+  try {
+    status = await system.authStatus();
+  } catch (err) {
+    if (err instanceof HttpError || err instanceof AuthError) {
+      // Server responded but not ok — treat as all-false → onboarding redirect.
+      return hardRedirect('/on-boarding/');
+    }
+    // Network / server unreachable — stay; guards on real endpoints still apply.
+    return true;
+  }
+
+  const { has_master_account, has_session, has_providers } = status;
+
+  if (!has_master_account) {
+    return hardRedirect('/on-boarding/');
+  }
+  if (!has_session) {
+    return hardRedirect(
+      '/login/?next=' + encodeURIComponent(window.location.pathname + window.location.search),
+    );
+  }
+
+  // Brain-specific: no providers → providersOnly LOCK (NOT a hard redirect).
+  // Stay in the Brain app; force providers panel and prevent navigating away.
+  if (!has_providers) {
+    shell.providersOnly = true;
+    // Force navigation to providers regardless of the requested route.
+    if (router.currentRoute.value.name !== 'providers') {
+      return { name: 'providers' };
+    }
+  }
+
+  return true;
+});

--- a/frontend/apps/brain/src/stores/shell.ts
+++ b/frontend/apps/brain/src/stores/shell.ts
@@ -21,12 +21,6 @@ export const useShellStore = defineStore('brain-shell', {
     /** Whether the mobile sidebar overlay is visible. */
     mobileOpen: false as boolean,
 
-    /** Current panel title for topbar breadcrumb (set by each view on mount). */
-    panelTitle: '' as string,
-
-    /** Current sub-panel label (set by sub-views inside panels). */
-    subTitle: '' as string,
-
     /** Whether the command palette overlay is open. */
     commandPaletteOpen: false as boolean,
   }),

--- a/frontend/apps/brain/src/stores/shell.ts
+++ b/frontend/apps/brain/src/stores/shell.ts
@@ -1,0 +1,55 @@
+import { defineStore } from 'pinia';
+
+/**
+ * Shell-level state for the Brain app.
+ *
+ * Port of the module-scoped state in legacy app.js:
+ *   _providersOnly, _sidebarCollapsed, _mobileOpen, _heartbeatFired.
+ *
+ * Options-style Pinia store (consistent with legacy OO module style).
+ */
+export const useShellStore = defineStore('brain-shell', {
+  state: () => ({
+    /** When true: the app launched with no providers configured. Navigation is
+     *  locked to the Providers panel until a provider is added. No hard redirect —
+     *  the Brain app stays mounted (legacy auth-gate.js:65-67 brain branch). */
+    providersOnly: false as boolean,
+
+    /** Whether the desktop sidebar is in collapsed (icon-only) mode. */
+    sidebarCollapsed: false as boolean,
+
+    /** Whether the mobile sidebar overlay is visible. */
+    mobileOpen: false as boolean,
+
+    /** Current panel title for topbar breadcrumb (set by each view on mount). */
+    panelTitle: '' as string,
+
+    /** Current sub-panel label (set by sub-views inside panels). */
+    subTitle: '' as string,
+  }),
+
+  actions: {
+    /**
+     * Called by the Providers panel after a provider is successfully saved and
+     * confirmed via GET /auth/status → has_providers=true.
+     *
+     * Lifts the navigation lock so the sidebar enables all items.
+     * Port of legacy BrainApp.liftProvidersOnly().
+     */
+    liftProvidersOnly(): void {
+      this.providersOnly = false;
+    },
+
+    toggleSidebar(): void {
+      this.sidebarCollapsed = !this.sidebarCollapsed;
+    },
+
+    openMobileSidebar(): void {
+      this.mobileOpen = true;
+    },
+
+    closeMobileSidebar(): void {
+      this.mobileOpen = false;
+    },
+  },
+});

--- a/frontend/apps/brain/src/stores/shell.ts
+++ b/frontend/apps/brain/src/stores/shell.ts
@@ -26,6 +26,9 @@ export const useShellStore = defineStore('brain-shell', {
 
     /** Current sub-panel label (set by sub-views inside panels). */
     subTitle: '' as string,
+
+    /** Whether the command palette overlay is open. */
+    commandPaletteOpen: false as boolean,
   }),
 
   actions: {
@@ -38,6 +41,18 @@ export const useShellStore = defineStore('brain-shell', {
      */
     liftProvidersOnly(): void {
       this.providersOnly = false;
+    },
+
+    openCommandPalette(): void {
+      this.commandPaletteOpen = true;
+    },
+
+    closeCommandPalette(): void {
+      this.commandPaletteOpen = false;
+    },
+
+    toggleCommandPalette(): void {
+      this.commandPaletteOpen = !this.commandPaletteOpen;
     },
 
     toggleSidebar(): void {

--- a/frontend/apps/brain/src/styles/_compat.scss
+++ b/frontend/apps/brain/src/styles/_compat.scss
@@ -1,0 +1,30 @@
+// ── Compat layer: legacy CSS var aliases → shared token names ──────────────
+//
+// The legacy brain/style.css uses the same var names as the shared design
+// tokens (_tokens.scss), so no aliases are needed. Both files define the same
+// set of CSS custom properties (--bg, --text, --border, --violet, etc.) under
+// [data-theme="dark"] and [data-theme="light"].
+//
+// This file exists as an extension point: if future panels introduce legacy
+// vars not present in _tokens.scss, add the aliases here rather than in the
+// component styles.
+//
+// Verified token parity (source: _tokens.scss vs frontend/shared/theme.css):
+//   --bg, --bg-2, --bg-surface, --bg-surface-2, --bg-input   ✓
+//   --text, --text-primary, --text-secondary, --text-muted    ✓
+//   --text-tertiary, --text-subtle                             ✓
+//   --border, --border-subtle, --border-strong                ✓
+//   --violet, --violet-hover, --magenta, --cyan                ✓
+//   --accent-primary, --accent-secondary, --accent-tertiary   ✓
+//   --success, --error, --warning                              ✓
+//   --ease-out, --shadow-card                                  ✓
+//   --grain-opacity, --grain-blend                             ✓
+//   --orb-1, --orb-2, --orb-3                                  ✓
+//   --scrim-top, --scrim-dock, --scrim-fallback               ✓
+//
+// The only legacy alias present in theme.css but NOT in _tokens.scss:
+//   --bg-dark → var(--bg)   (kept in _tokens.scss as legacy alias)
+//   --bg-card → var(--bg-surface)   (kept in _tokens.scss as legacy alias)
+//   --accent → var(--violet)
+//   --accent-hover → var(--violet-hover)
+// All four already aliased inside _tokens.scss — no additional compat needed.

--- a/frontend/apps/brain/src/styles/brain.scss
+++ b/frontend/apps/brain/src/styles/brain.scss
@@ -1,0 +1,1978 @@
+// ── Brain app styles ──────────────────────────────────────────────
+// Port of frontend/brain/style.css re-expressed as SCSS over shared tokens.
+// All colors use CSS variables from @chalie/shared/styles/_tokens.scss — never
+// hardcode theme-specific rgba values for a single theme.
+// ─────────────────────────────────────────────────────────────────
+
+// ── Layout tokens ─────────────────────────────────────────────────
+:root {
+  --sidebar-w: 248px;
+  --sidebar-w-collapsed: 64px;
+  --topbar-h: 56px;
+  --content-max: 1100px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+// ── Ambient breathing background ──────────────────────────────────
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse 70% 55% at 18% 8%, rgba(138, 92, 255, 0.10), transparent 70%),
+    radial-gradient(ellipse 60% 50% at 90% 100%, rgba(255, 47, 209, 0.06), transparent 70%),
+    radial-gradient(ellipse 80% 60% at 50% -10%, rgba(80, 50, 180, 0.05), transparent 70%);
+  animation: ambient-breathe 20s ease-in-out infinite;
+}
+
+@keyframes ambient-breathe {
+  0%, 100% { transform: scale(1); opacity: 0.85; }
+  50%       { transform: scale(1.06); opacity: 1; }
+}
+
+[data-theme='light'] body::before {
+  background:
+    radial-gradient(ellipse 70% 55% at 18% 8%, rgba(138, 92, 255, 0.10), transparent 70%),
+    radial-gradient(ellipse 60% 50% at 90% 100%, rgba(255, 47, 209, 0.05), transparent 70%);
+}
+
+// Grain overlay
+.grain {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  opacity: var(--grain-opacity, 0.04);
+  mix-blend-mode: var(--grain-blend, overlay);
+  // stylelint-disable-next-line
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='0.5'/></svg>");
+}
+
+// ── App grid ──────────────────────────────────────────────────────
+.app-shell {
+  display: grid;
+  grid-template-columns: var(--sidebar-w) 1fr;
+  grid-template-rows: var(--topbar-h) 1fr;
+  grid-template-areas: 'sidebar topbar' 'sidebar main';
+  min-height: 100vh;
+  position: relative;
+  z-index: 2;
+  opacity: 0;
+  transition: opacity 300ms ease;
+
+  &[data-collapsed='true'] {
+    grid-template-columns: var(--sidebar-w-collapsed) 1fr;
+  }
+}
+
+// Mobile overlay scrim — structural rules moved after .sidebar base styles
+.scrim { display: none; }
+
+// ── Topbar ────────────────────────────────────────────────────────
+.topbar {
+  grid-area: topbar;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 20px;
+  background: rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 50;
+
+  // Neon hairline under topbar
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: -1px;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--violet), var(--magenta), transparent);
+    opacity: 0.25;
+  }
+}
+
+[data-theme='light'] .topbar { background: rgba(255, 255, 255, 0.6); }
+
+.crumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  white-space: nowrap;
+
+  .sep { opacity: 0.4; }
+  .now { color: var(--text-primary); font-weight: 500; }
+}
+
+.topbar-center {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.topbar-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 12px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  cursor: pointer;
+  transition: border-color 150ms var(--ease-out), box-shadow 150ms;
+
+  &:hover {
+    border-color: rgba(138, 92, 255, 0.3);
+    box-shadow: 0 0 0 2px rgba(138, 92, 255, 0.06);
+  }
+}
+
+.topbar-search-text { flex: 1; }
+
+.topbar-search kbd {
+  font-family: 'Inter', monospace;
+  font-size: 10.5px;
+  padding: 1px 6px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-tertiary);
+  background: var(--bg-surface);
+}
+
+.topbar-actions { display: flex; align-items: center; gap: 8px; }
+
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: 150ms var(--ease-out);
+  position: relative;
+
+  &:hover {
+    color: var(--text-primary);
+    background: var(--bg-surface);
+    border-color: var(--border);
+    box-shadow: 0 0 8px rgba(138, 92, 255, 0.10);
+  }
+
+  .dot {
+    position: absolute;
+    top: 7px;
+    right: 7px;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--magenta);
+    box-shadow: 0 0 6px rgba(255, 47, 209, 0.5);
+  }
+}
+
+.hamburger { display: none; }
+.desktop-collapser { display: inline-flex; }
+
+@media (max-width: 900px) {
+  .hamburger { display: inline-flex; }
+  .desktop-collapser { display: none; }
+}
+
+// ── Sidebar ───────────────────────────────────────────────────────
+.sidebar {
+  grid-area: sidebar;
+  display: flex;
+  flex-direction: column;
+  background:
+    linear-gradient(180deg, rgba(138, 92, 255, 0.03) 0%, rgba(255, 47, 209, 0.015) 100%),
+    rgba(255, 255, 255, 0.02);
+  border-right: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow: hidden;
+  z-index: 60;
+  transition: width 220ms var(--ease-out);
+}
+
+[data-theme='light'] .sidebar {
+  background:
+    linear-gradient(180deg, rgba(138, 92, 255, 0.04) 0%, rgba(255, 47, 209, 0.02) 100%),
+    rgba(255, 255, 255, 0.5);
+}
+
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+  min-height: var(--topbar-h);
+  text-decoration: none;
+  color: inherit;
+
+  img { width: 28px; height: 28px; border-radius: 6px; }
+}
+
+.sidebar-brand-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  min-width: 0;
+}
+
+[data-collapsed='true'] .sidebar-brand-text { display: none; }
+
+.wordmark {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+}
+
+.wordmark-sub {
+  font-size: 11px;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.sidebar-scroll { flex: 1; overflow-y: auto; padding: 8px 0; }
+
+.sidebar-footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px;
+  border-top: 1px solid var(--border);
+}
+
+// Nav groups
+.nav-group { margin-bottom: 4px; }
+
+.nav-group-title {
+  padding: 12px 16px 4px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-tertiary);
+}
+
+[data-collapsed='true'] .nav-group-title { display: none; }
+
+// Nav items
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: calc(100% - 12px);
+  margin: 1px 6px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: 150ms var(--ease-out);
+  position: relative;
+  text-align: left;
+
+  &:hover { color: var(--text-primary); background: var(--bg-surface); }
+
+  // Active state with gradient bleed + glowing rail
+  &.active {
+    color: var(--text-primary);
+    background: linear-gradient(90deg, rgba(138, 92, 255, 0.12) 0%, transparent 100%);
+    border-color: rgba(138, 92, 255, 0.08);
+
+    &::before {
+      content: '';
+      position: absolute;
+      left: -6px;
+      top: 6px;
+      bottom: 6px;
+      width: 3px;
+      border-radius: 2px;
+      background: linear-gradient(180deg, var(--violet), var(--magenta));
+      box-shadow: 0 0 8px rgba(138, 92, 255, 0.4);
+    }
+  }
+
+  &[data-expanded='true'] .nav-chev { transform: rotate(90deg); }
+}
+
+.nav-icon { display: inline-flex; width: 18px; height: 18px; flex-shrink: 0; }
+
+.nav-label {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+[data-collapsed='true'] .nav-label { display: none; }
+
+.nav-chev { display: inline-flex; transition: transform 200ms; }
+
+[data-collapsed='true'] .nav-chev { display: none; }
+
+.nav-badge {
+  font-size: 11px;
+  padding: 1px 7px;
+  border-radius: 10px;
+  background: rgba(138, 92, 255, 0.12);
+  color: var(--violet);
+}
+
+[data-collapsed='true'] .nav-badge { display: none; }
+
+// Sub-list with slide animation
+.nav-sublist {
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 250ms var(--ease-out);
+
+  &[data-open='true'] { max-height: 300px; }
+
+  > div { padding: 2px 0 2px 38px; }
+}
+
+[data-collapsed='true'] .nav-sublist { display: none; }
+
+.nav-sub {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 5px 10px;
+  margin: 1px 0;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12.5px;
+  cursor: pointer;
+  transition: 150ms;
+  text-align: left;
+
+  &:hover { color: var(--text-primary); background: var(--bg-surface); }
+  &.active { color: var(--violet); font-weight: 500; }
+  .count { font-size: 11px; color: var(--text-tertiary); }
+}
+
+// ── Providers-only lock ───────────────────────────────────────────
+[data-providers-only='true'] {
+  .nav-item:not([data-nav='providers']) {
+    pointer-events: none;
+    opacity: 0.3;
+    user-select: none;
+  }
+
+  .nav-sublist { display: none; }
+
+  .topbar-search { pointer-events: none; opacity: 0.3; }
+}
+
+.sidebar-lock-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 4px 12px 12px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  font-size: 12px;
+  line-height: 1.45;
+  background: rgba(var(--bs-warning-rgb), 0.10);
+  color: var(--warning-banner-text);
+  border: 1px solid rgba(var(--bs-warning-rgb), 0.20);
+
+  .sidebar-lock-icon { flex-shrink: 0; margin-top: 1px; }
+}
+
+// ── Mobile sidebar overlay (must come after .sidebar base styles) ──
+@media (max-width: 900px) {
+  html,
+  body { overflow-x: hidden; }
+
+  .app-shell {
+    grid-template-columns: 1fr;
+    grid-template-areas: 'topbar' 'main';
+  }
+
+  .sidebar {
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: var(--sidebar-w);
+    height: 100vh;
+    transform: translateX(-100%);
+    transition: transform 250ms var(--ease-out);
+    z-index: 100;
+    grid-area: unset;
+    background-color: var(--bg) !important; // stylelint-disable-line declaration-no-important
+    background-image: none !important; // stylelint-disable-line declaration-no-important
+    border-right: none;
+  }
+
+  .app-shell[data-mobile-open='true'] .sidebar { transform: translateX(0); }
+
+  .scrim {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 90;
+    background: rgba(0, 0, 0, 0.5);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 250ms;
+  }
+
+  .app-shell[data-mobile-open='true'] .scrim { opacity: 1; pointer-events: auto; }
+}
+
+// ── Main content area ─────────────────────────────────────────────
+.main { grid-area: main; padding: 24px; overflow-y: auto; }
+.main-inner { max-width: var(--content-max); margin: 0 auto; }
+
+// ── Panel headers ─────────────────────────────────────────────────
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: -1px;
+    left: 0;
+    width: 120px;
+    height: 1px;
+    background: linear-gradient(90deg, var(--violet), transparent);
+    opacity: 0.5;
+  }
+
+  h2 { margin: 0; font-size: 20px; font-weight: 600; letter-spacing: -0.01em; }
+}
+
+.panel-header-actions { display: flex; align-items: center; gap: 10px; }
+.panel-desc { color: var(--text-secondary); font-size: 13px; margin: 0 0 20px; line-height: 1.5; }
+
+// ── Section head with glowing dot ─────────────────────────────────
+.section-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
+  margin: 20px 0 10px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+  position: relative;
+
+  &::before {
+    content: '';
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--violet);
+    box-shadow: 0 0 6px rgba(138, 92, 255, 0.5);
+  }
+}
+
+// ── Buttons ───────────────────────────────────────────────────────
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: 150ms var(--ease-out);
+  font-family: inherit;
+  line-height: 1;
+}
+
+.btn-sm { padding: 5px 10px; font-size: 12px; border-radius: 6px; }
+
+.btn-xs { padding: 3px 8px; font-size: 11px; border-radius: 5px; }
+
+.btn-primary {
+  background: var(--violet);
+  color: #fff;
+  border-color: var(--violet);
+  box-shadow: 0 0 12px rgba(138, 92, 255, 0.25);
+
+  &:hover { background: var(--violet-hover); box-shadow: 0 0 18px rgba(138, 92, 255, 0.35); }
+}
+
+.btn-secondary {
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  border-color: var(--border);
+
+  &:hover { border-color: rgba(138, 92, 255, 0.3); background: var(--bg-surface-2); }
+}
+
+.btn-danger {
+  background: transparent;
+  color: var(--error);
+  border-color: rgba(251, 113, 133, 0.3);
+
+  &:hover { background: rgba(251, 113, 133, 0.08); border-color: rgba(251, 113, 133, 0.5); }
+}
+
+// ── Filter tabs ───────────────────────────────────────────────────
+.filter-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 16px;
+  padding: 3px;
+  background: var(--bg-surface);
+  border-radius: 10px;
+  border: 1px solid var(--border);
+}
+
+.filter-tab {
+  padding: 6px 14px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: 150ms;
+
+  &:hover { color: var(--text-primary); }
+
+  &.active {
+    background: var(--bg-surface-2);
+    color: var(--violet);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+  }
+}
+
+[data-theme='light'] .filter-tab.active { background: #fff; }
+
+// Group tabs (documents)
+.doc-group-tabs { display: flex; gap: 8px; margin-bottom: 16px; }
+
+.group-tab {
+  padding: 4px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  transition: 150ms;
+
+  &:hover { border-color: rgba(138, 92, 255, 0.3); }
+
+  &.active {
+    background: rgba(138, 92, 255, 0.10);
+    color: var(--violet);
+    border-color: rgba(138, 92, 255, 0.3);
+  }
+}
+
+// ── Cards / surfaces ──────────────────────────────────────────────
+.provider-card,
+.schedule-item,
+.cap-card,
+.task-card,
+.list-card,
+.error-item,
+.blocked-item {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  border-radius: 10px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  margin-bottom: 8px;
+  transition: border-color 200ms, box-shadow 200ms;
+  position: relative;
+}
+
+.provider-card:hover,
+.schedule-item:hover,
+.cap-card:hover,
+.list-card:hover {
+  border-color: rgba(138, 92, 255, 0.2);
+  box-shadow: 0 0 0 1px rgba(138, 92, 255, 0.06);
+}
+
+.provider-card.selected {
+  border-color: rgba(138, 92, 255, 0.35);
+  background: rgba(138, 92, 255, 0.04);
+}
+
+// ── Provider card specifics ───────────────────────────────────────
+.providers-list { display: flex; flex-direction: column; gap: 4px; }
+
+.provider-radio {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  flex-shrink: 0;
+
+  input[type='radio'] { display: none; }
+
+  input:checked + .radio-dot {
+    border-color: var(--violet);
+    background: var(--violet);
+    box-shadow: 0 0 8px rgba(138, 92, 255, 0.4);
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 3px;
+      left: 3px;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: #fff;
+    }
+  }
+}
+
+.radio-dot {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid var(--border);
+  background: transparent;
+  position: relative;
+  transition: 200ms;
+}
+
+.provider-info { flex: 1; min-width: 0; }
+
+.provider-name {
+  font-weight: 500;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.provider-meta {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.provider-actions { display: flex; gap: 6px; flex-shrink: 0; }
+.provider-warn { color: var(--warning); font-size: 14px; }
+.provider-card.disabled { opacity: 0.55; }
+
+// ── Badges ────────────────────────────────────────────────────────
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+.badge-ollama,
+.badge-violet   { background: rgba(138, 92, 255, 0.14); color: var(--violet); }
+.badge-anthropic,
+.badge-magenta  { background: rgba(255, 47, 209, 0.12); color: var(--magenta); }
+.badge-openai,
+.badge-cyan     { background: rgba(0, 240, 255, 0.10); color: var(--cyan); }
+.badge-gemini   { background: rgba(52, 211, 153, 0.12); color: var(--success); }
+.badge-openai_compatible { background: rgba(251, 191, 36, 0.12); color: var(--warning); }
+.badge-success  { background: rgba(52, 211, 153, 0.12); color: var(--success); }
+.badge-warning  { background: rgba(251, 191, 36, 0.12); color: var(--warning); }
+.badge-danger   { background: rgba(251, 113, 133, 0.12); color: var(--error); }
+.badge-muted    { background: var(--bg-surface-2); color: var(--text-secondary); }
+.badge-online   { background: rgba(52, 211, 153, 0.12); color: var(--success); }
+.badge-offline  { background: rgba(251, 113, 133, 0.12); color: var(--error); }
+.badge-unknown  { background: var(--bg-surface-2); color: var(--text-secondary); }
+.badge-enabled  { background: rgba(52, 211, 153, 0.10); color: var(--success); }
+.badge-disabled { background: var(--bg-surface-2); color: var(--text-secondary); }
+
+// ── Inputs ────────────────────────────────────────────────────────
+input[type='text'],
+input[type='password'],
+input[type='email'],
+input[type='number'],
+input[type='datetime-local'],
+input[type='time'],
+textarea,
+select {
+  width: 100%;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 13px;
+  transition: border-color 150ms, box-shadow 150ms;
+  outline: none;
+
+  &:focus {
+    border-color: rgba(138, 92, 255, 0.45);
+    box-shadow: 0 0 0 3px rgba(138, 92, 255, 0.12);
+  }
+
+  &::placeholder { color: var(--text-tertiary); }
+}
+
+select {
+  appearance: none;
+  -webkit-appearance: none;
+  // stylelint-disable-next-line
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%239ca3af' stroke-width='2'><polyline points='6 9 12 15 18 9'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 30px;
+  cursor: pointer;
+
+  option { background: var(--bg-2); color: var(--text); }
+}
+
+input[type='checkbox'] {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  flex-shrink: 0;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  position: relative;
+  transition: 150ms;
+
+  &:checked {
+    background: var(--violet);
+    border-color: var(--violet);
+    box-shadow: 0 0 6px rgba(138, 92, 255, 0.3);
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 2px;
+      left: 5px;
+      width: 4px;
+      height: 8px;
+      border: solid #fff;
+      border-width: 0 2px 2px 0;
+      transform: rotate(45deg);
+    }
+  }
+}
+
+.search-input { max-width: 260px; }
+
+// ── Tables ────────────────────────────────────────────────────────
+.records-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+
+  th {
+    text-align: left;
+    padding: 8px 12px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-tertiary);
+    border-bottom: 1px solid var(--border);
+  }
+
+  td {
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-secondary);
+    vertical-align: top;
+  }
+
+  tr:hover td { color: var(--text-primary); }
+
+  tbody tr:hover {
+    background: rgba(138, 92, 255, 0.03);
+    box-shadow: inset 2px 0 0 var(--violet);
+  }
+}
+
+.key-cell { color: var(--text-primary); font-weight: 500; }
+.val-cell { max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.row-actions { white-space: nowrap; }
+
+.records-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.records-footer { display: flex; justify-content: center; padding: 12px 0; }
+
+// ── Stat cards ────────────────────────────────────────────────────
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.stat-card {
+  padding: 16px;
+  border-radius: 10px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  position: relative;
+  overflow: hidden;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: linear-gradient(90deg, var(--violet), var(--magenta));
+    opacity: 0.5;
+  }
+}
+
+.stat-value {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, var(--violet), var(--magenta));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.stat-label { font-size: 12px; color: var(--text-secondary); margin-top: 2px; }
+.stat-sub { font-size: 11px; color: var(--text-tertiary); margin-top: 4px; }
+
+// ── Chart ─────────────────────────────────────────────────────────
+.chart-wrap { margin: 12px 0; overflow-x: auto; }
+.usage-chart { width: 100%; height: auto; }
+.bar-local { fill: var(--violet); opacity: 0.7; }
+.bar-cloud { fill: var(--magenta); opacity: 0.5; }
+.bar-label { fill: var(--text-tertiary); font-size: 10px; text-anchor: middle; }
+
+.chart-legend {
+  display: flex;
+  gap: 16px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 8px;
+}
+
+.legend-local::before {
+  content: '';
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  background: var(--violet);
+  margin-right: 4px;
+  vertical-align: middle;
+}
+
+.legend-cloud::before {
+  content: '';
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  background: var(--magenta);
+  margin-right: 4px;
+  vertical-align: middle;
+}
+
+// ── Usage table ───────────────────────────────────────────────────
+.usage-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 16px;
+  font-size: 13px;
+
+  th {
+    text-align: left;
+    padding: 8px 12px;
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-secondary);
+    border-bottom: 1px solid var(--border);
+
+    &:not(:first-child) { text-align: right; }
+  }
+
+  td {
+    padding: 6px 12px;
+    border-bottom: 1px solid var(--border-subtle, var(--border));
+    color: var(--text-primary);
+
+    &.num { text-align: right; font-variant-numeric: tabular-nums; }
+  }
+
+  tbody tr:hover { background: var(--bg-surface-2); }
+}
+
+// ── Segmented controls (policies) ─────────────────────────────────
+.segmented {
+  display: flex;
+  gap: 2px;
+  padding: 2px;
+  background: var(--bg-surface);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+
+.seg-btn {
+  padding: 4px 12px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: 150ms;
+
+  &:hover { color: var(--text-primary); }
+
+  &.active {
+    background: var(--bg-surface-2);
+    color: var(--text-primary);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+
+    &[data-val='allow'] { color: var(--success); }
+    &[data-val='deny']  { color: var(--error); }
+    &[data-val='ask']   { color: var(--violet); }
+  }
+}
+
+.policy-bulk {
+  .seg-btn[data-bulk='allow'] { color: var(--success); }
+  .seg-btn[data-bulk='ask']   { color: var(--violet); }
+  .seg-btn[data-bulk='deny']  { color: var(--error); }
+  .seg-btn:hover { background: var(--bg-surface-2); }
+}
+
+// ── Status dots ───────────────────────────────────────────────────
+.status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-tertiary);
+
+  &.active {
+    background: var(--success);
+    box-shadow: 0 0 6px rgba(52, 211, 153, 0.5);
+    animation: pulse-dot 2s ease-in-out infinite;
+  }
+}
+
+@keyframes pulse-dot {
+  0%, 100% { box-shadow: 0 0 4px rgba(52, 211, 153, 0.3); }
+  50%       { box-shadow: 0 0 10px rgba(52, 211, 153, 0.6); }
+}
+
+// ── Progress bars ─────────────────────────────────────────────────
+.progress-bar {
+  height: 3px;
+  background: var(--bg-surface-2);
+  border-radius: 2px;
+  overflow: hidden;
+  margin: 8px 0;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: 2px;
+  background: linear-gradient(90deg, var(--violet), var(--magenta));
+  transition: width 300ms var(--ease-out);
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.3) 50%, transparent 100%);
+    animation: shimmer 2s infinite;
+  }
+}
+
+@keyframes shimmer {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+
+// ── Toggle switch ─────────────────────────────────────────────────
+.switch {
+  display: inline-flex;
+  cursor: pointer;
+
+  input { display: none; }
+
+  input:checked + .switch-track {
+    background: var(--violet);
+    border-color: var(--violet);
+    box-shadow: 0 0 10px rgba(138, 92, 255, 0.3);
+
+    &::after { transform: translateX(18px); background: #fff; }
+  }
+}
+
+.switch-track {
+  width: 40px;
+  height: 22px;
+  border-radius: 11px;
+  background: var(--bg-surface-2);
+  border: 1px solid var(--border);
+  position: relative;
+  transition: 200ms;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--text-secondary);
+    transition: 200ms;
+  }
+}
+
+// ── Toasts ────────────────────────────────────────────────────────
+.toast-host {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.toast {
+  padding: 10px 16px;
+  border-radius: 10px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  color: var(--text-primary);
+  font-size: 13px;
+  box-shadow: var(--shadow-card);
+  pointer-events: auto;
+  animation: toast-in 200ms var(--ease-out);
+  transition: opacity 300ms;
+}
+
+.toast-success { border-color: rgba(52, 211, 153, 0.3); }
+.toast-error   { border-color: rgba(251, 113, 133, 0.3); }
+
+.toast-action {
+  margin-left: 12px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--violet);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+@keyframes toast-in {
+  from { transform: translateY(10px); opacity: 0; }
+  to   { transform: translateY(0); opacity: 1; }
+}
+
+// ── Modals ────────────────────────────────────────────────────────
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  animation: fade-in 150ms;
+}
+
+.modal {
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  width: min(560px, 92vw);
+  max-height: 85vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+  padding: 20px 24px;
+  position: relative;
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: -1px;
+    border-radius: 15px;
+    background: linear-gradient(135deg, rgba(138, 92, 255, 0.2), rgba(255, 47, 209, 0.1));
+    z-index: -1;
+  }
+}
+
+.modal-sm { width: min(400px, 90vw); overflow: visible; }
+.modal-lg { width: min(720px, 94vw); }
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+
+  h3 { margin: 0; font-size: 17px; font-weight: 600; }
+}
+
+.modal-desc { color: var(--text-secondary); font-size: 13px; margin: 0 0 16px; }
+.modal-body { margin-bottom: 16px; }
+.modal-actions { display: flex; gap: 8px; justify-content: flex-end; }
+
+.btn-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: 150ms;
+
+  &:hover { background: var(--bg-surface); color: var(--text-primary); }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.form-group { margin-bottom: 14px; }
+
+.form-group label {
+  display: block;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+
+.form-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 16px; }
+.form-hint { font-size: 11px; color: var(--text-tertiary); margin-top: 2px; }
+
+// Tab selector (used for auth method toggle)
+.tab-select {
+  display: flex;
+  gap: 2px;
+  padding: 2px;
+  background: var(--bg-surface);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+
+.tab-btn {
+  flex: 1;
+  padding: 7px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: 150ms;
+
+  &:hover { color: var(--text-primary); background: var(--bg-surface-2); }
+
+  &.active {
+    color: var(--text-primary);
+    background: var(--bg-card);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+  }
+}
+
+// Input group with prefix / suffix
+.input-group {
+  display: flex;
+  align-items: stretch;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg-input);
+  overflow: hidden;
+
+  input {
+    flex: 1;
+    border: none;
+    background: transparent;
+    padding: 8px 12px;
+    color: var(--text);
+    font-size: 13px;
+    outline: none;
+    min-width: 0;
+
+    &.monospace { font-family: 'Inter', monospace; font-size: 12px; }
+  }
+}
+
+.input-prefix {
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  background: var(--bg-surface);
+  border-right: 1px solid var(--border);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.input-suffix-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12px;
+  border: none;
+  border-left: 1px solid var(--border);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: 150ms;
+
+  &:hover { background: rgba(138, 92, 255, 0.1); color: var(--violet); }
+}
+
+// ── Inline form pages (provider/scheduler/capability setup) ───────
+.provider-form-page { max-width: 560px; }
+
+.form-page-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+
+  h3 { margin: 0; font-size: 18px; font-weight: 600; }
+  .back-btn svg { transform: rotate(90deg); }
+}
+
+.switch-label { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text-secondary); cursor: pointer; }
+
+// ── Provider setup wizard ─────────────────────────────────────────
+.provider-wizard { width: 100%; }
+.wizard-hint { font-size: 13px; color: var(--text-secondary); margin: 0 0 18px; line-height: 1.5; }
+
+.provider-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.provider-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 14px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  cursor: pointer;
+  text-align: left;
+  color: var(--text-primary);
+  transition: 150ms;
+
+  &:hover {
+    border-color: rgba(138, 92, 255, 0.35);
+    background: var(--bg-surface-2);
+    transform: translateY(-1px);
+  }
+}
+
+.provider-tile-avatar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  background: rgba(138, 92, 255, 0.14);
+  color: var(--violet);
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.provider-tile-name { font-size: 13px; font-weight: 600; line-height: 1.2; }
+.provider-tile-platform { font-size: 11px; color: var(--text-tertiary); }
+
+// Progressive reveal: each step is hidden until its prerequisite is met.
+.wizard-form { max-width: 460px; }
+.wizard-step[hidden] { display: none; }
+
+.model-status {
+  font-size: 11px;
+  display: block;
+  margin-top: 2px;
+
+  &.loading { color: var(--text-secondary); }
+  &.ok  { color: var(--success); }
+  &.err { color: var(--error); }
+}
+
+// ── Command Palette ───────────────────────────────────────────────
+.cp-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 15vh;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  animation: fade-in 100ms;
+
+  &.hidden { display: none; }
+}
+
+.cp {
+  width: min(540px, 90vw);
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+
+.cp-input {
+  width: 100%;
+  padding: 14px 18px;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  font-size: 15px;
+  outline: none;
+  font-family: inherit;
+
+  &::placeholder { color: var(--text-tertiary); }
+}
+
+.cp-results { max-height: 50vh; overflow-y: auto; }
+
+.cp-section {
+  padding: 10px 18px 4px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+}
+
+.cp-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 18px;
+  cursor: pointer;
+  transition: 80ms;
+  font-size: 13px;
+  color: var(--text-secondary);
+
+  &:hover,
+  &.selected {
+    background: rgba(138, 92, 255, 0.08);
+    color: var(--text-primary);
+  }
+}
+
+.cp-icon { display: inline-flex; width: 18px; flex-shrink: 0; color: var(--text-tertiary); }
+.cp-hint { margin-left: auto; font-size: 12px; color: var(--text-tertiary); }
+.cp-empty { padding: 32px 22px; text-align: center; color: var(--text-secondary); font-size: 13px; }
+
+.cp-footer {
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 18px;
+  border-top: 1px solid var(--border);
+  font-size: 11px;
+  color: var(--text-tertiary);
+
+  kbd { font-size: 10px; padding: 1px 4px; border: 1px solid var(--border); border-radius: 3px; }
+}
+
+// ── Personality sliders ───────────────────────────────────────────
+.personality-grid { display: flex; flex-direction: column; gap: 16px; margin-bottom: 20px; }
+
+.personality-row { display: flex; align-items: center; gap: 12px; }
+
+.pole { font-size: 12px; color: var(--text-secondary); width: 90px; }
+.pole-left  { text-align: right; }
+.pole-right { text-align: left; }
+
+.personality-track { flex: 1; }
+
+.personality-label {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  margin-bottom: 4px;
+}
+
+.personality-range {
+  width: 100%;
+  height: 4px;
+  -webkit-appearance: none;
+  appearance: none;
+  background: var(--bg-surface-2);
+  border-radius: 2px;
+  outline: none;
+
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--violet);
+    border: 2px solid var(--bg-2);
+    box-shadow: 0 0 6px rgba(138, 92, 255, 0.4);
+    cursor: pointer;
+  }
+}
+
+.personality-actions { display: flex; justify-content: flex-end; }
+
+// ── Capabilities grid ─────────────────────────────────────────────
+.caps-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 12px; }
+
+.cap-card { flex-direction: column; align-items: flex-start; gap: 8px; padding: 16px; }
+
+.cap-header { display: flex; align-items: center; justify-content: space-between; width: 100%; }
+.cap-name { font-weight: 500; font-size: 14px; }
+.cap-meta { font-size: 12px; color: var(--text-secondary); }
+.cap-version { font-size: 11px; color: var(--text-tertiary); }
+.cap-actions { margin-top: 8px; }
+
+// ── Policies ──────────────────────────────────────────────────────
+.policies-grid { display: flex; flex-direction: column; gap: 8px; }
+.policy-category { margin-bottom: 12px; }
+
+.policy-rule {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 0;
+}
+
+.policy-label { font-size: 13px; color: var(--text-secondary); }
+
+.blocked-section { margin-top: 20px; }
+
+.blocked-toggle {
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 8px 0;
+
+  &:hover { color: var(--text-primary); }
+}
+
+.blocked-list { margin-top: 8px; }
+.blocked-item { gap: 10px; padding: 10px; font-size: 12px; }
+.blocked-time { margin-left: auto; color: var(--text-tertiary); font-size: 11px; }
+
+// ── MCP ───────────────────────────────────────────────────────────
+.mcp-settings { display: flex; flex-direction: column; gap: 16px; max-width: 600px; }
+.mcp-row { display: flex; align-items: center; justify-content: space-between; padding: 10px 0; }
+.mcp-label { font-size: 13px; font-weight: 500; }
+.mcp-token-section { margin-top: 8px; }
+.mcp-token-section h4 { font-size: 14px; font-weight: 600; margin: 0 0 4px; }
+.mcp-hint { font-size: 12px; color: var(--text-secondary); margin: 0 0 10px; }
+
+// MCP panel sections (Inbound / Outbound)
+.mcp-section-title {
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+  margin: 0 0 10px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+
+// Outbound server cards
+.mcp-out-card {
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+  margin-bottom: 10px;
+}
+
+.mcp-out-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.mcp-out-name { font-size: 13px; font-weight: 600; color: var(--text-primary); }
+.mcp-out-host { font-size: 12px; color: var(--text-secondary); }
+.mcp-out-badges { display: flex; gap: 6px; flex-shrink: 0; }
+.mcp-out-card-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+.mcp-out-card-editing { padding: 16px; }
+
+// Outbound add-form
+.mcp-out-add-form {
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+  margin-top: 8px;
+}
+
+.mcp-out-add-title { font-size: 13px; font-weight: 600; margin: 0 0 12px; }
+
+.mcp-out-form-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 0;
+  margin-bottom: 10px;
+}
+
+.form-input {
+  width: 100%;
+  padding: 7px 10px;
+  border-radius: 6px;
+  font-size: 13px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  color: var(--text);
+  box-sizing: border-box;
+
+  &:focus { outline: none; border-color: var(--violet); }
+}
+
+// Headers key-value rows
+.mcp-headers-list { display: flex; flex-direction: column; gap: 6px; margin-bottom: 6px; }
+
+.mcp-header-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+
+  .form-input { flex: 1; }
+}
+
+.mcp-header-sep { color: var(--text-secondary); font-size: 13px; }
+.mcp-header-remove { flex-shrink: 0; }
+
+// ── Lists ─────────────────────────────────────────────────────────
+.list-card { flex-direction: column; align-items: stretch; gap: 0; padding: 0; overflow: hidden; }
+
+.list-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  cursor: pointer;
+}
+
+.list-card-title { display: flex; align-items: center; gap: 8px; font-weight: 500; font-size: 14px; }
+.list-card-actions { display: flex; gap: 6px; }
+.list-chev { display: inline-flex; transition: transform 200ms; }
+.list-count { font-size: 11px; color: var(--text-tertiary); padding: 1px 6px; background: var(--bg-surface-2); border-radius: 8px; }
+
+.list-items { padding: 0 16px 12px; }
+
+.list-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 0;
+  font-size: 13px;
+  color: var(--text-secondary);
+  cursor: pointer;
+
+  input[type='checkbox'] { accent-color: var(--violet); }
+  .done { text-decoration: line-through; opacity: 0.5; }
+}
+
+.list-add-row { margin-top: 6px; }
+.list-add-input { font-size: 12px; padding: 6px 10px; }
+
+// ── Schedule items ────────────────────────────────────────────────
+.schedule-list { display: flex; flex-direction: column; gap: 4px; }
+.schedule-main { flex: 1; min-width: 0; }
+.schedule-message { font-size: 14px; font-weight: 500; margin-bottom: 4px; }
+
+.schedule-meta {
+  font-size: 12px;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.schedule-actions { display: flex; gap: 6px; flex-shrink: 0; }
+
+// ── Task cards (working on) ───────────────────────────────────────
+.task-cards { display: flex; flex-direction: column; gap: 8px; }
+.task-card { flex-direction: column; align-items: flex-start; gap: 6px; padding: 14px 16px; }
+.task-title { font-weight: 500; font-size: 14px; }
+.task-meta { font-size: 12px; color: var(--text-secondary); }
+
+// ── World state ───────────────────────────────────────────────────
+.world-state-grid { display: flex; flex-direction: column; gap: 20px; }
+.world-section h4 { font-size: 14px; font-weight: 600; margin: 0 0 8px; color: var(--text-primary); }
+.world-sees-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+.world-sees-header h4 { margin: 0; }
+.world-formatted { font-size: 13px; line-height: 1.7; }
+.world-formatted h3 { font-size: 14px; font-weight: 600; margin: 12px 0 6px; color: var(--violet); }
+.world-formatted h3:first-child { margin-top: 0; }
+.world-formatted ul { list-style: none; padding: 0; margin: 4px 0 12px; }
+.world-formatted li { padding: 4px 0; border-bottom: 1px solid var(--border); font-size: 12px; }
+.world-formatted li:last-child { border-bottom: none; }
+.world-formatted strong { color: var(--text-primary); font-weight: 600; }
+
+.world-tag {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  background: rgba(138, 92, 255, 0.12);
+  color: var(--violet);
+  vertical-align: middle;
+}
+
+// ── Code block ────────────────────────────────────────────────────
+.code-block {
+  padding: 16px;
+  border-radius: 10px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  overflow-x: auto;
+  position: relative;
+
+  pre { margin: 0; }
+
+  code {
+    font-family: 'Inter', monospace;
+    font-size: 12px;
+    color: var(--text-primary);
+    line-height: 1.6;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: repeating-linear-gradient(
+      0deg,
+      transparent,
+      transparent 2px,
+      rgba(138, 92, 255, 0.01) 2px,
+      rgba(138, 92, 255, 0.01) 4px
+    );
+  }
+}
+
+// ── Error list ────────────────────────────────────────────────────
+.error-list { display: flex; flex-direction: column; gap: 4px; }
+.error-item { padding: 10px 14px; gap: 10px; }
+.error-time { font-size: 11px; color: var(--text-tertiary); white-space: nowrap; flex-shrink: 0; font-family: 'Inter', monospace; }
+.error-msg { font-size: 13px; color: var(--text-secondary); }
+
+// ── Watched folders ───────────────────────────────────────────────
+.watched-folders-section { margin-bottom: 20px; }
+.watched-folders-list { display: flex; flex-direction: column; gap: 4px; }
+
+.watched-folder-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.wf-icon { color: var(--text-tertiary); flex-shrink: 0; }
+.wf-label { font-weight: 500; color: var(--text-primary); }
+.wf-path { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.wf-meta { color: var(--text-tertiary); white-space: nowrap; }
+.wf-status { flex-shrink: 0; }
+
+// ── Doc preview ───────────────────────────────────────────────────
+.doc-content {
+  white-space: pre-wrap;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text-primary);
+  padding: 16px;
+  border-radius: 10px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+}
+
+.doc-meta-row { display: flex; align-items: center; gap: 8px; margin-bottom: 16px; flex-wrap: wrap; }
+.doc-meta-item { font-size: 12px; color: var(--text-secondary); }
+
+// ── Group cards (document category/project/date drill-down) ───────
+.group-cards-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 12px; }
+
+.group-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px;
+  border-radius: 10px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  transition: border-color 200ms, box-shadow 200ms;
+  text-align: left;
+  font-family: inherit;
+  color: var(--text-primary);
+
+  &:hover {
+    border-color: rgba(138, 92, 255, 0.3);
+    box-shadow: 0 0 12px rgba(138, 92, 255, 0.08);
+  }
+}
+
+.group-card-name { font-size: 14px; font-weight: 500; }
+.group-card-count { font-size: 12px; color: var(--text-secondary); }
+
+// ── Loading / empty states ────────────────────────────────────────
+.loading { color: var(--text-secondary); font-size: 13px; padding: 40px 0; text-align: center; }
+
+.empty-state {
+  text-align: center;
+  padding: 48px 24px;
+  color: var(--text-secondary);
+}
+
+.empty-icon { margin-bottom: 12px; color: var(--text-tertiary); opacity: 0.5; }
+.empty-state h3 { font-size: 16px; color: var(--text-primary); margin: 0 0 6px; font-weight: 600; }
+.empty-state p { font-size: 13px; margin: 0; }
+
+// ── Utility ───────────────────────────────────────────────────────
+.hidden { display: none !important; } // stylelint-disable-line declaration-no-important
+.panel-placeholder { padding: 40px; text-align: center; color: var(--text-secondary); }
+.panel-placeholder h2 { color: var(--text-primary); margin: 0 0 8px; }
+
+// ── Scrollbar ─────────────────────────────────────────────────────
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: rgba(255, 255, 255, 0.08); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: rgba(255, 255, 255, 0.15); }
+
+[data-theme='light'] ::-webkit-scrollbar-thumb { background: rgba(0, 0, 0, 0.08); }
+[data-theme='light'] ::-webkit-scrollbar-thumb:hover { background: rgba(0, 0, 0, 0.15); }
+
+// ── Skills panel ──────────────────────────────────────────────────
+.skills-grid { display: flex; flex-direction: column; gap: 8px; }
+
+.skill-card { flex-direction: column; align-items: stretch; gap: 10px; padding: 16px; }
+.skill-card.skill-disabled { opacity: 0.6; }
+
+.skill-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.skill-card-title { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.skill-card-actions { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
+.skill-use-for { font-size: 13px; color: var(--text-secondary); line-height: 1.5; }
+.skill-tags { display: flex; flex-wrap: wrap; gap: 4px; }
+.skill-tag { font-size: 10px; padding: 1px 6px; }
+.skill-toggle-wrap { margin-right: 2px; }
+
+.skill-expand-icon { display: inline-flex; align-items: center; opacity: 0.5; transition: opacity 0.15s; }
+
+.skill-card-title:hover {
+  .skill-expand-icon { opacity: 1; }
+  strong { color: var(--accent); }
+}
+
+.skill-expanded-content {
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+  margin-top: 4px;
+}
+
+.skill-detail-row { font-size: 12px; color: var(--text-secondary); margin-bottom: 8px; }
+.skill-detail-label { font-weight: 600; color: var(--text-primary); margin-right: 6px; }
+
+.skill-content-preview {
+  font-family: 'Inter', monospace;
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  background: var(--bg-secondary, var(--bg-surface));
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  margin: 0;
+}
+
+// ── Responsive — match the 900px sidebar breakpoint ───────────────
+@media (max-width: 900px) {
+  .main { padding: 16px 12px; overflow-x: hidden; }
+  .main-inner { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  .panel-header { flex-direction: column; align-items: flex-start; gap: 10px; }
+  .panel-header h2 { font-size: 18px; }
+  .panel-header-actions { width: 100%; flex-wrap: wrap; }
+  .panel-header-actions .search-input { width: 100%; }
+  .panel-desc { font-size: 13px; }
+  .stat-grid { grid-template-columns: 1fr 1fr; gap: 8px; }
+  .stat-card { padding: 12px; }
+  .stat-value { font-size: 18px; }
+  .personality-row { flex-direction: column; align-items: stretch; gap: 4px; }
+  .pole { width: auto; text-align: left; }
+
+  // Tables scroll horizontally via parent overflow
+  .records-table {
+    min-width: 600px;
+
+    .key-cell { max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  }
+
+  // Grids single column
+  .group-cards-grid { grid-template-columns: 1fr; }
+  .caps-grid { grid-template-columns: 1fr !important; } // stylelint-disable-line declaration-no-important
+  .policies-grid { grid-template-columns: 1fr !important; } // stylelint-disable-line declaration-no-important
+  .policy-rule { flex-wrap: wrap; gap: 6px; }
+  .policy-label { flex: 1 1 100%; }
+
+  // MCP settings full width
+  .mcp-settings { max-width: none !important; } // stylelint-disable-line declaration-no-important
+  .mcp-row { flex-wrap: wrap; gap: 8px; }
+  .input-group { width: 100%; }
+
+  // Provider / form pages full width
+  .provider-form-page { max-width: none; }
+
+  // Chart responsive
+  .chart-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; max-width: 100%; }
+
+  // List cards
+  .list-card-header { flex-wrap: wrap; gap: 8px; }
+  .list-card-actions { width: 100%; justify-content: flex-end; }
+
+  // Topbar
+  .topbar { padding: 0 12px; gap: 8px; }
+  .topbar-center { display: none; }
+  .crumb { font-size: 12px; }
+  .crumb .sep:first-of-type,
+  .crumb span:first-child { display: none; }
+
+  // Modal full-width on mobile
+  .modal { width: 92vw; padding: 16px; }
+  .modal-sm { width: 92vw; }
+
+  // Filter/group tabs scroll
+  .filter-tabs,
+  .doc-group-tabs { overflow-x: auto; flex-wrap: nowrap; -webkit-overflow-scrolling: touch; }
+  .filter-tab,
+  .group-tab { flex-shrink: 0; }
+
+  // Segmented controls compact
+  .segmented { gap: 0; }
+  .seg-btn { padding: 4px 8px; font-size: 11px; }
+}

--- a/frontend/apps/brain/src/styles/brain.scss
+++ b/frontend/apps/brain/src/styles/brain.scss
@@ -1976,3 +1976,96 @@ input[type='checkbox'] {
   .segmented { gap: 0; }
   .seg-btn { padding: 4px 8px; font-size: 11px; }
 }
+
+// ── Brain backup/restore panel (ported from frontend/brain/style.css:1112-1191) ──
+// .form-hint (line 1239) and .form-input (line 1627) already exist above — not repeated.
+
+.brain-overview {
+  max-width: 640px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.brain-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.export-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 20px;
+  text-align: center;
+}
+
+.export-card-icon {
+  color: var(--violet);
+  margin-bottom: 8px;
+}
+
+.export-card-label {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+
+.export-card-value {
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+
+.brain-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.brain-section {
+  border-top: 1px solid var(--border);
+  padding-top: 20px;
+}
+
+.brain-section-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 12px;
+  color: var(--text-secondary);
+}
+
+.brain-form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.brain-form-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+// Legacy brain section re-declares .form-hint brighter/larger (style.css:1179-1182).
+// Scoped here (not a global re-declare) to restore the ghStatus appearance without
+// regressing the global .form-hint used by other panels.
+.brain-form-actions .form-hint {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+// Legacy style.css:1184 declares a column-flex .form-label globally. The shared
+// design tokens (_tokens.scss:210) already own a global .form-label (bold inline
+// label), imported before this file — so a top-level re-declare here would
+// silently clobber that token app-wide. Scope to where BrainView actually uses
+// the legacy column variant: the GitHub form grid and the export/import modals.
+.brain-form-grid .form-label,
+.modal .form-label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+}

--- a/frontend/apps/brain/src/ui/Badge.vue
+++ b/frontend/apps/brain/src/ui/Badge.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+const props = defineProps<{
+  variant?: string;
+}>();
+</script>
+
+<template>
+  <span :class="['badge', props.variant ? `badge-${props.variant}` : '']">
+    <slot />
+  </span>
+</template>

--- a/frontend/apps/brain/src/ui/BrainIcon.vue
+++ b/frontend/apps/brain/src/ui/BrainIcon.vue
@@ -1,0 +1,95 @@
+<!--
+  BrainIcon — port of frontend/brain/icons.js.
+  All icons are Lucide-style, 1.75px stroke, currentColor, rounded.
+  Props:
+    name: icon name (matches the key in the legacy Icons object)
+    size: pixel size (default 18)
+-->
+<script setup lang="ts">
+const props = withDefaults(
+  defineProps<{
+    name: string;
+    size?: number;
+  }>(),
+  { size: 18 },
+);
+
+const ICONS: Record<string, string> = {
+  Providers:
+    '<rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/>',
+  Brain:
+    '<path d="M12 4.5C12 3.12 10.88 2 9.5 2c-1.38 0-2.5 1.12-2.5 2.5 0 .25.04.49.1.72A3 3 0 0 0 4.5 8c0 .82.33 1.56.86 2.1A3 3 0 0 0 4 13a3 3 0 0 0 3 3 3 3 0 0 0 .9 2.6A2.5 2.5 0 0 0 12 22V4.5z"/><path d="M12 4.5C12 3.12 13.12 2 14.5 2c1.38 0 2.5 1.12 2.5 2.5 0 .25-.04.49-.1.72A3 3 0 0 1 19.5 8c0 .82-.33 1.56-.86 2.1A3 3 0 0 1 20 13a3 3 0 0 1-3 3 3 3 0 0 1-.9 2.6A2.5 2.5 0 0 1 12 22"/>',
+  Calendar:
+    '<rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/>',
+  List: '<path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"/>',
+  Document:
+    '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/>',
+  Capability:
+    '<path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/><circle cx="12" cy="12" r="3"/>',
+  Policy:
+    '<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/>',
+  Server:
+    '<rect x="2" y="3" width="20" height="8" rx="2"/><rect x="2" y="13" width="20" height="8" rx="2"/><path d="M6 7h.01M6 17h.01"/>',
+  Memory:
+    '<path d="M21 12a9 9 0 1 1-6.22-8.56"/><path d="M12 7v5l3 2"/>',
+  Tool: '<path d="M14.7 6.3a4 4 0 0 0-5.4 5.4l-6.6 6.6a2 2 0 1 0 2.83 2.83l6.6-6.6a4 4 0 0 0 5.4-5.4l-2.83 2.83-2.83-2.83 2.83-2.83z"/>',
+  Globe:
+    '<circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15 15 0 0 1 0 20M12 2a15 15 0 0 0 0 20"/>',
+  Sparkles:
+    '<path d="M12 3v3M12 18v3M5 12H2M22 12h-3M5.6 5.6l2.1 2.1M16.3 16.3l2.1 2.1M5.6 18.4l2.1-2.1M16.3 7.7l2.1-2.1"/>',
+  Alert:
+    '<path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><path d="M12 9v4M12 17h.01"/>',
+  Chart:
+    '<path d="M3 3v18h18"/><path d="m7 14 4-4 4 4 5-5"/>',
+  Working:
+    '<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="m9 11 3 3L22 4"/>',
+  Menu: '<path d="M3 6h18M3 12h18M3 18h18"/>',
+  Search:
+    '<circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/>',
+  Sun: '<circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>',
+  Moon: '<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>',
+  Bell: '<path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/>',
+  Sidebar:
+    '<rect x="3" y="3" width="18" height="18" rx="2"/><path d="M9 3v18"/>',
+  Chevron: '<path d="m9 18 6-6-6-6"/>',
+  ChevronDown: '<path d="m6 9 6 6 6-6"/>',
+  Plus: '<path d="M12 5v14M5 12h14"/>',
+  Edit: '<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4z"/>',
+  Trash:
+    '<path d="M3 6h18M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2M10 11v6M14 11v6"/>',
+  Copy: '<rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>',
+  Refresh:
+    '<path d="M21 12a9 9 0 0 0-15-6.7L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 15 6.7L21 16"/><path d="M21 21v-5h-5"/>',
+  Folder:
+    '<path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>',
+  Upload:
+    '<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m17 8-5-5-5 5M12 3v12"/>',
+  Download:
+    '<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>',
+  Database:
+    '<ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/>',
+  Close: '<path d="M18 6 6 18M6 6l12 12"/>',
+  Eye: '<path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/>',
+  Link: '<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.72"/>',
+  Power:
+    '<path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><path d="M12 2v10"/>',
+  Check: '<path d="M20 6 9 17l-5-5"/>',
+  X: '<path d="M18 6 6 18M6 6l12 12"/>',
+  Filter:
+    '<polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/>',
+  MoreH:
+    '<circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/>',
+  Skill:
+    '<path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/>',
+};
+
+function svgHtml(name: string, size: number): string {
+  const inner = ICONS[name] ?? '';
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">${inner}</svg>`;
+}
+</script>
+
+<template>
+  <!-- eslint-disable-next-line vue/no-v-html -->
+  <span class="brain-icon" v-html="svgHtml(props.name, props.size)"></span>
+</template>

--- a/frontend/apps/brain/src/ui/BrainModal.vue
+++ b/frontend/apps/brain/src/ui/BrainModal.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+const props = defineProps<{
+  modelValue: boolean;
+  size?: 'sm' | 'lg' | '';
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void;
+}>();
+
+function close(): void {
+  emit('update:modelValue', false);
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="props.modelValue" class="modal-overlay" @click.self="close">
+      <div :class="['modal', props.size ? `modal-${props.size}` : '']">
+        <slot :close="close" />
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/frontend/apps/brain/src/ui/BrainSidebar.vue
+++ b/frontend/apps/brain/src/ui/BrainSidebar.vue
@@ -1,0 +1,202 @@
+<!--
+  BrainSidebar — port of frontend/brain/sidebar.js.
+  Renders the two NAV groups (Cognition + System) with collapsible sub-lists,
+  active-route highlighting via Vue Router, lock-banner when providersOnly,
+  and a theme toggle button at the bottom.
+-->
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useRouter, useRoute } from 'vue-router';
+import { useTheme } from '@chalie/shared';
+import { useShellStore } from '../stores/shell';
+import BrainIcon from './BrainIcon.vue';
+
+const shell = useShellStore();
+const route = useRoute();
+const router = useRouter();
+const { theme, toggle: toggleTheme } = useTheme();
+
+// Absolute runtime URL — Flask serves /icons/icon.png regardless of Vue base path.
+// Using :src (dynamic binding) prevents Vite/Rollup from attempting to resolve
+// this as a local module import during build.
+const brandIconUrl = '/icons/icon.png';
+
+interface SubItem {
+  id: string;
+  label: string;
+}
+
+interface NavItem {
+  id: string;
+  label: string;
+  icon: string;
+  group: 'cognition' | 'system';
+  sub?: SubItem[];
+}
+
+// Port of BrainSidebar.NAV (sidebar.js:3-42).
+const NAV: NavItem[] = [
+  { id: 'providers', label: 'Providers', icon: 'Providers', group: 'cognition' },
+  { id: 'vision', label: 'Vision', icon: 'Eye', group: 'cognition' },
+  {
+    id: 'cognition', label: 'Cognition', icon: 'Brain', group: 'cognition',
+    sub: [
+      { id: 'memory', label: 'Memory' },
+      { id: 'tools', label: 'Tools' },
+      { id: 'world', label: 'World state' },
+      { id: 'personality', label: 'Personality' },
+      { id: 'errors', label: 'Errors' },
+      { id: 'usage', label: 'Usage' },
+      { id: 'compaction', label: 'Compacted Summary' },
+    ],
+  },
+  {
+    id: 'scheduler', label: 'Scheduler', icon: 'Calendar', group: 'cognition',
+    sub: [
+      { id: 'all', label: 'All' },
+      { id: 'pending', label: 'Pending' },
+      { id: 'fired', label: 'Fired' },
+      { id: 'failed', label: 'Failed' },
+      { id: 'cancelled', label: 'Cancelled' },
+    ],
+  },
+  { id: 'lists', label: 'Lists', icon: 'List', group: 'cognition' },
+  {
+    id: 'documents', label: 'Documents', icon: 'Document', group: 'cognition',
+    sub: [
+      { id: 'active', label: 'Active' },
+      { id: 'processing', label: 'Processing' },
+      { id: 'uploads', label: 'Uploads' },
+      { id: 'deleted', label: 'Deleted' },
+    ],
+  },
+  { id: 'capabilities', label: 'Capabilities', icon: 'Capability', group: 'system' },
+  {
+    id: 'policies', label: 'Policies', icon: 'Policy', group: 'system',
+    sub: [
+      { id: 'chat', label: 'Chat' },
+      { id: 'background', label: 'Background' },
+      { id: 'external', label: 'External agent' },
+    ],
+  },
+  { id: 'skills', label: 'Skills', icon: 'Skill', group: 'system' },
+  { id: 'mcp', label: 'MCP', icon: 'Server', group: 'system' },
+  { id: 'brain', label: 'Brain', icon: 'Brain', group: 'system' },
+];
+
+const cognitionItems = computed(() => NAV.filter((n) => n.group === 'cognition'));
+const systemItems = computed(() => NAV.filter((n) => n.group === 'system'));
+
+/** The active top-level section (first path segment after /). */
+const activeSection = computed(() => route.path.split('/')[1] || 'providers');
+/** The active sub-section (second path segment). */
+const activeSub = computed(() => route.path.split('/')[2] || '');
+
+function navigate(section: string, sub: string | null = null): void {
+  if (shell.providersOnly && section !== 'providers') return;
+  if (sub) {
+    void router.push({ path: `/${section}/${sub}` });
+  } else {
+    void router.push({ path: `/${section}` });
+  }
+  if (window.innerWidth <= 900) shell.closeMobileSidebar();
+}
+
+function isActive(item: NavItem): boolean {
+  return activeSection.value === item.id;
+}
+
+function isSubActive(item: NavItem, sub: SubItem): boolean {
+  return isActive(item) && activeSub.value === sub.id;
+}
+
+function isExpanded(item: NavItem): boolean {
+  return isActive(item) && !!item.sub && !shell.sidebarCollapsed;
+}
+</script>
+
+<template>
+  <aside class="sidebar">
+    <!-- Brand -->
+    <a class="sidebar-brand" href="/">
+      <!-- eslint-disable-next-line vue/html-self-closing -->
+      <img :src="brandIconUrl" alt="Chalie" width="28" height="28" />
+      <div class="sidebar-brand-text">
+        <div class="wordmark">Chalie</div>
+        <div class="wordmark-sub">Brain</div>
+      </div>
+    </a>
+
+    <!-- Navigation -->
+    <nav class="sidebar-scroll">
+      <!-- Providers-only lock banner -->
+      <div v-if="shell.providersOnly && !shell.sidebarCollapsed" class="sidebar-lock-banner">
+        <span class="sidebar-lock-icon"><BrainIcon name="Providers" :size="16" /></span>
+        <span>Add a provider to unlock the full dashboard.</span>
+      </div>
+
+      <!-- Cognition group -->
+      <div class="nav-group">
+        <div v-if="!shell.sidebarCollapsed" class="nav-group-title">Cognition</div>
+        <template v-for="item in cognitionItems" :key="item.id">
+          <div :data-section="item.id">
+            <button
+              :class="['nav-item', { active: isActive(item) }]"
+              :data-nav="item.id"
+              :data-expanded="isExpanded(item)"
+              @click="navigate(item.id, item.sub ? item.sub[0].id : null)"
+            >
+              <span class="nav-icon"><BrainIcon :name="item.icon" /></span>
+              <span class="nav-label">{{ item.label }}</span>
+              <span v-if="item.sub" class="nav-chev"><BrainIcon name="Chevron" :size="14" /></span>
+            </button>
+            <div v-if="item.sub" class="nav-sublist" :data-open="isExpanded(item)">
+              <div>
+                <button
+                  v-for="sub in item.sub"
+                  :key="sub.id"
+                  :class="['nav-sub', { active: isSubActive(item, sub) }]"
+                  :data-sub="sub.id"
+                  @click="navigate(item.id, sub.id)"
+                >
+                  <span>{{ sub.label }}</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </template>
+      </div>
+
+      <!-- System group -->
+      <div class="nav-group">
+        <div v-if="!shell.sidebarCollapsed" class="nav-group-title">System</div>
+        <template v-for="item in systemItems" :key="item.id">
+          <div :data-section="item.id">
+            <button
+              :class="['nav-item', { active: isActive(item) }]"
+              :data-nav="item.id"
+              :data-expanded="isExpanded(item)"
+              @click="navigate(item.id, item.sub ? item.sub[0].id : null)"
+            >
+              <span class="nav-icon"><BrainIcon :name="item.icon" /></span>
+              <span class="nav-label">{{ item.label }}</span>
+              <span v-if="item.sub" class="nav-chev"><BrainIcon name="Chevron" :size="14" /></span>
+            </button>
+          </div>
+        </template>
+      </div>
+    </nav>
+
+    <!-- Footer: theme toggle -->
+    <div class="sidebar-footer">
+      <button
+        type="button"
+        class="icon-btn theme-toggle"
+        aria-label="Toggle theme"
+        @click="toggleTheme"
+      >
+        <BrainIcon :name="theme === 'dark' ? 'Sun' : 'Moon'" />
+      </button>
+    </div>
+  </aside>
+</template>

--- a/frontend/apps/brain/src/ui/BrainTopbar.vue
+++ b/frontend/apps/brain/src/ui/BrainTopbar.vue
@@ -1,0 +1,89 @@
+<!--
+  BrainTopbar — port of legacy _renderTopbar() in app.js.
+  Shows hamburger (mobile), collapse toggle (desktop), breadcrumb, search button.
+-->
+<script setup lang="ts">
+import { computed, inject } from 'vue';
+import { useRoute } from 'vue-router';
+import { useShellStore } from '../stores/shell';
+import BrainIcon from './BrainIcon.vue';
+
+const shell = useShellStore();
+const route = useRoute();
+
+// Inject the openCommandPalette function provided by CommandPalette or App.vue.
+// Fallback is a no-op if not provided.
+const openCP = inject<() => void>('openCommandPalette', () => {});
+
+const LABELS: Record<string, string> = {
+  providers: 'Providers', cognition: 'Cognition', scheduler: 'Scheduler',
+  lists: 'Lists', documents: 'Documents', capabilities: 'Capabilities',
+  vision: 'Vision', policies: 'Policies', skills: 'Skills', mcp: 'MCP', brain: 'Brain',
+  memory: 'Memory', tools: 'Tools', world: 'World state',
+  personality: 'Personality', errors: 'Errors', usage: 'Usage',
+  compaction: 'Compacted Summary',
+  all: 'All', pending: 'Pending', fired: 'Fired', failed: 'Failed', cancelled: 'Cancelled',
+  active: 'Active', processing: 'Processing', uploads: 'Uploads', deleted: 'Deleted',
+  chat: 'Chat', background: 'Background', external: 'External agent',
+};
+
+const segments = computed(() => route.path.split('/').filter(Boolean));
+const topLabel = computed(() => LABELS[segments.value[0]] ?? segments.value[0] ?? '');
+const subLabel = computed(() => LABELS[segments.value[1]] ?? segments.value[1] ?? '');
+
+function handleSearchKeydown(e: KeyboardEvent): void {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault();
+    openCP();
+  }
+}
+</script>
+
+<template>
+  <header class="topbar">
+    <!-- Mobile hamburger -->
+    <button class="icon-btn hamburger" aria-label="Open menu" @click="shell.openMobileSidebar()">
+      <BrainIcon name="Menu" />
+    </button>
+
+    <!-- Desktop sidebar collapser -->
+    <button
+      class="icon-btn desktop-collapser"
+      aria-label="Toggle sidebar"
+      title="Toggle sidebar"
+      @click="shell.toggleSidebar()"
+    >
+      <BrainIcon name="Sidebar" />
+    </button>
+
+    <!-- Breadcrumb -->
+    <div class="crumb">
+      <span>Brain</span>
+      <span class="sep">/</span>
+      <span class="now">{{ topLabel }}</span>
+      <template v-if="subLabel">
+        <span class="sep">/</span>
+        <span class="now">{{ subLabel }}</span>
+      </template>
+    </div>
+
+    <!-- Search / command palette trigger -->
+    <div class="topbar-center">
+      <div
+        class="topbar-search"
+        role="button"
+        tabindex="0"
+        @click="openCP()"
+        @keydown="handleSearchKeydown"
+      >
+        <BrainIcon name="Search" :size="14" />
+        <span class="topbar-search-text">Search…</span>
+        <kbd>⌘K</kbd>
+      </div>
+    </div>
+
+    <div class="topbar-actions">
+      <slot />
+    </div>
+  </header>
+</template>

--- a/frontend/apps/brain/src/ui/BrainTopbar.vue
+++ b/frontend/apps/brain/src/ui/BrainTopbar.vue
@@ -3,17 +3,13 @@
   Shows hamburger (mobile), collapse toggle (desktop), breadcrumb, search button.
 -->
 <script setup lang="ts">
-import { computed, inject } from 'vue';
+import { computed } from 'vue';
 import { useRoute } from 'vue-router';
 import { useShellStore } from '../stores/shell';
 import BrainIcon from './BrainIcon.vue';
 
 const shell = useShellStore();
 const route = useRoute();
-
-// Inject the openCommandPalette function provided by CommandPalette or App.vue.
-// Fallback is a no-op if not provided.
-const openCP = inject<() => void>('openCommandPalette', () => {});
 
 const LABELS: Record<string, string> = {
   providers: 'Providers', cognition: 'Cognition', scheduler: 'Scheduler',
@@ -34,7 +30,7 @@ const subLabel = computed(() => LABELS[segments.value[1]] ?? segments.value[1] ?
 function handleSearchKeydown(e: KeyboardEvent): void {
   if (e.key === 'Enter' || e.key === ' ') {
     e.preventDefault();
-    openCP();
+    shell.openCommandPalette();
   }
 }
 </script>
@@ -73,7 +69,7 @@ function handleSearchKeydown(e: KeyboardEvent): void {
         class="topbar-search"
         role="button"
         tabindex="0"
-        @click="openCP()"
+        @click="shell.openCommandPalette()"
         @keydown="handleSearchKeydown"
       >
         <BrainIcon name="Search" :size="14" />

--- a/frontend/apps/brain/src/ui/CommandPalette.vue
+++ b/frontend/apps/brain/src/ui/CommandPalette.vue
@@ -1,10 +1,10 @@
 <!--
   CommandPalette — port of legacy _renderCommandPalette() in app.js.
   Opened by ⌘K/Ctrl-K or the topbar search button.
-  Provides the openCommandPalette injection consumed by BrainTopbar.
+  Visibility is driven by shell.commandPaletteOpen (Pinia store).
 -->
 <script setup lang="ts">
-import { ref, computed, watch, nextTick, provide, onMounted, onBeforeUnmount } from 'vue';
+import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue';
 import { useRouter } from 'vue-router';
 import { useShellStore } from '../stores/shell';
 import BrainIcon from './BrainIcon.vue';
@@ -12,7 +12,6 @@ import BrainIcon from './BrainIcon.vue';
 const shell = useShellStore();
 const router = useRouter();
 
-const visible = ref(false);
 const query = ref('');
 const selectedIdx = ref(0);
 const inputRef = ref<HTMLInputElement | null>(null);
@@ -60,26 +59,18 @@ const filtered = computed(() => {
 });
 
 watch(query, () => { selectedIdx.value = 0; });
-watch(visible, (v) => {
+watch(() => shell.commandPaletteOpen, (v) => {
   if (v) {
+    query.value = '';
     selectedIdx.value = 0;
     void nextTick(() => inputRef.value?.focus());
   }
 });
 
-function open(): void {
-  query.value = '';
-  visible.value = true;
-}
-
-function close(): void {
-  visible.value = false;
-}
-
 function selectItem(item: CPItem): void {
   if (shell.providersOnly && item.path !== '/providers') return;
   void router.push(item.path);
-  close();
+  shell.closeCommandPalette();
 }
 
 function onKeydown(e: KeyboardEvent): void {
@@ -94,29 +85,26 @@ function onKeydown(e: KeyboardEvent): void {
     const item = filtered.value[selectedIdx.value];
     if (item) selectItem(item);
   } else if (e.key === 'Escape') {
-    close();
+    shell.closeCommandPalette();
   }
 }
 
 function onGlobalKeydown(e: KeyboardEvent): void {
   if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
     e.preventDefault();
-    if (visible.value) close(); else open();
-  } else if (e.key === 'Escape' && visible.value) {
-    close();
+    shell.toggleCommandPalette();
+  } else if (e.key === 'Escape' && shell.commandPaletteOpen) {
+    shell.closeCommandPalette();
   }
 }
 
 onMounted(() => document.addEventListener('keydown', onGlobalKeydown));
 onBeforeUnmount(() => document.removeEventListener('keydown', onGlobalKeydown));
-
-// Provide the open function so BrainTopbar can call it via inject.
-provide('openCommandPalette', open);
 </script>
 
 <template>
-  <div :class="['cp-overlay', { hidden: !visible }]" @click.self="close">
-    <div class="cp" v-if="visible">
+  <div :class="['cp-overlay', { hidden: !shell.commandPaletteOpen }]" @click.self="shell.closeCommandPalette()">
+    <div class="cp" v-if="shell.commandPaletteOpen">
       <input
         ref="inputRef"
         class="cp-input"

--- a/frontend/apps/brain/src/ui/CommandPalette.vue
+++ b/frontend/apps/brain/src/ui/CommandPalette.vue
@@ -1,0 +1,151 @@
+<!--
+  CommandPalette — port of legacy _renderCommandPalette() in app.js.
+  Opened by ⌘K/Ctrl-K or the topbar search button.
+  Provides the openCommandPalette injection consumed by BrainTopbar.
+-->
+<script setup lang="ts">
+import { ref, computed, watch, nextTick, provide, onMounted, onBeforeUnmount } from 'vue';
+import { useRouter } from 'vue-router';
+import { useShellStore } from '../stores/shell';
+import BrainIcon from './BrainIcon.vue';
+
+const shell = useShellStore();
+const router = useRouter();
+
+const visible = ref(false);
+const query = ref('');
+const selectedIdx = ref(0);
+const inputRef = ref<HTMLInputElement | null>(null);
+
+interface CPItem {
+  kind: string;
+  label: string;
+  icon: string;
+  path: string;
+}
+
+// Port of allItems in _renderCommandPalette (app.js:162-178).
+const ALL_ITEMS: CPItem[] = [
+  { kind: 'Jump', label: 'Providers', icon: 'Providers', path: '/providers' },
+  { kind: 'Jump', label: 'Vision', icon: 'Eye', path: '/vision' },
+  { kind: 'Jump', label: 'Cognition · Memory', icon: 'Memory', path: '/cognition/memory' },
+  { kind: 'Jump', label: 'Cognition · Tools', icon: 'Tool', path: '/cognition/tools' },
+  { kind: 'Jump', label: 'Cognition · World state', icon: 'Globe', path: '/cognition/world' },
+  { kind: 'Jump', label: 'Cognition · Personality', icon: 'Sparkles', path: '/cognition/personality' },
+  { kind: 'Jump', label: 'Cognition · Errors', icon: 'Alert', path: '/cognition/errors' },
+  { kind: 'Jump', label: 'Cognition · Usage', icon: 'Chart', path: '/cognition/usage' },
+  { kind: 'Jump', label: 'Cognition · Compacted Summary', icon: 'Document', path: '/cognition/compaction' },
+  { kind: 'Jump', label: 'Scheduler · All', icon: 'Calendar', path: '/scheduler/all' },
+  { kind: 'Jump', label: 'Scheduler · Pending', icon: 'Calendar', path: '/scheduler/pending' },
+  { kind: 'Jump', label: 'Scheduler · Fired', icon: 'Calendar', path: '/scheduler/fired' },
+  { kind: 'Jump', label: 'Scheduler · Failed', icon: 'Calendar', path: '/scheduler/failed' },
+  { kind: 'Jump', label: 'Scheduler · Cancelled', icon: 'Calendar', path: '/scheduler/cancelled' },
+  { kind: 'Jump', label: 'Lists', icon: 'List', path: '/lists' },
+  { kind: 'Jump', label: 'Documents · Active', icon: 'Document', path: '/documents/active' },
+  { kind: 'Jump', label: 'Documents · Processing', icon: 'Document', path: '/documents/processing' },
+  { kind: 'Jump', label: 'Documents · Uploads', icon: 'Upload', path: '/documents/uploads' },
+  { kind: 'Jump', label: 'Documents · Deleted', icon: 'Trash', path: '/documents/deleted' },
+  { kind: 'Jump', label: 'Capabilities', icon: 'Capability', path: '/capabilities' },
+  { kind: 'Jump', label: 'Policies · Chat', icon: 'Policy', path: '/policies/chat' },
+  { kind: 'Jump', label: 'Policies · Background', icon: 'Policy', path: '/policies/background' },
+  { kind: 'Jump', label: 'Policies · External agent', icon: 'Policy', path: '/policies/external' },
+  { kind: 'Jump', label: 'Skills', icon: 'Skill', path: '/skills' },
+  { kind: 'Jump', label: 'MCP', icon: 'Server', path: '/mcp' },
+  { kind: 'Jump', label: 'Brain', icon: 'Brain', path: '/brain' },
+];
+
+const filtered = computed(() => {
+  const q = query.value.toLowerCase();
+  return q ? ALL_ITEMS.filter((i) => i.label.toLowerCase().includes(q)) : ALL_ITEMS;
+});
+
+watch(query, () => { selectedIdx.value = 0; });
+watch(visible, (v) => {
+  if (v) {
+    selectedIdx.value = 0;
+    void nextTick(() => inputRef.value?.focus());
+  }
+});
+
+function open(): void {
+  query.value = '';
+  visible.value = true;
+}
+
+function close(): void {
+  visible.value = false;
+}
+
+function selectItem(item: CPItem): void {
+  if (shell.providersOnly && item.path !== '/providers') return;
+  void router.push(item.path);
+  close();
+}
+
+function onKeydown(e: KeyboardEvent): void {
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    selectedIdx.value = Math.min(filtered.value.length - 1, selectedIdx.value + 1);
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    selectedIdx.value = Math.max(0, selectedIdx.value - 1);
+  } else if (e.key === 'Enter') {
+    e.preventDefault();
+    const item = filtered.value[selectedIdx.value];
+    if (item) selectItem(item);
+  } else if (e.key === 'Escape') {
+    close();
+  }
+}
+
+function onGlobalKeydown(e: KeyboardEvent): void {
+  if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+    e.preventDefault();
+    if (visible.value) close(); else open();
+  } else if (e.key === 'Escape' && visible.value) {
+    close();
+  }
+}
+
+onMounted(() => document.addEventListener('keydown', onGlobalKeydown));
+onBeforeUnmount(() => document.removeEventListener('keydown', onGlobalKeydown));
+
+// Provide the open function so BrainTopbar can call it via inject.
+provide('openCommandPalette', open);
+</script>
+
+<template>
+  <div :class="['cp-overlay', { hidden: !visible }]" @click.self="close">
+    <div class="cp" v-if="visible">
+      <input
+        ref="inputRef"
+        class="cp-input"
+        v-model="query"
+        placeholder="Search the brain… (try 'memory', 'policy')"
+        @keydown="onKeydown"
+      />
+      <div class="cp-results">
+        <template v-if="filtered.length > 0">
+          <div class="cp-section">Jump</div>
+          <div
+            v-for="(item, idx) in filtered"
+            :key="item.path"
+            :class="['cp-row', { selected: idx === selectedIdx }]"
+            :data-section="item.path.split('/')[1]"
+            :data-sub="item.path.split('/')[2] || ''"
+            @click="selectItem(item)"
+          >
+            <span class="cp-icon"><BrainIcon :name="item.icon" :size="14" /></span>
+            <span>{{ item.label }}</span>
+            <span v-if="idx === selectedIdx" class="cp-hint">↵</span>
+          </div>
+        </template>
+        <div v-else class="cp-empty">No matches. Try fewer words.</div>
+      </div>
+      <div class="cp-footer">
+        <span><kbd>↑</kbd><kbd>↓</kbd> navigate · <kbd>↵</kbd> open · <kbd>esc</kbd> close</span>
+        <span>{{ filtered.length }} result{{ filtered.length === 1 ? '' : 's' }}</span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/apps/brain/src/ui/CommandPalette.vue
+++ b/frontend/apps/brain/src/ui/CommandPalette.vue
@@ -104,11 +104,11 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onGlobalKeydown));
 
 <template>
   <div :class="['cp-overlay', { hidden: !shell.commandPaletteOpen }]" @click.self="shell.closeCommandPalette()">
-    <div class="cp" v-if="shell.commandPaletteOpen">
+    <div v-if="shell.commandPaletteOpen" class="cp">
       <input
         ref="inputRef"
-        class="cp-input"
         v-model="query"
+        class="cp-input"
         placeholder="Search the brain… (try 'memory', 'policy')"
         @keydown="onKeydown"
       />

--- a/frontend/apps/brain/src/ui/ConfirmDialog.vue
+++ b/frontend/apps/brain/src/ui/ConfirmDialog.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { useConfirm } from '../composables/useConfirm';
+
+const { visible, pending, accept, cancel } = useConfirm();
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="visible && pending" class="modal-overlay" @click.self="cancel">
+      <div class="modal modal-sm">
+        <div class="modal-header">
+          <h3>{{ pending.title }}</h3>
+        </div>
+        <p class="modal-desc">{{ pending.desc }}</p>
+        <div class="modal-actions">
+          <button class="btn btn-secondary" @click="cancel">Cancel</button>
+          <button :class="['btn', pending.confirmClass || 'btn-primary']" @click="accept">
+            {{ pending.confirmLabel || 'Confirm' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/frontend/apps/brain/src/ui/DataTable.vue
+++ b/frontend/apps/brain/src/ui/DataTable.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import EmptyState from './EmptyState.vue';
+
+interface Column {
+  key: string;
+  label: string;
+  class?: string;
+}
+
+const props = defineProps<{
+  columns: Column[];
+  rows: Record<string, unknown>[];
+  emptyMessage?: string;
+}>();
+</script>
+
+<template>
+  <div>
+    <table v-if="props.rows.length > 0" class="records-table">
+      <thead>
+        <tr>
+          <th v-for="col in props.columns" :key="col.key">{{ col.label }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(row, i) in props.rows" :key="i">
+          <td v-for="col in props.columns" :key="col.key" :class="col.class">
+            <slot :name="`cell-${col.key}`" :row="row" :value="row[col.key]">
+              {{ row[col.key] ?? '' }}
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <EmptyState v-else :message="props.emptyMessage ?? 'No records found.'" />
+  </div>
+</template>

--- a/frontend/apps/brain/src/ui/EmptyState.vue
+++ b/frontend/apps/brain/src/ui/EmptyState.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+const props = defineProps<{
+  message?: string;
+  icon?: string;
+}>();
+</script>
+
+<template>
+  <div class="empty-state">
+    <div v-if="props.icon" class="empty-icon" v-html="props.icon"></div>
+    <p>{{ props.message ?? 'Nothing here yet.' }}</p>
+    <slot />
+  </div>
+</template>

--- a/frontend/apps/brain/src/ui/EmptyState.vue
+++ b/frontend/apps/brain/src/ui/EmptyState.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
 
 <template>
   <div class="empty-state">
+    <!-- eslint-disable-next-line vue/no-v-html -->
     <div v-if="props.icon" class="empty-icon" v-html="props.icon"></div>
     <p>{{ props.message ?? 'Nothing here yet.' }}</p>
     <slot />

--- a/frontend/apps/brain/src/ui/SegmentedControl.vue
+++ b/frontend/apps/brain/src/ui/SegmentedControl.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+interface Segment {
+  value: string;
+  label: string;
+}
+
+const props = defineProps<{
+  modelValue: string;
+  segments: Segment[];
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string): void;
+}>();
+</script>
+
+<template>
+  <div class="segmented">
+    <button
+      v-for="seg in props.segments"
+      :key="seg.value"
+      :class="['seg-btn', { active: modelValue === seg.value }]"
+      :data-val="seg.value"
+      type="button"
+      @click="emit('update:modelValue', seg.value)"
+    >
+      {{ seg.label }}
+    </button>
+  </div>
+</template>

--- a/frontend/apps/brain/src/ui/ToastHost.vue
+++ b/frontend/apps/brain/src/ui/ToastHost.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { useToast } from '../composables/useToast';
+
+const { toasts, dismiss } = useToast();
+</script>
+
+<template>
+  <div class="toast-host">
+    <div
+      v-for="toast in toasts"
+      :key="toast.id"
+      :class="['toast', `toast-${toast.type}`]"
+    >
+      {{ toast.message }}
+      <button v-if="toast.action && toast.onAction" class="toast-action" @click="toast.onAction?.(); dismiss(toast.id)">
+        {{ toast.action }}
+      </button>
+    </div>
+  </div>
+</template>

--- a/frontend/apps/brain/src/ui/ToggleSwitch.vue
+++ b/frontend/apps/brain/src/ui/ToggleSwitch.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+const props = defineProps<{
+  modelValue: boolean;
+  label?: string;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void;
+}>();
+</script>
+
+<template>
+  <label class="switch">
+    <input
+      type="checkbox"
+      :checked="props.modelValue"
+      @change="emit('update:modelValue', ($event.target as HTMLInputElement).checked)"
+    />
+    <span class="switch-track"></span>
+    <span v-if="props.label" class="switch-label">{{ props.label }}</span>
+  </label>
+</template>

--- a/frontend/apps/brain/src/utils/format.ts
+++ b/frontend/apps/brain/src/utils/format.ts
@@ -1,0 +1,22 @@
+/**
+ * Format a backend timestamp string to `YYYY-MM-DD HH:MM` in local time.
+ *
+ * Verbatim port of legacy `frontend/brain/app.js:385-393` (`BrainApp.formatDate`),
+ * used by the Cognition / Scheduler / Documents / Skills / Policies panels:
+ *   - empty / falsy input  → ''
+ *   - a naive timestamp (no `T`, `+`, or `Z`) is treated as UTC: ' ' → 'T', then append 'Z'
+ *   - an unparseable value  → returned as-is
+ */
+export function formatDate(raw: string | null | undefined): string {
+  if (!raw) return '';
+  try {
+    const d = new Date(
+      raw.includes('T') || raw.includes('+') || raw.includes('Z') ? raw : raw.replace(' ', 'T') + 'Z',
+    );
+    if (isNaN(d.getTime())) return raw;
+    const pad = (n: number): string => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  } catch {
+    return raw;
+  }
+}

--- a/frontend/apps/brain/src/utils/format.ts
+++ b/frontend/apps/brain/src/utils/format.ts
@@ -20,3 +20,14 @@ export function formatDate(raw: string | null | undefined): string {
     return raw;
   }
 }
+
+/**
+ * Escape HTML special characters. Verbatim port of legacy
+ * `frontend/brain/app.js:380-383` (`BrainApp.escapeHtml`). Needed only where
+ * markup is assembled for `v-html` (e.g. the World view's markdown renderer);
+ * ordinary `{{ }}` interpolation already escapes its content.
+ */
+export function escapeHtml(s: string | null | undefined): string {
+  if (!s) return '';
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}

--- a/frontend/apps/brain/src/views/BrainView.vue
+++ b/frontend/apps/brain/src/views/BrainView.vue
@@ -1,4 +1,386 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { brain } from '../api/brain';
+import type { BrainInfo } from '../api/brain';
+import { useToast } from '../composables/useToast';
+import { useConfirm } from '../composables/useConfirm';
+import BrainModal from '../ui/BrainModal.vue';
+import BrainIcon from '../ui/BrainIcon.vue';
+import { apiErrorMessage } from '../api/http';
+
+const { show: showToast } = useToast();
+const { confirm } = useConfirm();
+
+// ── Info state ────────────────────────────────────────────────────────────────
+const info = ref<BrainInfo | null>(null);
+const loading = ref(true);
+const loadError = ref(false);
+
+// ── Export modal state ────────────────────────────────────────────────────────
+const showExport = ref(false);
+const expFiles = ref(true);
+const expEncrypt = ref(true);
+const expPass = ref('');
+const expPassConfirm = ref('');
+
+// ── Import state ──────────────────────────────────────────────────────────────
+const fileInput = ref<HTMLInputElement | null>(null);
+const importFile = ref<File | null>(null);
+const showImportPass = ref(false);
+const impPass = ref('');
+
+// ── GitHub form state ─────────────────────────────────────────────────────────
+const ghRepo = ref('');
+const ghToken = ref('');
+const ghStatus = ref('');
+
+// ── GitHub upload modal state ─────────────────────────────────────────────────
+const showGhUpload = ref(false);
+const ghUploadPass = ref('');
+
+// ── Computed ──────────────────────────────────────────────────────────────────
+const dbSize = computed(() => info.value?.db_size_human || '0 B');
+const docCount = computed(() => info.value?.document_count || 0);
+
+// ── loadInfo (brain.js:26-36) ─────────────────────────────────────────────────
+async function loadInfo(): Promise<void> {
+  try {
+    info.value = await brain.info();
+  } catch {
+    loadError.value = true;
+  } finally {
+    loading.value = false;
+  }
+}
+
+// ── openExport (brain.js:89-107) ─────────────────────────────────────────────
+function openExport(): void {
+  expFiles.value = true;
+  expEncrypt.value = true;
+  expPass.value = '';
+  expPassConfirm.value = '';
+  showExport.value = true;
+}
+
+// ── doExport (brain.js:103-147) ──────────────────────────────────────────────
+// The legacy modal closes before onConfirm fires — reproduce by closing first.
+async function doExport(): Promise<void> {
+  showExport.value = false;
+
+  if (expEncrypt.value) {
+    if (!expPass.value || expPass.value.length < 4) {
+      showToast('Passphrase must be at least 4 characters', 'error');
+      return;
+    }
+    if (expPass.value !== expPassConfirm.value) {
+      showToast('Passphrases do not match', 'error');
+      return;
+    }
+  }
+
+  showToast('Exporting brain…', 'info');
+  try {
+    const res = await brain.export({
+      include_files: expFiles.value,
+      encrypt: expEncrypt.value,
+      password: expEncrypt.value ? expPass.value : null,
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ error: 'Export failed' }));
+      throw new Error((err as { error?: string }).error || 'Export failed');
+    }
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `brain-export-${new Date().toISOString().replace(/[:.]/g, '-')}.chalie-backup`;
+    a.click();
+    URL.revokeObjectURL(url);
+    showToast('Brain exported successfully', 'success');
+  } catch (e) {
+    showToast(e instanceof Error ? e.message : 'Export failed', 'error');
+  }
+}
+
+// ── openImport (brain.js:149-164) ────────────────────────────────────────────
+async function openImport(): Promise<void> {
+  const ok = await confirm({
+    title: 'Restore from Backup',
+    desc: 'This will replace all current data. A pre-restore snapshot is saved automatically.',
+    confirmLabel: 'Choose Backup File',
+    confirmClass: 'btn-danger',
+  });
+  if (!ok) return;
+  fileInput.value?.click();
+}
+
+// ── onFileChosen — triggered by the hidden <input type="file"> ────────────────
+function onFileChosen(e: Event): void {
+  const input = e.target as HTMLInputElement;
+  const file = input.files?.[0];
+  input.value = ''; // allow re-selecting the same file
+  if (!file) return;
+  importFile.value = file;
+  impPass.value = '';
+  showImportPass.value = true;
+}
+
+// ── doImport (brain.js:183-212) ──────────────────────────────────────────────
+// Modal closes first (matches legacy _showModal confirm handler).
+async function doImport(): Promise<void> {
+  showImportPass.value = false;
+  const file = importFile.value;
+  if (!file) return;
+
+  if (!impPass.value) {
+    showToast('Passphrase is required', 'error');
+    return;
+  }
+
+  showToast('Restoring brain…', 'info');
+  const form = new FormData();
+  form.append('file', file);
+  form.append('password', impPass.value);
+
+  try {
+    const data = await brain.import(form);
+    showToast(
+      `Restored! DB: ${(data.db_size / 1024 / 1024).toFixed(1)} MB, Files: ${data.files_restored}`,
+      'success',
+      { duration: 6000 },
+    );
+    setTimeout(() => location.reload(), 2000);
+  } catch (e) {
+    showToast(apiErrorMessage(e, 'Import failed'), 'error');
+  }
+}
+
+// ── testGithub (brain.js:214-232) ────────────────────────────────────────────
+async function testGithub(): Promise<void> {
+  const token = ghToken.value;
+  if (!token) {
+    showToast('Enter a GitHub token first', 'error');
+    return;
+  }
+  ghStatus.value = 'Testing…';
+  try {
+    const data = await brain.testGithub({ github_token: token });
+    ghStatus.value = `Connected as @${data.username}`;
+    showToast(`GitHub connected as @${data.username}`, 'success');
+  } catch (e) {
+    ghStatus.value = 'Connection failed';
+    showToast(apiErrorMessage(e, 'GitHub test failed'), 'error');
+  }
+}
+
+// ── openGhUpload (brain.js:234-248) ──────────────────────────────────────────
+function openGhUpload(): void {
+  ghUploadPass.value = '';
+  showGhUpload.value = true;
+}
+
+// ── doGhUpload (brain.js:250-285) ────────────────────────────────────────────
+// Modal closes first (matches legacy _showModal confirm handler).
+async function doGhUpload(): Promise<void> {
+  showGhUpload.value = false;
+  const repo = ghRepo.value.trim();
+  const token = ghToken.value.trim();
+  if (!repo || !token) {
+    showToast('Enter repo and token', 'error');
+    return;
+  }
+
+  const password = ghUploadPass.value;
+  const encrypt = password.length >= 4;
+  if (password && password.length < 4) {
+    showToast('Passphrase must be at least 4 characters', 'error');
+    return;
+  }
+
+  showToast('Exporting and uploading to GitHub…', 'info');
+  try {
+    const data = await brain.exportUpload({
+      include_files: true,
+      encrypt,
+      password: encrypt ? password : null,
+      github_repo: repo,
+      github_token: token,
+    });
+    showToast('Backup uploaded to GitHub!', 'success', { duration: 5000 });
+    if (data.commit_url) {
+      ghStatus.value = 'Last upload: ' + new Date().toISOString().slice(0, 10);
+    }
+  } catch (e) {
+    showToast(apiErrorMessage(e, 'Upload failed'), 'error');
+  }
+}
+
+onMounted(loadInfo);
+</script>
+
 <template>
-  <div class="panel-header"><h2>Brain</h2></div>
-  <div class="panel-placeholder"><p>Brain panel — implementation in P2f.</p></div>
+  <!-- Header (brain.js:18-20) -->
+  <div class="panel-header">
+    <h2><BrainIcon name="Brain" :size="20" /> Brain</h2>
+  </div>
+
+  <!-- Hidden file input for import (brain.js:156-162) -->
+  <input
+    ref="fileInput"
+    type="file"
+    accept=".chalie-backup"
+    style="display: none"
+    @change="onFileChosen"
+  >
+
+  <!-- Loading state (brain.js:22) -->
+  <div v-if="loading" class="loading">Loading brain info…</div>
+
+  <!-- Error / empty state (brain.js:34) -->
+  <div v-else-if="loadError || !info" class="empty-state">
+    <p>Could not load brain info.</p>
+  </div>
+
+  <!-- Brain overview (brain.js:46-81) -->
+  <div v-else class="brain-overview">
+    <!-- Stats cards (brain.js:47-58) -->
+    <div class="brain-stats">
+      <div class="export-card">
+        <div class="export-card-icon"><BrainIcon name="Database" :size="24" /></div>
+        <div class="export-card-label">Database</div>
+        <div class="export-card-value">{{ dbSize }}</div>
+      </div>
+      <div class="export-card">
+        <div class="export-card-icon"><BrainIcon name="Document" :size="24" /></div>
+        <div class="export-card-label">Documents</div>
+        <div class="export-card-value">{{ docCount }}</div>
+      </div>
+    </div>
+
+    <!-- Action buttons (brain.js:60-63) -->
+    <div class="brain-actions">
+      <button class="btn btn-primary" @click="openExport">
+        <BrainIcon name="Download" :size="14" /> Export Brain
+      </button>
+      <button class="btn btn-secondary" @click="openImport">
+        <BrainIcon name="Upload" :size="14" /> Restore from Backup
+      </button>
+    </div>
+
+    <!-- GitHub Backup section (brain.js:65-80) -->
+    <div class="brain-section">
+      <h3 class="brain-section-title">GitHub Backup</h3>
+      <div class="brain-form-grid">
+        <label class="form-label">Repository
+          <input
+            v-model="ghRepo"
+            type="text"
+            class="form-input"
+            placeholder="owner/chalie-brain-backup"
+          >
+        </label>
+        <label class="form-label">Token
+          <input
+            v-model="ghToken"
+            type="password"
+            class="form-input"
+            placeholder="ghp_..."
+          >
+        </label>
+      </div>
+      <div class="brain-form-actions">
+        <button class="btn btn-sm btn-secondary" @click="testGithub">Test Connection</button>
+        <button class="btn btn-sm btn-primary" @click="openGhUpload">Upload Backup</button>
+        <span class="form-hint">{{ ghStatus }}</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Export Brain modal (brain.js:89-107) -->
+  <BrainModal v-model="showExport">
+    <div class="modal-header">
+      <h3>Export Brain</h3>
+      <button class="btn-close" type="button" @click="showExport = false">
+        <BrainIcon name="Close" :size="16" />
+      </button>
+    </div>
+    <form @submit.prevent="doExport">
+      <label class="form-label">
+        <input v-model="expFiles" type="checkbox"> Include document files
+      </label>
+      <label class="form-label">
+        <input v-model="expEncrypt" type="checkbox"> Encrypt with passphrase
+      </label>
+      <label class="form-label">Passphrase
+        <input
+          v-model="expPass"
+          type="password"
+          class="form-input"
+          autocomplete="new-password"
+        >
+      </label>
+      <label class="form-label">Confirm passphrase
+        <input
+          v-model="expPassConfirm"
+          type="password"
+          class="form-input"
+          autocomplete="new-password"
+        >
+      </label>
+      <div class="form-actions">
+        <button type="button" class="btn btn-secondary" @click="showExport = false">Cancel</button>
+        <button type="submit" class="btn btn-primary">Export</button>
+      </div>
+    </form>
+  </BrainModal>
+
+  <!-- Import passphrase modal (brain.js:167-181) -->
+  <BrainModal v-model="showImportPass">
+    <div class="modal-header">
+      <h3>Enter Passphrase</h3>
+      <button class="btn-close" type="button" @click="showImportPass = false">
+        <BrainIcon name="Close" :size="16" />
+      </button>
+    </div>
+    <form @submit.prevent="doImport">
+      <p>Decrypting: <strong>{{ importFile?.name }}</strong></p>
+      <label class="form-label">Passphrase
+        <input
+          v-model="impPass"
+          type="password"
+          class="form-input"
+          autocomplete="current-password"
+        >
+      </label>
+      <div class="form-actions">
+        <button type="button" class="btn btn-secondary" @click="showImportPass = false">Cancel</button>
+        <button type="submit" class="btn btn-danger">Restore</button>
+      </div>
+    </form>
+  </BrainModal>
+
+  <!-- GitHub upload modal (brain.js:234-248) -->
+  <BrainModal v-model="showGhUpload">
+    <div class="modal-header">
+      <h3>Upload Backup to GitHub</h3>
+      <button class="btn-close" type="button" @click="showGhUpload = false">
+        <BrainIcon name="Close" :size="16" />
+      </button>
+    </div>
+    <form @submit.prevent="doGhUpload">
+      <p class="modal-desc">The backup will be encrypted and stored as a file in the repo.</p>
+      <label class="form-label">Encryption passphrase (optional)
+        <input
+          v-model="ghUploadPass"
+          type="password"
+          class="form-input"
+          autocomplete="new-password"
+        >
+      </label>
+      <div class="form-actions">
+        <button type="button" class="btn btn-secondary" @click="showGhUpload = false">Cancel</button>
+        <button type="submit" class="btn btn-primary">Upload</button>
+      </div>
+    </form>
+  </BrainModal>
 </template>

--- a/frontend/apps/brain/src/views/BrainView.vue
+++ b/frontend/apps/brain/src/views/BrainView.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.panelTitle = 'Brain'; shell.subTitle = ''; });
+</script>
+
+<template>
+  <div class="panel-header"><h2>Brain</h2></div>
+  <div class="panel-placeholder"><p>Brain panel — implementation in P2f.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/BrainView.vue
+++ b/frontend/apps/brain/src/views/BrainView.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.panelTitle = 'Brain'; shell.subTitle = ''; });
-</script>
-
 <template>
   <div class="panel-header"><h2>Brain</h2></div>
   <div class="panel-placeholder"><p>Brain panel — implementation in P2f.</p></div>

--- a/frontend/apps/brain/src/views/CapabilitiesView.vue
+++ b/frontend/apps/brain/src/views/CapabilitiesView.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.panelTitle = 'Capabilities'; shell.subTitle = ''; });
-</script>
-
 <template>
   <div class="panel-header"><h2>Capabilities</h2></div>
   <div class="panel-placeholder"><p>Capabilities panel — implementation in P2d.</p></div>

--- a/frontend/apps/brain/src/views/CapabilitiesView.vue
+++ b/frontend/apps/brain/src/views/CapabilitiesView.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.panelTitle = 'Capabilities'; shell.subTitle = ''; });
+</script>
+
+<template>
+  <div class="panel-header"><h2>Capabilities</h2></div>
+  <div class="panel-placeholder"><p>Capabilities panel — implementation in P2d.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/CapabilitiesView.vue
+++ b/frontend/apps/brain/src/views/CapabilitiesView.vue
@@ -1,4 +1,219 @@
+<script setup lang="ts">
+import { ref, reactive, computed, onMounted } from 'vue';
+import { capabilities } from '../api/capabilities';
+import type { Capability, CapabilityField } from '../api/capabilities';
+import { apiErrorMessage } from '../api/http';
+import { HttpError } from '@chalie/shared';
+import { useToast } from '../composables/useToast';
+import BrainIcon from '../ui/BrainIcon.vue';
+
+const { show: showToast } = useToast();
+
+const caps = ref<Capability[]>([]);
+const loading = ref(true);
+const viewMode = ref<'list' | 'form'>('list');
+const formCap = ref<Capability | null>(null);
+const formConnected = ref(false);
+const textValues = reactive<Record<string, string>>({});
+const boolValues = reactive<Record<string, boolean>>({});
+
+function isConnected(c: Capability): boolean {
+  return !!(c.connected || c.status === 'connected');
+}
+
+const formFields = computed<CapabilityField[]>(() => formCap.value?.fields ?? []);
+
+function isVisible(f: CapabilityField): boolean {
+  return (
+    !f.show_when ||
+    Object.entries(f.show_when).every(([k, v]) => textValues[k] === v)
+  );
+}
+
+async function load(): Promise<void> {
+  loading.value = true;
+  try {
+    caps.value = (await capabilities.list()).capabilities ?? [];
+  } catch {
+    showToast('Failed to load capabilities', 'error');
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function openForm(c: Capability): Promise<void> {
+  formCap.value = c;
+  formConnected.value = isConnected(c);
+
+  let config: Record<string, unknown> = {};
+  if (formConnected.value) {
+    try {
+      const d = await capabilities.get(c.id);
+      config = (d.config ?? d.settings ?? d ?? {}) as Record<string, unknown>;
+    } catch {
+      // swallow — empty config
+    }
+  }
+
+  // Stale-guard: a newer openForm() may have superseded this one during the await above.
+  if (formCap.value !== c) return;
+
+  // Clear both records
+  for (const key of Object.keys(textValues)) delete textValues[key];
+  for (const key of Object.keys(boolValues)) delete boolValues[key];
+
+  // Seed per field
+  for (const f of c.fields ?? []) {
+    if (f.type === 'checkbox') {
+      boolValues[f.name] =
+        config[f.name] !== undefined ? !!config[f.name] : !!f.default;
+    } else if (f.type === 'password') {
+      textValues[f.name] = '';
+    } else {
+      textValues[f.name] = String(config[f.name] ?? f.default ?? '');
+    }
+  }
+
+  viewMode.value = 'form';
+}
+
+async function submit(): Promise<void> {
+  if (!formCap.value) return;
+  const body: Record<string, unknown> = {};
+  for (const f of formFields.value) {
+    body[f.name] =
+      f.type === 'checkbox' ? !!boolValues[f.name] : (textValues[f.name] ?? '').trim();
+  }
+  try {
+    await capabilities.setup(formCap.value.id, body);
+    showToast(formConnected.value ? 'Settings saved' : 'Capability connected', 'success');
+    viewMode.value = 'list';
+    await load();
+  } catch (e) {
+    showToast(apiErrorMessage(e, 'Setup failed'), 'error');
+  }
+}
+
+async function disconnect(c: Capability): Promise<void> {
+  try {
+    await capabilities.disconnect(c.id);
+    showToast('Capability disconnected', 'success');
+    await load();
+  } catch (e) {
+    showToast(e instanceof HttpError ? 'Failed to disconnect' : 'Network error', 'error');
+  }
+}
+
+onMounted(load);
+</script>
+
 <template>
-  <div class="panel-header"><h2>Capabilities</h2></div>
-  <div class="panel-placeholder"><p>Capabilities panel — implementation in P2d.</p></div>
+  <div class="panel-header">
+    <h2>Capabilities</h2>
+  </div>
+
+  <div v-if="loading" class="loading">Loading…</div>
+
+  <template v-else-if="viewMode === 'form' && formCap">
+    <div class="provider-form-page">
+      <div class="form-page-header">
+        <button class="btn btn-secondary btn-sm back-btn" @click="viewMode = 'list'">
+          <BrainIcon name="Chevron" :size="14" /> Back
+        </button>
+        <h3>{{ formCap.name }} {{ formConnected ? 'Settings' : 'Setup' }}</h3>
+      </div>
+      <form @submit.prevent="submit">
+        <template v-for="f in formFields" :key="f.name">
+          <!-- checkbox -->
+          <div v-if="f.type === 'checkbox'" class="form-group">
+            <label class="switch-label">
+              <label class="switch">
+                <input v-model="boolValues[f.name]" type="checkbox">
+                <span class="switch-track"></span>
+              </label>
+              <span>{{ f.label }}</span>
+            </label>
+          </div>
+
+          <!-- select -->
+          <div v-else-if="f.type === 'select'" class="form-group">
+            <label>{{ f.label }}</label>
+            <div class="tab-select">
+              <button
+                v-for="o in f.options"
+                :key="o.value"
+                type="button"
+                class="tab-btn"
+                :class="{ active: textValues[f.name] === o.value }"
+                @click="textValues[f.name] = o.value"
+              >{{ o.label }}</button>
+            </div>
+          </div>
+
+          <!-- textarea -->
+          <div v-else-if="f.type === 'textarea'" class="form-group">
+            <label>{{ f.label }}</label>
+            <textarea
+              v-model="textValues[f.name]"
+              rows="4"
+              :placeholder="f.placeholder ?? ''"
+            ></textarea>
+          </div>
+
+          <!-- text / password -->
+          <div
+            v-else
+            v-show="isVisible(f)"
+            class="form-group"
+          >
+            <label>{{ f.label }}</label>
+            <input
+              v-model="textValues[f.name]"
+              :type="f.type === 'password' ? 'password' : 'text'"
+              :placeholder="f.placeholder ?? ''"
+              :required="!!(f.required && !formConnected)"
+            >
+          </div>
+        </template>
+
+        <div class="form-actions">
+          <button type="button" class="btn btn-secondary" @click="viewMode = 'list'">Cancel</button>
+          <button type="submit" class="btn btn-primary">{{ formConnected ? 'Save' : 'Connect' }}</button>
+        </div>
+      </form>
+    </div>
+  </template>
+
+  <div v-else-if="caps.length === 0" class="empty-state">
+    <div class="empty-icon">
+      <BrainIcon name="Capability" :size="40" />
+    </div>
+    <h3>No capabilities</h3>
+    <p>No services are configured yet.</p>
+  </div>
+
+  <div v-else class="caps-grid">
+    <div
+      v-for="c in caps"
+      :key="c.id"
+      class="cap-card"
+      :class="{ connected: isConnected(c) }"
+    >
+      <div class="cap-header">
+        <div class="cap-name">{{ c.name }}</div>
+        <span class="status-dot" :class="{ active: isConnected(c) }"></span>
+      </div>
+      <div class="cap-meta">{{ c.platform || '' }}</div>
+      <div v-if="c.version" class="cap-version">{{ c.version }}</div>
+      <div class="cap-actions">
+        <template v-if="isConnected(c)">
+          <button class="btn btn-sm btn-secondary" @click="openForm(c)">Edit</button>
+          <button class="btn btn-sm btn-danger" @click="disconnect(c)">Disconnect</button>
+        </template>
+        <template v-else>
+          <button class="btn btn-sm btn-primary" @click="openForm(c)">Setup</button>
+        </template>
+      </div>
+    </div>
+  </div>
 </template>

--- a/frontend/apps/brain/src/views/CognitionView.vue
+++ b/frontend/apps/brain/src/views/CognitionView.vue
@@ -1,10 +1,5 @@
 <script setup lang="ts">
 import { RouterView } from 'vue-router';
-import { onMounted } from 'vue';
-import { useShellStore } from '../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.panelTitle = 'Cognition'; });
 </script>
 
 <template>

--- a/frontend/apps/brain/src/views/CognitionView.vue
+++ b/frontend/apps/brain/src/views/CognitionView.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { RouterView } from 'vue-router';
+import { onMounted } from 'vue';
+import { useShellStore } from '../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.panelTitle = 'Cognition'; });
+</script>
+
+<template>
+  <div class="panel-header"><h2>Cognition</h2></div>
+  <RouterView />
+</template>

--- a/frontend/apps/brain/src/views/DocumentsView.vue
+++ b/frontend/apps/brain/src/views/DocumentsView.vue
@@ -1,10 +1,5 @@
 <script setup lang="ts">
 import { RouterView } from 'vue-router';
-import { onMounted } from 'vue';
-import { useShellStore } from '../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.panelTitle = 'Documents'; });
 </script>
 
 <template>

--- a/frontend/apps/brain/src/views/DocumentsView.vue
+++ b/frontend/apps/brain/src/views/DocumentsView.vue
@@ -2,7 +2,4 @@
 import { RouterView } from 'vue-router';
 </script>
 
-<template>
-  <div class="panel-header"><h2>Documents</h2></div>
-  <RouterView />
-</template>
+<template><RouterView /></template>

--- a/frontend/apps/brain/src/views/DocumentsView.vue
+++ b/frontend/apps/brain/src/views/DocumentsView.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { RouterView } from 'vue-router';
+import { onMounted } from 'vue';
+import { useShellStore } from '../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.panelTitle = 'Documents'; });
+</script>
+
+<template>
+  <div class="panel-header"><h2>Documents</h2></div>
+  <RouterView />
+</template>

--- a/frontend/apps/brain/src/views/ListsView.vue
+++ b/frontend/apps/brain/src/views/ListsView.vue
@@ -1,4 +1,268 @@
+<script setup lang="ts">
+import { ref, reactive, onMounted } from 'vue';
+import { lists as listsApi } from '../api/lists';
+import type { List, ListItem } from '../api/lists';
+import { useToast } from '../composables/useToast';
+import { useConfirm } from '../composables/useConfirm';
+import BrainModal from '../ui/BrainModal.vue';
+import BrainIcon from '../ui/BrainIcon.vue';
+import { HttpError } from '@chalie/shared';
+
+const { show: showToast } = useToast();
+const { confirm } = useConfirm();
+
+const listsData = ref<List[]>([]);
+const loading = ref(true);
+const expanded = reactive<Record<string, boolean>>({});
+
+// Modal state
+const showNew = ref(false);
+const newListName = ref('');
+const showRename = ref(false);
+const renameName = ref('');
+const renameId = ref<string | number>('');
+
+// --- counts helper (legacy lists.js:48-51) ---
+function counts(list: List): { done: number; total: number; pct: number } {
+  const items = list.items ?? [];
+  const done = list.items ? items.filter((i) => i.checked).length : (list.checked_count ?? 0);
+  const total = list.items ? items.length : (list.item_count ?? 0);
+  const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+  return { done, total, pct };
+}
+
+// --- load (legacy lists.js:28-37) ---
+async function load(): Promise<void> {
+  loading.value = true;
+  try {
+    const d = await listsApi.list();
+    listsData.value = d.items ?? [];
+  } catch {
+    showToast('Failed to load lists', 'error');
+  } finally {
+    loading.value = false;
+  }
+}
+
+// --- fetchListDetail (legacy lists.js:113-123) ---
+async function fetchListDetail(list: List): Promise<void> {
+  try {
+    const d = await listsApi.get(list.id);
+    list.items = d.item.items ?? [];
+  } catch {
+    showToast('Failed to load list items', 'error');
+  }
+}
+
+// --- toggle expand/collapse (legacy lists.js:79-87) ---
+function toggle(list: List): void {
+  const id = String(list.id);
+  expanded[id] = !expanded[id];
+  if (expanded[id]) fetchListDetail(list);
+}
+
+// --- toggleItem (legacy lists.js:125-136) ---
+async function toggleItem(list: List, item: ListItem, checked: boolean): Promise<void> {
+  const endpoint = checked ? 'check' : 'uncheck';
+  try {
+    await listsApi.toggleItem(list.id, endpoint, { content: item.content });
+    item.checked = checked;
+  } catch {
+    showToast('Failed to update item', 'error');
+  }
+}
+
+// --- onAddKey handler (legacy lists.js:96-103) ---
+function onAddKey(e: KeyboardEvent, list: List): void {
+  const input = e.target as HTMLInputElement;
+  const value = input.value.trim();
+  if (value) {
+    addItem(list, value);
+    input.value = '';
+  }
+}
+
+// --- addItem (legacy lists.js:138-143) ---
+async function addItem(list: List, text: string): Promise<void> {
+  try {
+    await listsApi.addItems(list.id, [text]);
+    await fetchListDetail(list);
+  } catch (e) {
+    // mirrors legacy lists.js:138-143 — silent on non-ok, toast on network error
+    if (!(e instanceof HttpError)) showToast('Failed to add item', 'error');
+  }
+}
+
+// --- openRename (legacy lists.js:169-192) ---
+function openRename(list: List): void {
+  renameId.value = list.id;
+  renameName.value = list.name;
+  showRename.value = true;
+}
+
+// --- createList (legacy lists.js:159-166) ---
+async function createList(): Promise<void> {
+  try {
+    await listsApi.create(newListName.value.trim());
+    showNew.value = false;
+    showToast('List created', 'success');
+    await load();
+  } catch (e) {
+    showToast(e instanceof HttpError ? 'Failed to create list' : 'Network error', 'error');
+  }
+}
+
+// --- renameList (legacy lists.js:184-191) ---
+async function renameList(): Promise<void> {
+  try {
+    await listsApi.rename(renameId.value, renameName.value.trim());
+    showRename.value = false;
+    showToast('List renamed', 'success');
+    await load();
+  } catch (e) {
+    showToast(e instanceof HttpError ? 'Failed to rename' : 'Network error', 'error');
+  }
+}
+
+// --- deleteList (legacy lists.js:194-213) ---
+async function deleteList(list: List): Promise<void> {
+  const ok = await confirm({
+    title: 'Delete List',
+    desc: 'Delete "' + list.name + '"?',
+    confirmLabel: 'Delete',
+    confirmClass: 'btn-danger',
+  });
+  if (!ok) return;
+  try {
+    await listsApi.delete(list.id);
+    showToast('List deleted', 'success');
+    await load();
+  } catch (e) {
+    showToast(e instanceof HttpError ? 'Delete failed' : 'Network error', 'error');
+  }
+}
+
+onMounted(load);
+</script>
+
 <template>
-  <div class="panel-header"><h2>Lists</h2></div>
-  <div class="panel-placeholder"><p>Lists panel — implementation in P2c.</p></div>
+  <!-- Header (legacy lists.js:17-20) -->
+  <div class="panel-header">
+    <h2>Lists</h2>
+    <button class="btn btn-primary" @click="showNew = true; newListName = ''">
+      <BrainIcon name="Plus" :size="14" /> New List
+    </button>
+  </div>
+
+  <!-- Loading state -->
+  <div v-if="loading" class="loading">Loading…</div>
+
+  <!-- Empty state (legacy lists.js:43, VisionView inline pattern) -->
+  <div v-else-if="listsData.length === 0" class="empty-state">
+    <div class="empty-icon">
+      <BrainIcon name="List" :size="40" />
+    </div>
+    <h3>No lists</h3>
+    <p>Create your first list to get started.</p>
+  </div>
+
+  <!-- List cards (legacy lists.js:47-77) -->
+  <template v-else>
+    <div v-for="list in listsData" :key="list.id" class="list-card">
+      <div class="list-card-header" @click="toggle(list)">
+        <div class="list-card-title">
+          <span class="list-chev">
+            <BrainIcon :name="expanded[String(list.id)] ? 'ChevronDown' : 'Chevron'" :size="14" />
+          </span>
+          <span>{{ list.name }}</span>
+          <span class="list-count">{{ counts(list).done }}/{{ counts(list).total }}</span>
+        </div>
+        <div class="list-card-actions">
+          <button class="btn btn-sm btn-secondary" @click.stop="openRename(list)">Rename</button>
+          <button class="btn btn-sm btn-danger" @click.stop="deleteList(list)">Delete</button>
+        </div>
+      </div>
+
+      <div v-if="counts(list).total > 0" class="progress-bar">
+        <div class="progress-fill" :style="{ width: counts(list).pct + '%' }"></div>
+      </div>
+
+      <div v-if="expanded[String(list.id)]" class="list-items">
+        <label
+          v-for="item in list.items ?? []"
+          :key="item.id"
+          class="list-item"
+        >
+          <input
+            type="checkbox"
+            :checked="item.checked"
+            @change="toggleItem(list, item, ($event.target as HTMLInputElement).checked)"
+          >
+          <span :class="{ done: item.checked }">{{ item.content }}</span>
+        </label>
+        <div class="list-add-row">
+          <input
+            type="text"
+            class="list-add-input"
+            placeholder="Add item…"
+            maxlength="300"
+            @keydown.enter="onAddKey($event, list)"
+          >
+        </div>
+      </div>
+    </div>
+  </template>
+
+  <!-- Create list modal (legacy lists.js:145-167) -->
+  <BrainModal v-model="showNew" size="sm">
+    <div class="modal-header">
+      <h3>New List</h3>
+      <button class="btn-close" @click="showNew = false">
+        <BrainIcon name="Close" :size="16" />
+      </button>
+    </div>
+    <form @submit.prevent="createList">
+      <div class="form-group">
+        <label for="newListName">List Name</label>
+        <input
+          id="newListName"
+          v-model="newListName"
+          type="text"
+          maxlength="200"
+          placeholder="e.g. Shopping List"
+          required
+        >
+      </div>
+      <div class="form-actions">
+        <button type="button" class="btn btn-secondary" @click="showNew = false">Cancel</button>
+        <button type="submit" class="btn btn-primary">Create</button>
+      </div>
+    </form>
+  </BrainModal>
+
+  <!-- Rename list modal (legacy lists.js:169-192) -->
+  <BrainModal v-model="showRename" size="sm">
+    <div class="modal-header">
+      <h3>Rename List</h3>
+      <button class="btn-close" @click="showRename = false">
+        <BrainIcon name="Close" :size="16" />
+      </button>
+    </div>
+    <form @submit.prevent="renameList">
+      <div class="form-group">
+        <label for="renameInput">New Name</label>
+        <input
+          id="renameInput"
+          v-model="renameName"
+          type="text"
+          maxlength="200"
+          required
+        >
+      </div>
+      <div class="form-actions">
+        <button type="button" class="btn btn-secondary" @click="showRename = false">Cancel</button>
+        <button type="submit" class="btn btn-primary">Rename</button>
+      </div>
+    </form>
+  </BrainModal>
 </template>

--- a/frontend/apps/brain/src/views/ListsView.vue
+++ b/frontend/apps/brain/src/views/ListsView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, reactive, onMounted } from 'vue';
+import { ref, reactive, computed, onMounted } from 'vue';
 import { lists as listsApi } from '../api/lists';
 import type { List, ListItem } from '../api/lists';
 import { useToast } from '../composables/useToast';
@@ -20,7 +20,7 @@ const showNew = ref(false);
 const newListName = ref('');
 const showRename = ref(false);
 const renameName = ref('');
-const renameId = ref<string | number>('');
+const renameId = ref<string | number | null>(null);
 
 // --- counts helper (legacy lists.js:48-51) ---
 function counts(list: List): { done: number; total: number; pct: number } {
@@ -30,6 +30,10 @@ function counts(list: List): { done: number; total: number; pct: number } {
   const pct = total > 0 ? Math.round((done / total) * 100) : 0;
   return { done, total, pct };
 }
+
+// Decorate each list with its counts once per render pass (the `list` object is the
+// same reference held in listsData, so toggle/fetchListDetail mutations still apply).
+const decoratedLists = computed(() => listsData.value.map((list) => ({ list, c: counts(list) })));
 
 // --- load (legacy lists.js:28-37) ---
 async function load(): Promise<void> {
@@ -114,6 +118,7 @@ async function createList(): Promise<void> {
 
 // --- renameList (legacy lists.js:184-191) ---
 async function renameList(): Promise<void> {
+  if (renameId.value == null) return;
   try {
     await listsApi.rename(renameId.value, renameName.value.trim());
     showRename.value = false;
@@ -168,14 +173,14 @@ onMounted(load);
 
   <!-- List cards (legacy lists.js:47-77) -->
   <template v-else>
-    <div v-for="list in listsData" :key="list.id" class="list-card">
+    <div v-for="{ list, c } in decoratedLists" :key="list.id" class="list-card">
       <div class="list-card-header" @click="toggle(list)">
         <div class="list-card-title">
           <span class="list-chev">
             <BrainIcon :name="expanded[String(list.id)] ? 'ChevronDown' : 'Chevron'" :size="14" />
           </span>
           <span>{{ list.name }}</span>
-          <span class="list-count">{{ counts(list).done }}/{{ counts(list).total }}</span>
+          <span class="list-count">{{ c.done }}/{{ c.total }}</span>
         </div>
         <div class="list-card-actions">
           <button class="btn btn-sm btn-secondary" @click.stop="openRename(list)">Rename</button>
@@ -183,8 +188,8 @@ onMounted(load);
         </div>
       </div>
 
-      <div v-if="counts(list).total > 0" class="progress-bar">
-        <div class="progress-fill" :style="{ width: counts(list).pct + '%' }"></div>
+      <div v-if="c.total > 0" class="progress-bar">
+        <div class="progress-fill" :style="{ width: c.pct + '%' }"></div>
       </div>
 
       <div v-if="expanded[String(list.id)]" class="list-items">

--- a/frontend/apps/brain/src/views/ListsView.vue
+++ b/frontend/apps/brain/src/views/ListsView.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.panelTitle = 'Lists'; shell.subTitle = ''; });
+</script>
+
+<template>
+  <div class="panel-header"><h2>Lists</h2></div>
+  <div class="panel-placeholder"><p>Lists panel — implementation in P2c.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/ListsView.vue
+++ b/frontend/apps/brain/src/views/ListsView.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.panelTitle = 'Lists'; shell.subTitle = ''; });
-</script>
-
 <template>
   <div class="panel-header"><h2>Lists</h2></div>
   <div class="panel-placeholder"><p>Lists panel — implementation in P2c.</p></div>

--- a/frontend/apps/brain/src/views/McpView.vue
+++ b/frontend/apps/brain/src/views/McpView.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.panelTitle = 'MCP'; shell.subTitle = ''; });
+</script>
+
+<template>
+  <div class="panel-header"><h2>MCP</h2></div>
+  <div class="panel-placeholder"><p>MCP panel — implementation in P2f.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/McpView.vue
+++ b/frontend/apps/brain/src/views/McpView.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.panelTitle = 'MCP'; shell.subTitle = ''; });
-</script>
-
 <template>
   <div class="panel-header"><h2>MCP</h2></div>
   <div class="panel-placeholder"><p>MCP panel — implementation in P2f.</p></div>

--- a/frontend/apps/brain/src/views/McpView.vue
+++ b/frontend/apps/brain/src/views/McpView.vue
@@ -1,4 +1,486 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { mcp } from '../api/mcp';
+import type { McpClient, McpServerConfig } from '../api/mcp';
+import { apiErrorMessage } from '../api/http';
+import { HttpError } from '@chalie/shared';
+import { useToast } from '../composables/useToast';
+import { useConfirm } from '../composables/useConfirm';
+import BrainIcon from '../ui/BrainIcon.vue';
+
+const { show: showToast } = useToast();
+const { confirm } = useConfirm();
+
+// ── Inbound state ─────────────────────────────────────────────────────────
+const inConfig = ref<McpServerConfig>({});
+const inPort = ref<number>(8462);
+const loadingInbound = ref(true);
+
+// ── Outbound state ────────────────────────────────────────────────────────
+const outServers = ref<McpClient[]>([]);
+const editingId = ref<string | number | null>(null);
+const loadingOutbound = ref(true);
+
+// Add-form state
+const addEnabled = ref(true);
+const addName = ref('');
+const addHost = ref('');
+const addHeaders = ref<{ key: string; value: string }[]>([]);
+
+// Edit-form state
+const editEnabled = ref(true);
+const editName = ref('');
+const editHost = ref('');
+const editHeaders = ref<{ key: string; value: string }[]>([]);
+
+// ── Inbound ───────────────────────────────────────────────────────────────
+
+async function loadInbound(): Promise<void> {
+  try {
+    const data = await mcp.getServerConfig();
+    inConfig.value = data;
+    inPort.value = (data.port as number) || 8462;
+  } catch {
+    showToast('Failed to load MCP inbound settings', 'error');
+  } finally {
+    loadingInbound.value = false;
+  }
+}
+
+async function saveInbound(updates: Partial<McpServerConfig>): Promise<void> {
+  try {
+    await mcp.updateServerConfig(updates);
+    Object.assign(inConfig.value, updates);
+    showToast('Settings saved', 'success');
+  } catch (e) {
+    showToast(e instanceof HttpError ? 'Save failed' : 'Network error', 'error');
+  }
+}
+
+function onEnabledChange(e: Event): void {
+  const checked = (e.target as HTMLInputElement).checked;
+  saveInbound({ enabled: checked });
+}
+
+function onPortBlur(): void {
+  const val = inPort.value;
+  if (val >= 1024 && val <= 65535 && val !== inConfig.value.port) {
+    saveInbound({ port: val });
+  }
+}
+
+async function copyToken(): Promise<void> {
+  try {
+    await navigator.clipboard.writeText((inConfig.value.token as string) || '');
+    showToast('Token copied', 'success');
+  } catch {
+    showToast('Copy failed', 'error');
+  }
+}
+
+async function regenToken(): Promise<void> {
+  try {
+    const data = await mcp.regenerateToken();
+    inConfig.value = { ...inConfig.value, token: data.token };
+    showToast('Token regenerated', 'success');
+  } catch (e) {
+    showToast(e instanceof HttpError ? 'Regenerate failed' : 'Network error', 'error');
+  }
+}
+
+// ── Outbound ──────────────────────────────────────────────────────────────
+
+async function loadOutbound(): Promise<void> {
+  try {
+    outServers.value = await mcp.listClients();
+  } catch {
+    showToast('Failed to load MCP outbound servers', 'error');
+    outServers.value = [];
+  } finally {
+    loadingOutbound.value = false;
+  }
+}
+
+function addHeaderRow(list: { key: string; value: string }[]): void {
+  list.push({ key: '', value: '' });
+}
+
+function removeHeaderRow(list: { key: string; value: string }[], idx: number): void {
+  list.splice(idx, 1);
+}
+
+function collectHeaders(list: { key: string; value: string }[]): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const row of list) {
+    const k = row.key.trim();
+    const v = row.value.trim();
+    if (k) headers[k] = v;
+  }
+  return headers;
+}
+
+async function addServer(): Promise<void> {
+  const name = addName.value.trim();
+  const host = addHost.value.trim();
+  const enabled = addEnabled.value;
+  const headers = collectHeaders(addHeaders.value);
+
+  if (!name) { showToast('Name is required', 'error'); return; }
+  if (!host) { showToast('Host is required', 'error'); return; }
+
+  try {
+    await mcp.createClient({ name, host, headers, enabled });
+    showToast(`Server "${name}" added`, 'success');
+    addName.value = '';
+    addHost.value = '';
+    addEnabled.value = true;
+    addHeaders.value = [];
+    await loadOutbound();
+  } catch (e) {
+    showToast(apiErrorMessage(e, 'Failed to add server'), 'error');
+  }
+}
+
+function startEdit(server: McpClient): void {
+  editingId.value = server.id;
+  editEnabled.value = server.enabled !== false;
+  editName.value = server.name;
+  editHost.value = server.host;
+  const raw = server.headers;
+  editHeaders.value = raw
+    ? Object.entries(raw).map(([k, v]) => ({ key: k, value: String(v) }))
+    : [];
+}
+
+function cancelEdit(): void {
+  editingId.value = null;
+}
+
+async function saveEdit(id: string | number): Promise<void> {
+  const name = editName.value.trim();
+  const host = editHost.value.trim();
+  const enabled = editEnabled.value;
+  const headers = collectHeaders(editHeaders.value);
+
+  if (!name) { showToast('Name is required', 'error'); return; }
+  if (!host) { showToast('Host is required', 'error'); return; }
+
+  try {
+    await mcp.updateClient(id, { name, host, headers, enabled });
+    showToast(`Server "${name}" updated`, 'success');
+    editingId.value = null;
+    await testServer(id, true);
+  } catch (e) {
+    showToast(apiErrorMessage(e, 'Failed to update server'), 'error');
+  }
+}
+
+async function testServer(id: string | number, silent = false): Promise<void> {
+  try {
+    const data = await mcp.testClient(id);
+    if (!silent) {
+      const msg = data.reachable
+        ? `Online — ${data.tool_count} tool(s) synced`
+        : `Offline (${data.status})`;
+      showToast(msg, data.reachable ? 'success' : 'error');
+    }
+  } catch (e) {
+    if (!silent) showToast(e instanceof HttpError ? 'Test request failed' : 'Network error', 'error');
+  } finally {
+    await loadOutbound();
+  }
+}
+
+async function toggleServer(server: McpClient): Promise<void> {
+  const enabled = !server.enabled;
+  try {
+    await mcp.updateClient(server.id, { enabled });
+    showToast(enabled ? 'Server enabled' : 'Server disabled', 'success');
+    await loadOutbound();
+  } catch (e) {
+    showToast(e instanceof HttpError ? 'Update failed' : 'Network error', 'error');
+  }
+}
+
+async function deleteServer(server: McpClient): Promise<void> {
+  const ok = await confirm({
+    title: 'Delete MCP Server',
+    desc: 'Delete this MCP server connection? This will remove its tools and policy rows.',
+    confirmLabel: 'Delete',
+    confirmClass: 'btn-danger',
+  });
+  if (!ok) return;
+  try {
+    await mcp.deleteClient(server.id);
+    showToast('Server deleted', 'success');
+    await loadOutbound();
+  } catch (e) {
+    showToast(e instanceof HttpError ? 'Delete failed' : 'Network error', 'error');
+  }
+}
+
+onMounted(async () => {
+  await Promise.all([loadInbound(), loadOutbound()]);
+});
+</script>
+
 <template>
-  <div class="panel-header"><h2>MCP</h2></div>
-  <div class="panel-placeholder"><p>MCP panel — implementation in P2f.</p></div>
+  <div class="panel-header">
+    <h2>MCP</h2>
+  </div>
+
+  <!-- ── Inbound section ─────────────────────────────────────────────── -->
+  <section class="mcp-section">
+    <h3 class="mcp-section-title">Inbound</h3>
+    <p class="panel-desc">
+      External agents (Claude Code, Codex, CI bots) connect to Chalie via MCP.
+      Manage access and view the connection token below.
+    </p>
+
+    <div v-if="loadingInbound" class="loading">Loading…</div>
+
+    <div v-else class="mcp-settings">
+      <div class="mcp-row">
+        <label class="mcp-label">Server Enabled</label>
+        <label class="switch">
+          <input
+            type="checkbox"
+            :checked="inConfig.enabled !== false"
+            @change="onEnabledChange"
+          >
+          <span class="switch-track"></span>
+        </label>
+      </div>
+
+      <div class="form-group">
+        <label for="mcpPort">Port</label>
+        <div class="input-group">
+          <span class="input-prefix">TCP</span>
+          <input
+            id="mcpPort"
+            v-model.number="inPort"
+            type="number"
+            min="1024"
+            max="65535"
+            @blur="onPortBlur"
+          >
+        </div>
+      </div>
+
+      <div class="mcp-token-section">
+        <h4>Connection Token</h4>
+        <p class="mcp-hint">Give this token to external agents so they can authenticate.</p>
+        <div class="input-group">
+          <input
+            type="text"
+            class="monospace"
+            :value="(inConfig.token as string) || ''"
+            readonly
+          >
+          <button class="input-suffix-btn" title="Copy" @click="copyToken">
+            <BrainIcon name="Copy" :size="14" />
+          </button>
+        </div>
+        <div style="margin-top:10px">
+          <button class="btn btn-sm btn-danger" @click="regenToken">Regenerate Token</button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Outbound section ────────────────────────────────────────────── -->
+  <section class="mcp-section" style="margin-top:28px">
+    <h3 class="mcp-section-title">Outbound</h3>
+    <p class="panel-desc">
+      Connect Chalie to remote MCP servers so their tools become available.
+      Chalie uses the streamable-HTTP transport.
+    </p>
+
+    <div v-if="loadingOutbound" class="loading">Loading…</div>
+
+    <template v-else>
+    <!-- Server cards -->
+    <template v-for="server in outServers" :key="server.id">
+      <!-- Edit mode -->
+      <div v-if="editingId === server.id" class="mcp-out-card mcp-out-card-editing">
+        <h4 class="mcp-out-add-title">Edit MCP Server</h4>
+
+        <div class="mcp-out-form-row">
+          <label class="mcp-label">Enabled</label>
+          <label class="switch">
+            <input
+              type="checkbox"
+              :checked="editEnabled"
+              @change="editEnabled = ($event.target as HTMLInputElement).checked"
+            >
+            <span class="switch-track"></span>
+          </label>
+        </div>
+
+        <div class="form-group">
+          <label for="mcpEditName">Name</label>
+          <input
+            id="mcpEditName"
+            v-model="editName"
+            type="text"
+            class="form-input"
+          >
+        </div>
+
+        <div class="form-group">
+          <label for="mcpEditHost">Host (incl. port)</label>
+          <input
+            id="mcpEditHost"
+            v-model="editHost"
+            type="text"
+            class="form-input"
+          >
+        </div>
+
+        <div class="form-group">
+          <label>Additional Headers</label>
+          <div class="mcp-headers-list">
+            <div
+              v-for="(row, idx) in editHeaders"
+              :key="idx"
+              class="mcp-header-row"
+            >
+              <input
+                v-model="row.key"
+                type="text"
+                placeholder="Header name"
+                class="form-input mcp-header-key"
+              >
+              <span class="mcp-header-sep">:</span>
+              <input
+                v-model="row.value"
+                type="text"
+                placeholder="Value"
+                class="form-input mcp-header-val"
+              >
+              <button
+                class="btn btn-xs btn-danger mcp-header-remove"
+                type="button"
+                @click="removeHeaderRow(editHeaders, idx)"
+              >✕</button>
+            </div>
+          </div>
+          <button
+            class="btn btn-xs btn-secondary"
+            type="button"
+            @click="addHeaderRow(editHeaders)"
+          >+ Header</button>
+        </div>
+
+        <div class="mcp-out-card-actions">
+          <button class="btn btn-primary" type="button" @click="saveEdit(server.id)">Save</button>
+          <button class="btn btn-secondary" type="button" @click="cancelEdit">Cancel</button>
+        </div>
+      </div>
+
+      <!-- Display mode -->
+      <div v-else class="mcp-out-card">
+        <div class="mcp-out-card-header">
+          <div>
+            <span class="mcp-out-name">{{ server.name }}</span>
+            <span class="mcp-out-host"> — {{ server.host }}</span>
+          </div>
+          <div class="mcp-out-badges">
+            <span :class="`badge badge-status badge-${server.status}`">{{ server.status }}</span>
+            <span :class="server.enabled ? 'badge badge-enabled' : 'badge badge-disabled'">
+              {{ server.enabled ? 'enabled' : 'disabled' }}
+            </span>
+          </div>
+        </div>
+        <div class="mcp-out-card-actions">
+          <button class="btn btn-xs btn-secondary" type="button" @click="startEdit(server)">Edit</button>
+          <button class="btn btn-xs btn-secondary" type="button" @click="testServer(server.id)">Test</button>
+          <button
+            class="btn btn-xs"
+            :class="server.enabled ? 'btn-secondary' : 'btn-primary'"
+            type="button"
+            @click="toggleServer(server)"
+          >{{ server.enabled ? 'Disable' : 'Enable' }}</button>
+          <button class="btn btn-xs btn-danger" type="button" @click="deleteServer(server)">Delete</button>
+        </div>
+      </div>
+    </template>
+
+    <!-- Add-server form -->
+    <div class="mcp-out-add-form">
+      <h4 class="mcp-out-add-title">Add Remote MCP Server</h4>
+
+      <div class="mcp-out-form-row">
+        <label class="mcp-label">Enabled</label>
+        <label class="switch">
+          <input
+            type="checkbox"
+            :checked="addEnabled"
+            @change="addEnabled = ($event.target as HTMLInputElement).checked"
+          >
+          <span class="switch-track"></span>
+        </label>
+      </div>
+
+      <div class="form-group">
+        <label for="mcpOutName">Name</label>
+        <input
+          id="mcpOutName"
+          v-model="addName"
+          type="text"
+          placeholder="e.g. taskie"
+          class="form-input"
+        >
+      </div>
+
+      <div class="form-group">
+        <label for="mcpOutHost">Host (incl. port)</label>
+        <input
+          id="mcpOutHost"
+          v-model="addHost"
+          type="text"
+          placeholder="https://mcp.example.com/mcp"
+          class="form-input"
+        >
+      </div>
+
+      <div class="form-group">
+        <label>Additional Headers</label>
+        <div class="mcp-headers-list">
+          <div
+            v-for="(row, idx) in addHeaders"
+            :key="idx"
+            class="mcp-header-row"
+          >
+            <input
+              v-model="row.key"
+              type="text"
+              placeholder="Header name"
+              class="form-input mcp-header-key"
+            >
+            <span class="mcp-header-sep">:</span>
+            <input
+              v-model="row.value"
+              type="text"
+              placeholder="Value"
+              class="form-input mcp-header-val"
+            >
+            <button
+              class="btn btn-xs btn-danger mcp-header-remove"
+              type="button"
+              @click="removeHeaderRow(addHeaders, idx)"
+            >✕</button>
+          </div>
+        </div>
+        <button
+          class="btn btn-xs btn-secondary"
+          type="button"
+          @click="addHeaderRow(addHeaders)"
+        >+ Header</button>
+      </div>
+
+      <button class="btn btn-primary" type="button" @click="addServer">Add Server</button>
+    </div>
+    </template>
+  </section>
 </template>

--- a/frontend/apps/brain/src/views/PoliciesView.vue
+++ b/frontend/apps/brain/src/views/PoliciesView.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { RouterView } from 'vue-router';
+import { onMounted } from 'vue';
+import { useShellStore } from '../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.panelTitle = 'Policies'; });
+</script>
+
+<template>
+  <div class="panel-header"><h2>Policies</h2></div>
+  <RouterView />
+</template>

--- a/frontend/apps/brain/src/views/PoliciesView.vue
+++ b/frontend/apps/brain/src/views/PoliciesView.vue
@@ -1,10 +1,5 @@
 <script setup lang="ts">
 import { RouterView } from 'vue-router';
-import { onMounted } from 'vue';
-import { useShellStore } from '../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.panelTitle = 'Policies'; });
 </script>
 
 <template>

--- a/frontend/apps/brain/src/views/PoliciesView.vue
+++ b/frontend/apps/brain/src/views/PoliciesView.vue
@@ -3,6 +3,5 @@ import { RouterView } from 'vue-router';
 </script>
 
 <template>
-  <div class="panel-header"><h2>Policies</h2></div>
   <RouterView />
 </template>

--- a/frontend/apps/brain/src/views/ProvidersView.vue
+++ b/frontend/apps/brain/src/views/ProvidersView.vue
@@ -1,8 +1,592 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, watch, onUnmounted } from 'vue';
+import { providers } from '../api/providers';
+import type { Provider, CatalogEntry } from '../api/providers';
+import { useToast } from '../composables/useToast';
+import { useConfirm } from '../composables/useConfirm';
+import { useShellStore } from '../stores/shell';
+import BrainIcon from '../ui/BrainIcon.vue';
+
+const { show: showToast } = useToast();
+const { confirm } = useConfirm();
+const shell = useShellStore();
+
+// ── List state ────────────────────────────────────────────────────
+const providerList = ref<Provider[]>([]);
+const selectedId = ref<number | null>(null);
+const loading = ref(true);
+
+// ── Catalog cache ─────────────────────────────────────────────────
+const catalog = ref<CatalogEntry[]>([]);
+const catalogLoaded = ref(false);
+
+// ── Wizard state ──────────────────────────────────────────────────
+// 'list' | 'picker' | 'form'
+const mode = ref<'list' | 'picker' | 'form'>('list');
+
+const CUSTOM_PRESET: CatalogEntry = {
+  id: 'custom',
+  name: 'Custom (OpenAI-compatible)',
+  platform: 'openai_compatible',
+  host: '',
+  needs_key: true,
+};
+
+const preset = ref<CatalogEntry | null>(null);
+const editingId = ref<number | null>(null);
+const editModel = ref('');
+
+// Form fields
+const formName = ref('');
+const formHost = ref('');
+const formKey = ref('');
+const formModel = ref('');
+
+// Model fetch state
+const models = ref<string[]>([]);
+const modelsFetchInFlight = ref(false);
+const modelStatus = ref('');
+const modelStatusClass = ref('');
+const lastFetchKey = ref('');
+let modelFetchTimer: ReturnType<typeof setTimeout> | null = null;
+
+const MODEL_FETCH_DEBOUNCE_MS = 600;
+
+// Test button state
+const testing = ref(false);
+
+// ── Computed helpers ──────────────────────────────────────────────
+const needsHost = computed(() =>
+  preset.value?.platform === 'ollama' || preset.value?.platform === 'openai_compatible',
+);
+
+const needsKey = computed(() => !!preset.value?.needs_key);
+
+const hostReady = computed(() => !needsHost.value || formHost.value.trim() !== '');
+
+const keyReady = computed(() => !needsKey.value || formKey.value.trim() !== '');
+
+const canFetch = computed(() => hostReady.value && keyReady.value);
+
+const showHostGroup = computed(() => needsHost.value);
+
+const showKeyGroup = computed(() => needsKey.value && hostReady.value);
+
+const showModelGroup = computed(() => canFetch.value || models.value.length > 0);
+
+const saveDisabled = computed(() => !formModel.value);
+
+const isEditing = computed(() => editingId.value !== null);
+
+// ── Catalog tiles ─────────────────────────────────────────────────
+const catalogTiles = computed(() => [...catalog.value, CUSTOM_PRESET]);
+
+function avatar(name: string): string {
+  const s = (name || '').trim();
+  return s ? s[0].toUpperCase() : '?';
+}
+
+// ── Mount ─────────────────────────────────────────────────────────
+onMounted(async () => {
+  await load();
+});
+
+onUnmounted(() => {
+  if (modelFetchTimer !== null) {
+    clearTimeout(modelFetchTimer);
+    modelFetchTimer = null;
+  }
+});
+
+async function load(): Promise<void> {
+  loading.value = true;
+  try {
+    const [provRes, selRes] = await Promise.all([
+      providers.list(),
+      providers.getSelected(),
+    ]);
+    providerList.value = provRes.providers ?? [];
+    selectedId.value = selRes.provider ? selRes.provider.id : null;
+  } catch {
+    showToast('Failed to connect to backend', 'error');
+  }
+  loading.value = false;
+}
+
+// ── Select provider ───────────────────────────────────────────────
+async function selectProvider(id: number): Promise<void> {
+  try {
+    await providers.setSelected(id);
+    selectedId.value = id;
+    showToast('Provider selected', 'success');
+  } catch (e: unknown) {
+    const err = e as { error?: string };
+    showToast(err.error || 'Failed', 'error');
+  }
+}
+
+// ── Delete provider ───────────────────────────────────────────────
+async function confirmDelete(id: number): Promise<void> {
+  const p = providerList.value.find((x) => x.id === id);
+  const name = p?.name || 'this provider';
+  const confirmed = await confirm({
+    title: 'Delete Provider',
+    desc: `Delete "${name}"? This cannot be undone.`,
+    confirmLabel: 'Delete',
+    confirmClass: 'btn-danger',
+  });
+  if (!confirmed) return;
+  try {
+    await providers.delete(id);
+    showToast('Provider deleted', 'success');
+    await load();
+  } catch (e: unknown) {
+    if (e && typeof e === 'object' && 'error' in e) {
+      showToast((e as { error?: string }).error || 'Delete failed', 'error');
+    } else {
+      showToast('Network error', 'error');
+    }
+  }
+}
+
+// ── Wizard: open ─────────────────────────────────────────────────
+async function openWizard(id: number | null): Promise<void> {
+  editingId.value = id;
+  editModel.value = '';
+  models.value = [];
+  lastFetchKey.value = '';
+  modelStatus.value = '';
+  modelStatusClass.value = '';
+  if (modelFetchTimer !== null) {
+    clearTimeout(modelFetchTimer);
+    modelFetchTimer = null;
+  }
+
+  await ensureCatalog();
+
+  if (id !== null) {
+    const p = providerList.value.find((x) => x.id === id);
+    if (!p) {
+      mode.value = 'list';
+      return;
+    }
+    editModel.value = p.model || '';
+    models.value = editModel.value ? [editModel.value] : [];
+    preset.value = presetFor(p);
+    formName.value = p.name;
+    formHost.value = p.host || '';
+    formKey.value = '';
+    formModel.value = editModel.value;
+    mode.value = 'form';
+    if (canFetch.value) {
+      void fetchModels();
+    }
+  } else {
+    preset.value = null;
+    formName.value = '';
+    formHost.value = '';
+    formKey.value = '';
+    formModel.value = '';
+    mode.value = 'picker';
+  }
+}
+
+function presetFor(provider: Provider): CatalogEntry {
+  const match = catalog.value.find(
+    (c) => c.platform === provider.platform && (c.host || '') === (provider.host || ''),
+  );
+  if (match) return match;
+  return {
+    id: 'edit',
+    name: provider.name,
+    platform: provider.platform,
+    host: provider.host || '',
+    needs_key: provider.platform !== 'ollama',
+  };
+}
+
+async function ensureCatalog(): Promise<void> {
+  if (catalogLoaded.value) return;
+  try {
+    const res = await providers.getCatalog();
+    catalog.value = Array.isArray(res.catalog) ? res.catalog : [];
+  } catch {
+    catalog.value = [];
+  }
+  catalogLoaded.value = true;
+}
+
+// ── Wizard: picker ────────────────────────────────────────────────
+function selectTile(p: CatalogEntry): void {
+  preset.value = { ...p };
+  editModel.value = '';
+  models.value = [];
+  lastFetchKey.value = '';
+  modelStatus.value = '';
+  modelStatusClass.value = '';
+  formName.value = p.name;
+  formHost.value = p.host || '';
+  formKey.value = '';
+  formModel.value = '';
+  mode.value = 'form';
+  if (canFetch.value) {
+    void fetchModels();
+  }
+}
+
+function backFromPicker(): void {
+  mode.value = 'list';
+}
+
+function backFromForm(): void {
+  if (isEditing.value) {
+    mode.value = 'list';
+  } else {
+    mode.value = 'picker';
+  }
+}
+
+function cancelForm(): void {
+  mode.value = 'list';
+}
+
+// ── Progressive reveal: watch creds inputs ────────────────────────
+watch([() => formHost.value, () => formKey.value], () => {
+  if (mode.value !== 'form') return;
+  debouncedFetchModels();
+});
+
+// ── Model fetch ───────────────────────────────────────────────────
+function debouncedFetchModels(): void {
+  if (modelFetchTimer !== null) {
+    clearTimeout(modelFetchTimer);
+  }
+  modelFetchTimer = setTimeout(() => {
+    if (canFetch.value) void fetchModels();
+  }, MODEL_FETCH_DEBOUNCE_MS);
+}
+
+async function fetchModels(): Promise<void> {
+  if (modelsFetchInFlight.value || !preset.value) return;
+
+  const creds: { host?: string; api_key?: string } = {};
+  if (needsHost.value) creds.host = formHost.value.trim();
+  if (needsKey.value) creds.api_key = formKey.value.trim();
+
+  const fetchKey = `${preset.value.platform}|${creds.host || ''}|${creds.api_key ? 'k' : ''}`;
+  if (fetchKey === lastFetchKey.value && models.value.length > 0) return;
+  lastFetchKey.value = fetchKey;
+
+  modelsFetchInFlight.value = true;
+  modelStatus.value = 'Loading models…';
+  modelStatusClass.value = 'model-status loading';
+
+  try {
+    const data = await providers.listModels({ platform: preset.value.platform, ...creds });
+    const fetched = (data.models ?? [])
+      .map((m) => (typeof m === 'string' ? m : m?.id || ''))
+      .filter(Boolean);
+    models.value = fetched;
+
+    // Preserve the editModel selection: append it as an extra option if not in the fetched list
+    if (editModel.value && !models.value.includes(editModel.value)) {
+      models.value = [...models.value, editModel.value];
+    }
+
+    // Restore the previously-selected model if it's in the new list
+    if (editModel.value && models.value.includes(editModel.value)) {
+      formModel.value = editModel.value;
+    } else if (formModel.value && !models.value.includes(formModel.value)) {
+      formModel.value = '';
+    }
+
+    const n = models.value.length;
+    modelStatus.value = `${n} model${n === 1 ? '' : 's'}`;
+    modelStatusClass.value = 'model-status ok';
+  } catch (e: unknown) {
+    if (e && typeof e === 'object' && 'error' in e) {
+      modelStatus.value = (e as { error?: string }).error || 'Failed to fetch models';
+    } else {
+      modelStatus.value = 'Network error';
+    }
+    modelStatusClass.value = 'model-status err';
+    lastFetchKey.value = ''; // allow retry
+  }
+  modelsFetchInFlight.value = false;
+}
+
+// ── Test connection ───────────────────────────────────────────────
+async function testConnection(): Promise<void> {
+  if (!preset.value) return;
+  testing.value = true;
+  try {
+    const body: {
+      platform: string;
+      name: string;
+      model: string;
+      host?: string;
+      api_key?: string;
+      provider_id?: number;
+    } = {
+      platform: preset.value.platform,
+      name: formName.value.trim(),
+      model: formModel.value,
+    };
+    if (needsHost.value) body.host = formHost.value.trim();
+    if (needsKey.value) body.api_key = formKey.value.trim();
+    if (editingId.value !== null) body.provider_id = editingId.value;
+
+    const data = await providers.test(body);
+    if (data.success) {
+      showToast(data.message || 'Connection successful', 'success');
+    } else {
+      showToast(data.error || 'Test failed', 'error');
+    }
+  } catch {
+    showToast('Network error', 'error');
+  }
+  testing.value = false;
+}
+
+// ── Save provider ─────────────────────────────────────────────────
+async function saveProvider(): Promise<void> {
+  if (!preset.value || !formModel.value) {
+    showToast('Select a model first', 'error');
+    return;
+  }
+
+  const body: {
+    platform: string;
+    name: string;
+    model: string;
+    host?: string;
+    api_key?: string;
+  } = {
+    platform: preset.value.platform,
+    name: formName.value.trim(),
+    model: formModel.value,
+  };
+  if (needsHost.value) body.host = formHost.value.trim();
+  if (needsKey.value) {
+    const k = formKey.value.trim();
+    if (k) body.api_key = k;
+  }
+
+  try {
+    if (editingId.value !== null) {
+      await providers.update(editingId.value, body);
+    } else {
+      await providers.create(body);
+    }
+    showToast(editingId.value !== null ? 'Provider updated' : 'Provider added', 'success');
+    await load();
+    mode.value = 'list';
+
+    // Providers-only lift check
+    if (shell.providersOnly) {
+      try {
+        const res = await fetch('/auth/status', { credentials: 'same-origin' });
+        if (res.ok) {
+          const sd = (await res.json()) as { has_providers?: boolean };
+          if (sd.has_providers) shell.liftProvidersOnly();
+        }
+      } catch {
+        // keep locked
+      }
+    }
+  } catch (e: unknown) {
+    if (e && typeof e === 'object' && 'error' in e) {
+      showToast((e as { error?: string }).error || 'Save failed', 'error');
+    } else {
+      showToast('Network error', 'error');
+    }
+  }
+}
+</script>
+
 <template>
-  <div class="panel-header">
-    <h2>Providers</h2>
-  </div>
-  <div class="panel-placeholder">
-    <p>Providers panel — implementation in P2b.</p>
-  </div>
+  <!-- ── List view ─────────────────────────────────────────────── -->
+  <template v-if="mode === 'list'">
+    <div class="panel-header">
+      <h2>LLM Providers</h2>
+      <button class="btn btn-primary" @click="openWizard(null)">
+        <BrainIcon name="Plus" :size="14" />
+        Add Provider
+      </button>
+    </div>
+
+    <div class="providers-list">
+      <template v-if="loading">
+        <div class="loading">Loading providers…</div>
+      </template>
+
+      <template v-else-if="providerList.length === 0">
+        <div class="empty-state">
+          <div class="empty-icon">
+            <BrainIcon name="Providers" :size="40" />
+          </div>
+          <h3>No providers</h3>
+          <p>Add your first LLM provider to get started.</p>
+        </div>
+      </template>
+
+      <template v-else>
+        <div
+          v-for="p in providerList"
+          :key="p.id"
+          :class="['provider-card', { selected: p.id === selectedId }]"
+        >
+          <label class="provider-radio">
+            <input
+              type="radio"
+              name="sel_prov"
+              :value="p.id"
+              :checked="p.id === selectedId"
+              @change="selectProvider(p.id)"
+            />
+            <span class="radio-dot"></span>
+          </label>
+          <div class="provider-info">
+            <div class="provider-name">
+              {{ p.name }}
+              <span
+                v-if="p.decrypt_failed"
+                class="provider-warn"
+                title="Misconfigured — re-enter credentials"
+              >⚠</span>
+            </div>
+            <div class="provider-meta">
+              <span :class="`badge badge-${p.platform}`">{{ p.platform }}</span>
+              <span
+                v-if="p.supports_vision"
+                class="badge badge-success"
+                title="Verified image understanding"
+              >Vision</span>
+              <span>{{ p.model || 'no model' }}</span>
+              <span v-if="p.host">· {{ p.host }}</span>
+            </div>
+          </div>
+          <div class="provider-actions">
+            <button class="btn btn-sm btn-secondary" @click="openWizard(p.id)">Edit</button>
+            <button class="btn btn-sm btn-danger" @click="confirmDelete(p.id)">Delete</button>
+          </div>
+        </div>
+      </template>
+    </div>
+  </template>
+
+  <!-- ── Picker ────────────────────────────────────────────────── -->
+  <template v-else-if="mode === 'picker'">
+    <div class="provider-wizard">
+      <div class="form-page-header">
+        <button class="btn btn-secondary btn-sm back-btn" @click="backFromPicker">
+          <BrainIcon name="Chevron" :size="14" />
+          Back
+        </button>
+        <h3>Choose a provider</h3>
+      </div>
+      <p class="wizard-hint">
+        Pick your AI provider. We'll pre-fill the connection details and fetch its models for you.
+      </p>
+      <div class="provider-grid">
+        <button
+          v-for="t in catalogTiles"
+          :key="t.id"
+          type="button"
+          class="provider-tile"
+          @click="selectTile(t)"
+        >
+          <span class="provider-tile-avatar">{{ avatar(t.name) }}</span>
+          <span class="provider-tile-name">{{ t.name }}</span>
+          <span class="provider-tile-platform">{{
+            t.platform === 'openai_compatible' ? 'OpenAI-compatible' : t.platform
+          }}</span>
+        </button>
+      </div>
+    </div>
+  </template>
+
+  <!-- ── Form ──────────────────────────────────────────────────── -->
+  <template v-else-if="mode === 'form'">
+    <div class="provider-wizard">
+      <div class="form-page-header">
+        <button class="btn btn-secondary btn-sm back-btn" @click="backFromForm">
+          <BrainIcon name="Chevron" :size="14" />
+          {{ isEditing ? 'Back' : 'Providers' }}
+        </button>
+        <h3>{{ isEditing ? 'Edit Provider' : `Set up ${preset?.name ?? ''}` }}</h3>
+      </div>
+
+      <form class="wizard-form" autocomplete="off" @submit.prevent="saveProvider">
+        <!-- Name -->
+        <div class="form-group">
+          <label for="pName">Name</label>
+          <input
+            id="pName"
+            v-model="formName"
+            type="text"
+            required
+          />
+        </div>
+
+        <!-- Host / Base URL -->
+        <div
+          id="hostGroup"
+          class="form-group wizard-step"
+          :hidden="!showHostGroup"
+        >
+          <label for="pHost">Host / Base URL</label>
+          <input
+            id="pHost"
+            v-model="formHost"
+            type="text"
+            placeholder="https://…"
+          />
+        </div>
+
+        <!-- API Key -->
+        <div
+          id="keyGroup"
+          class="form-group wizard-step"
+          :hidden="!showKeyGroup"
+        >
+          <label for="pKey">API Key</label>
+          <input
+            id="pKey"
+            v-model="formKey"
+            type="password"
+            autocomplete="new-password"
+            :placeholder="isEditing ? 'Leave blank to keep existing' : 'Paste your API key'"
+          />
+        </div>
+
+        <!-- Model -->
+        <div
+          id="modelGroup"
+          class="form-group wizard-step"
+          :hidden="!showModelGroup"
+        >
+          <label for="pModel">Model</label>
+          <select id="pModel" v-model="formModel">
+            <option value="">Select model…</option>
+            <option v-for="m in models" :key="m" :value="m">{{ m }}</option>
+          </select>
+          <span :class="modelStatusClass">{{ modelStatus }}</span>
+        </div>
+
+        <div class="form-actions">
+          <button type="button" class="btn btn-secondary" @click="cancelForm">Cancel</button>
+          <button
+            type="button"
+            class="btn btn-secondary"
+            :disabled="testing"
+            @click="testConnection"
+          >
+            {{ testing ? 'Testing…' : 'Test' }}
+          </button>
+          <button type="submit" class="btn btn-primary" :disabled="saveDisabled">Save</button>
+        </div>
+      </form>
+    </div>
+  </template>
 </template>

--- a/frontend/apps/brain/src/views/ProvidersView.vue
+++ b/frontend/apps/brain/src/views/ProvidersView.vue
@@ -98,8 +98,11 @@ onUnmounted(() => {
   }
 });
 
+// `loading` is initialized true (initial-mount placeholder, matching the
+// legacy mount() innerHTML). Reloads after CRUD must NOT re-flash the
+// placeholder — legacy _load() re-rendered the list in place — so this
+// function never re-sets loading to true.
 async function load(): Promise<void> {
-  loading.value = true;
   try {
     const [provRes, selRes] = await Promise.all([
       providers.list(),

--- a/frontend/apps/brain/src/views/ProvidersView.vue
+++ b/frontend/apps/brain/src/views/ProvidersView.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.panelTitle = 'Providers'; shell.subTitle = ''; });
-</script>
-
 <template>
   <div class="panel-header">
     <h2>Providers</h2>

--- a/frontend/apps/brain/src/views/ProvidersView.vue
+++ b/frontend/apps/brain/src/views/ProvidersView.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.panelTitle = 'Providers'; shell.subTitle = ''; });
+</script>
+
+<template>
+  <div class="panel-header">
+    <h2>Providers</h2>
+  </div>
+  <div class="panel-placeholder">
+    <p>Providers panel — implementation in P2b.</p>
+  </div>
+</template>

--- a/frontend/apps/brain/src/views/ProvidersView.vue
+++ b/frontend/apps/brain/src/views/ProvidersView.vue
@@ -235,6 +235,9 @@ function selectTile(p: CatalogEntry): void {
   modelStatus.value = '';
   modelStatusClass.value = '';
   formName.value = p.name;
+  // FIX 6 (cont.): like openWizard(), this mutates formHost/formKey and may call
+  // fetchModels() directly below, so suppress the watch's redundant debounced fetch.
+  suppressNextCredsWatch = true;
   formHost.value = p.host || '';
   formKey.value = '';
   formModel.value = '';

--- a/frontend/apps/brain/src/views/ProvidersView.vue
+++ b/frontend/apps/brain/src/views/ProvidersView.vue
@@ -2,6 +2,7 @@
 import { ref, computed, onMounted, watch, onUnmounted } from 'vue';
 import { providers } from '../api/providers';
 import type { Provider, CatalogEntry } from '../api/providers';
+import { apiErrorMessage } from '../api/http';
 import { useToast } from '../composables/useToast';
 import { useConfirm } from '../composables/useConfirm';
 import { useShellStore } from '../stores/shell';
@@ -51,6 +52,11 @@ const lastFetchKey = ref('');
 let modelFetchTimer: ReturnType<typeof setTimeout> | null = null;
 
 const MODEL_FETCH_DEBOUNCE_MS = 600;
+
+// FIX 6: suppress the debounced watch that fires right after openWizard() pre-populates
+// formHost/formKey and then directly calls fetchModels() itself. Without this, the watch
+// would schedule a second debounced fetch on top of the one already in flight.
+let suppressNextCredsWatch = false;
 
 // Test button state
 const testing = ref(false);
@@ -123,8 +129,7 @@ async function selectProvider(id: number): Promise<void> {
     selectedId.value = id;
     showToast('Provider selected', 'success');
   } catch (e: unknown) {
-    const err = e as { error?: string };
-    showToast(err.error || 'Failed', 'error');
+    showToast(apiErrorMessage(e, 'Failed', 'Failed to select provider'), 'error');
   }
 }
 
@@ -144,11 +149,7 @@ async function confirmDelete(id: number): Promise<void> {
     showToast('Provider deleted', 'success');
     await load();
   } catch (e: unknown) {
-    if (e && typeof e === 'object' && 'error' in e) {
-      showToast((e as { error?: string }).error || 'Delete failed', 'error');
-    } else {
-      showToast('Network error', 'error');
-    }
+    showToast(apiErrorMessage(e, 'Delete failed'), 'error');
   }
 }
 
@@ -177,6 +178,10 @@ async function openWizard(id: number | null): Promise<void> {
     models.value = editModel.value ? [editModel.value] : [];
     preset.value = presetFor(p);
     formName.value = p.name;
+    // Suppress the creds watch: we mutate formHost/formKey here and call
+    // fetchModels() directly below, so we must skip the debounced watch that
+    // would otherwise schedule a redundant second fetch.
+    suppressNextCredsWatch = true;
     formHost.value = p.host || '';
     formKey.value = '';
     formModel.value = editModel.value;
@@ -213,10 +218,12 @@ async function ensureCatalog(): Promise<void> {
   try {
     const res = await providers.getCatalog();
     catalog.value = Array.isArray(res.catalog) ? res.catalog : [];
+    catalogLoaded.value = true;  // only mark loaded on success so next open retries
   } catch {
     catalog.value = [];
+    showToast('Could not load provider catalog', 'error');
+    // catalogLoaded stays false → next wizard open will retry
   }
-  catalogLoaded.value = true;
 }
 
 // ── Wizard: picker ────────────────────────────────────────────────
@@ -256,6 +263,12 @@ function cancelForm(): void {
 // ── Progressive reveal: watch creds inputs ────────────────────────
 watch([() => formHost.value, () => formKey.value], () => {
   if (mode.value !== 'form') return;
+  // FIX 6: openWizard() pre-populates these fields and calls fetchModels()
+  // directly. Skip the debounced duplicate triggered by that mutation.
+  if (suppressNextCredsWatch) {
+    suppressNextCredsWatch = false;
+    return;
+  }
   debouncedFetchModels();
 });
 
@@ -307,15 +320,12 @@ async function fetchModels(): Promise<void> {
     modelStatus.value = `${n} model${n === 1 ? '' : 's'}`;
     modelStatusClass.value = 'model-status ok';
   } catch (e: unknown) {
-    if (e && typeof e === 'object' && 'error' in e) {
-      modelStatus.value = (e as { error?: string }).error || 'Failed to fetch models';
-    } else {
-      modelStatus.value = 'Network error';
-    }
+    modelStatus.value = apiErrorMessage(e, 'Failed to fetch models');
     modelStatusClass.value = 'model-status err';
     lastFetchKey.value = ''; // allow retry
+  } finally {
+    modelsFetchInFlight.value = false;
   }
-  modelsFetchInFlight.value = false;
 }
 
 // ── Test connection ───────────────────────────────────────────────
@@ -345,10 +355,11 @@ async function testConnection(): Promise<void> {
     } else {
       showToast(data.error || 'Test failed', 'error');
     }
-  } catch {
-    showToast('Network error', 'error');
+  } catch (e: unknown) {
+    showToast(apiErrorMessage(e, 'Test failed'), 'error');
+  } finally {
+    testing.value = false;
   }
-  testing.value = false;
 }
 
 // ── Save provider ─────────────────────────────────────────────────
@@ -398,11 +409,7 @@ async function saveProvider(): Promise<void> {
       }
     }
   } catch (e: unknown) {
-    if (e && typeof e === 'object' && 'error' in e) {
-      showToast((e as { error?: string }).error || 'Save failed', 'error');
-    } else {
-      showToast('Network error', 'error');
-    }
+    showToast(apiErrorMessage(e, 'Save failed'), 'error');
   }
 }
 </script>

--- a/frontend/apps/brain/src/views/SchedulerView.vue
+++ b/frontend/apps/brain/src/views/SchedulerView.vue
@@ -3,6 +3,5 @@ import { RouterView } from 'vue-router';
 </script>
 
 <template>
-  <div class="panel-header"><h2>Scheduler</h2></div>
   <RouterView />
 </template>

--- a/frontend/apps/brain/src/views/SchedulerView.vue
+++ b/frontend/apps/brain/src/views/SchedulerView.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { RouterView } from 'vue-router';
+import { onMounted } from 'vue';
+import { useShellStore } from '../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.panelTitle = 'Scheduler'; });
+</script>
+
+<template>
+  <div class="panel-header"><h2>Scheduler</h2></div>
+  <RouterView />
+</template>

--- a/frontend/apps/brain/src/views/SchedulerView.vue
+++ b/frontend/apps/brain/src/views/SchedulerView.vue
@@ -1,10 +1,5 @@
 <script setup lang="ts">
 import { RouterView } from 'vue-router';
-import { onMounted } from 'vue';
-import { useShellStore } from '../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.panelTitle = 'Scheduler'; });
 </script>
 
 <template>

--- a/frontend/apps/brain/src/views/SkillsView.vue
+++ b/frontend/apps/brain/src/views/SkillsView.vue
@@ -1,4 +1,426 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { skills as skillsApi } from '../api/skills';
+import type { Skill, Association } from '../api/skills';
+import { formatDate } from '../utils/format';
+import { apiErrorMessage } from '../api/http';
+import { useToast } from '../composables/useToast';
+import { useConfirm } from '../composables/useConfirm';
+import BrainIcon from '../ui/BrainIcon.vue';
+
+const { show: showToast } = useToast();
+const { confirm } = useConfirm();
+
+const skills = ref<Skill[]>([]);
+const associations = ref<Association[]>([]);
+const loading = ref(true);
+const expandedId = ref<string | number | null>(null);
+const editingId = ref<string | number | null>(null);
+const viewMode = ref<'list' | 'create'>('list');
+
+const userSkills = computed<Skill[]>(() => skills.value.filter((s) => s.source === 'user'));
+const curatedSkills = computed<Skill[]>(() => skills.value.filter((s) => s.source === 'curated'));
+
+// Create-form refs
+const createTitle = ref('');
+const createUseFor = ref('');
+const createTags = ref('');
+const createContent = ref('');
+
+// Edit-form refs (only one card is ever in edit mode at a time)
+const editUseFor = ref('');
+const editTags = ref('');
+const editContent = ref('');
+
+// ── Load ─────────────────────────────────────────────────────────────
+
+async function load(): Promise<void> {
+  loading.value = true;
+  try {
+    const data = await skillsApi.list();
+    skills.value = data.skills ?? [];
+    associations.value = data.associations ?? [];
+  } catch {
+    showToast('Failed to load skills', 'error');
+  } finally {
+    loading.value = false;
+  }
+}
+
+// ── Expand ───────────────────────────────────────────────────────────
+
+function toggleExpand(skill: Skill): void {
+  expandedId.value = expandedId.value === skill.id ? null : skill.id;
+}
+
+// ── Edit ─────────────────────────────────────────────────────────────
+
+function startEdit(skill: Skill): void {
+  editUseFor.value = skill.use_for;
+  editTags.value = skill.tags ?? '';
+  editContent.value = skill.content;
+  editingId.value = skill.id;
+}
+
+async function saveEdit(skill: Skill): Promise<void> {
+  const use_for = editUseFor.value.trim();
+  const content = editContent.value.trim();
+  const tags = editTags.value.trim();
+  try {
+    const data = await skillsApi.update(skill.id, { use_for, content, tags });
+    showToast('Skill updated', 'success');
+    const idx = skills.value.findIndex((s) => s.id === skill.id);
+    if (idx !== -1) skills.value[idx] = data.skill;
+    editingId.value = null;
+  } catch (e) {
+    showToast(apiErrorMessage(e, 'Failed to update skill'), 'error');
+  }
+}
+
+// ── Toggle ───────────────────────────────────────────────────────────
+
+async function toggleSkill(skill: Skill): Promise<void> {
+  try {
+    const data = await skillsApi.toggle(skill.id);
+    skill.enabled = data.enabled;
+    showToast(data.enabled ? 'Skill enabled' : 'Skill disabled', 'success');
+  } catch (e) {
+    showToast(apiErrorMessage(e, 'Failed to toggle skill'), 'error');
+  }
+}
+
+// ── Delete ───────────────────────────────────────────────────────────
+
+async function deleteSkill(skill: Skill): Promise<void> {
+  const ok = await confirm({
+    title: 'Delete Skill',
+    desc: `Delete "${skill.title}"? This cannot be undone.`,
+    confirmLabel: 'Delete',
+    confirmClass: 'btn-danger',
+  });
+  if (!ok) return;
+  try {
+    await skillsApi.delete(skill.id);
+    showToast('Skill deleted', 'success');
+    skills.value = skills.value.filter((s) => s.id !== skill.id);
+    editingId.value = null;
+  } catch (e) {
+    showToast(apiErrorMessage(e, 'Failed to delete skill'), 'error');
+  }
+}
+
+// ── Copy ─────────────────────────────────────────────────────────────
+
+async function copySkill(skill: Skill): Promise<void> {
+  const ok = await confirm({
+    title: 'Customise Skill',
+    desc: `Copy "${skill.title}" as a customisable skill? The curated version will be disabled.`,
+    confirmLabel: 'Customise',
+    confirmClass: 'btn-primary',
+  });
+  if (!ok) return;
+  try {
+    const data = await skillsApi.copy(skill.id);
+    showToast(`Skill copied as "${data.skill.title}"`, 'success');
+    await load();
+  } catch (e) {
+    showToast(apiErrorMessage(e, 'Failed to copy skill'), 'error');
+  }
+}
+
+// ── Create ───────────────────────────────────────────────────────────
+
+function openCreate(): void {
+  createTitle.value = '';
+  createUseFor.value = '';
+  createTags.value = '';
+  createContent.value = '';
+  viewMode.value = 'create';
+}
+
+async function submitCreate(): Promise<void> {
+  const title = createTitle.value.trim();
+  const use_for = createUseFor.value.trim();
+  const content = createContent.value.trim();
+  const tags = createTags.value.trim();
+  try {
+    const data = await skillsApi.create({ title, use_for, content, tags });
+    showToast(`Skill "${title}" created`, 'success');
+    skills.value.push(data.skill);
+    editingId.value = null;
+    viewMode.value = 'list';
+  } catch (e) {
+    showToast(apiErrorMessage(e, 'Failed to create skill'), 'error');
+  }
+}
+
+onMounted(load);
+</script>
+
 <template>
-  <div class="panel-header"><h2>Skills</h2></div>
-  <div class="panel-placeholder"><p>Skills panel — implementation in P2e.</p></div>
+  <!-- Header -->
+  <div class="panel-header">
+    <h2><BrainIcon name="Skill" :size="20" /> Skills</h2>
+    <div class="panel-header-actions">
+      <button class="btn btn-primary btn-sm" @click="openCreate">
+        <BrainIcon name="Plus" :size="14" /> New Skill
+      </button>
+    </div>
+  </div>
+
+  <div v-if="loading" class="loading">Loading…</div>
+
+  <!-- Create form -->
+  <template v-else-if="viewMode === 'create'">
+    <div class="provider-form-page">
+      <div class="form-page-header">
+        <button class="btn btn-secondary btn-sm" @click="viewMode = 'list'">
+          <BrainIcon name="Chevron" :size="14" /> Back
+        </button>
+        <h3>New Skill</h3>
+      </div>
+      <form @submit.prevent="submitCreate">
+        <div class="form-group">
+          <label>Title <span style="color:var(--error)">*</span></label>
+          <input
+            v-model="createTitle"
+            type="text"
+            placeholder="e.g. Track Package Delivery"
+            required
+          >
+        </div>
+        <div class="form-group">
+          <label>Use for <span style="color:var(--error)">*</span></label>
+          <input
+            v-model="createUseFor"
+            type="text"
+            placeholder="One sentence: when should this skill be used?"
+            required
+          >
+        </div>
+        <div class="form-group">
+          <label>Tags</label>
+          <input
+            v-model="createTags"
+            type="text"
+            placeholder="logistics, tracking, delivery"
+          >
+        </div>
+        <div class="form-group">
+          <label>Instructions <span style="color:var(--error)">*</span></label>
+          <textarea
+            v-model="createContent"
+            rows="10"
+            :placeholder="'1. First step (reference tools like `search`, `memory`)\n2. Second step\n3. Third step'"
+            required
+          ></textarea>
+        </div>
+        <div class="form-actions">
+          <button type="button" class="btn btn-secondary" @click="viewMode = 'list'">Cancel</button>
+          <button type="submit" class="btn btn-primary">Create Skill</button>
+        </div>
+      </form>
+    </div>
+  </template>
+
+  <!-- List view -->
+  <template v-else>
+    <!-- My Skills -->
+    <h4 class="section-head">My Skills</h4>
+
+    <div
+      v-if="userSkills.length === 0"
+      class="empty-state"
+      style="margin-bottom:24px;"
+    >
+      <div class="empty-icon">
+        <BrainIcon name="Skill" :size="40" />
+      </div>
+      <h3>No custom skills yet</h3>
+      <p>Click "New Skill" to create a step-by-step playbook for a recurring task.</p>
+    </div>
+
+    <div v-else id="userSkillsGrid" class="skills-grid">
+      <template v-for="skill in userSkills" :key="skill.id">
+        <!-- Edit mode -->
+        <div v-if="editingId === skill.id" class="cap-card skill-card">
+          <div class="skill-card-header">
+            <strong>{{ skill.title }}</strong>
+            <span class="badge badge-violet">v{{ skill.version }}</span>
+          </div>
+          <form class="skill-edit-form" @submit.prevent="saveEdit(skill)">
+            <div class="form-group">
+              <label>Use for</label>
+              <input
+                v-model="editUseFor"
+                type="text"
+                class="skill-field-use_for"
+                placeholder="When should this skill be used?"
+              >
+            </div>
+            <div class="form-group">
+              <label>Tags</label>
+              <input
+                v-model="editTags"
+                type="text"
+                class="skill-field-tags"
+                placeholder="tag1, tag2"
+              >
+            </div>
+            <div class="form-group">
+              <label>Instructions</label>
+              <textarea
+                v-model="editContent"
+                class="skill-field-content"
+                rows="8"
+                :placeholder="'1. First step\n2. Second step'"
+              ></textarea>
+            </div>
+            <div class="form-actions">
+              <button type="button" class="btn btn-secondary btn-sm" @click="editingId = null">Cancel</button>
+              <button type="submit" class="btn btn-primary btn-sm">Save</button>
+            </div>
+          </form>
+        </div>
+
+        <!-- Display mode -->
+        <div
+          v-else
+          class="cap-card skill-card"
+          :class="{ 'skill-expanded': expandedId === skill.id }"
+        >
+          <div class="skill-card-header">
+            <div class="skill-card-title" style="cursor:pointer;" @click="toggleExpand(skill)">
+              <span class="skill-expand-icon">
+                <BrainIcon :name="expandedId === skill.id ? 'ChevronDown' : 'Chevron'" :size="12" />
+              </span>
+              <strong>{{ skill.title }}</strong>
+              <span class="badge badge-violet">v{{ skill.version }}</span>
+              <span v-if="skill.enabled" class="badge badge-success">enabled</span>
+              <span v-else class="badge badge-muted">disabled</span>
+            </div>
+            <div class="skill-card-actions">
+              <label
+                class="switch-label skill-toggle-wrap"
+                :title="skill.enabled ? 'Disable' : 'Enable'"
+              >
+                <label class="switch">
+                  <input
+                    type="checkbox"
+                    class="skill-toggle"
+                    :checked="skill.enabled"
+                    @change="toggleSkill(skill)"
+                  >
+                  <span class="switch-track"></span>
+                </label>
+              </label>
+              <button class="btn btn-secondary btn-sm" @click="startEdit(skill)">
+                <BrainIcon name="Edit" :size="13" />
+              </button>
+              <button class="btn btn-danger btn-sm" @click="deleteSkill(skill)">
+                <BrainIcon name="Trash" :size="13" />
+              </button>
+            </div>
+          </div>
+          <div class="skill-use-for">{{ skill.use_for }}</div>
+          <div v-if="skill.tags" class="skill-tags">
+            <span
+              v-for="tag in skill.tags.split(',').map(t => t.trim()).filter(Boolean)"
+              :key="tag"
+              class="badge badge-muted skill-tag"
+            >{{ tag }}</span>
+          </div>
+          <div v-if="expandedId === skill.id" class="skill-expanded-content">
+            <pre class="skill-content-preview">{{ skill.content }}</pre>
+          </div>
+        </div>
+      </template>
+    </div>
+
+    <!-- Curated Skills -->
+    <h4 class="section-head" style="margin-top:32px;">Curated Skills</h4>
+
+    <div v-if="curatedSkills.length === 0" class="empty-state">
+      <p>No curated skills loaded.</p>
+    </div>
+
+    <div v-else id="curatedSkillsGrid" class="skills-grid">
+      <div
+        v-for="skill in curatedSkills"
+        :key="skill.id"
+        class="cap-card skill-card"
+        :class="{ 'skill-disabled': !skill.enabled, 'skill-expanded': expandedId === skill.id }"
+      >
+        <div class="skill-card-header">
+          <div class="skill-card-title" style="cursor:pointer;" @click="toggleExpand(skill)">
+            <span class="skill-expand-icon">
+              <BrainIcon :name="expandedId === skill.id ? 'ChevronDown' : 'Chevron'" :size="12" />
+            </span>
+            <strong>{{ skill.title }}</strong>
+            <span class="badge badge-muted">v{{ skill.version }}</span>
+            <span v-if="skill.enabled" class="badge badge-success">enabled</span>
+            <span v-else class="badge badge-muted">disabled</span>
+          </div>
+          <div class="skill-card-actions">
+            <label
+              class="switch-label skill-toggle-wrap"
+              :title="skill.enabled ? 'Disable' : 'Enable'"
+            >
+              <label class="switch">
+                <input
+                  type="checkbox"
+                  class="skill-toggle"
+                  :checked="skill.enabled"
+                  @change="toggleSkill(skill)"
+                >
+                <span class="switch-track"></span>
+              </label>
+            </label>
+            <button
+              class="btn btn-secondary btn-sm"
+              title="Copy &amp; Customise"
+              @click="copySkill(skill)"
+            >
+              <BrainIcon name="Copy" :size="13" /> Customise
+            </button>
+          </div>
+        </div>
+        <div class="skill-use-for">{{ skill.use_for }}</div>
+        <div v-if="skill.tags" class="skill-tags">
+          <span
+            v-for="tag in skill.tags.split(',').map(t => t.trim()).filter(Boolean)"
+            :key="tag"
+            class="badge badge-muted skill-tag"
+          >{{ tag }}</span>
+        </div>
+        <div v-if="expandedId === skill.id" class="skill-expanded-content">
+          <pre class="skill-content-preview">{{ skill.content }}</pre>
+        </div>
+      </div>
+    </div>
+
+    <!-- Skill Associations -->
+    <template v-if="associations.length > 0">
+      <h4 class="section-head" style="margin-top:32px;">Skill Associations</h4>
+      <p class="panel-desc">Patterns discovered from your behaviour, linked to skills.</p>
+      <table class="records-table">
+        <thead>
+          <tr>
+            <th>Pattern</th>
+            <th>Skill</th>
+            <th>Rule</th>
+            <th>Since</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(a, idx) in associations" :key="idx">
+            <td><span class="badge badge-violet">{{ a.pattern_name }}</span></td>
+            <td>{{ a.skill_title }}</td>
+            <td style="font-size:12px;color:var(--text-secondary);">{{ a.rule }}</td>
+            <td style="font-size:12px;color:var(--text-tertiary);">{{ formatDate(a.created_at) }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </template>
+  </template>
 </template>

--- a/frontend/apps/brain/src/views/SkillsView.vue
+++ b/frontend/apps/brain/src/views/SkillsView.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.panelTitle = 'Skills'; shell.subTitle = ''; });
+</script>
+
+<template>
+  <div class="panel-header"><h2>Skills</h2></div>
+  <div class="panel-placeholder"><p>Skills panel — implementation in P2e.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/SkillsView.vue
+++ b/frontend/apps/brain/src/views/SkillsView.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.panelTitle = 'Skills'; shell.subTitle = ''; });
-</script>
-
 <template>
   <div class="panel-header"><h2>Skills</h2></div>
   <div class="panel-placeholder"><p>Skills panel — implementation in P2e.</p></div>

--- a/frontend/apps/brain/src/views/VisionView.vue
+++ b/frontend/apps/brain/src/views/VisionView.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted } from 'vue';
 import { providers } from '../api/providers';
 import type { Provider } from '../api/providers';
+import { apiErrorMessage } from '../api/http';
 import { useToast } from '../composables/useToast';
 import BrainIcon from '../ui/BrainIcon.vue';
 
@@ -34,11 +35,7 @@ async function setVision(id: number): Promise<void> {
     source.value = 'explicit';
     showToast('Vision provider set', 'success');
   } catch (e: unknown) {
-    if (e && typeof e === 'object' && 'error' in e) {
-      showToast((e as { error?: string }).error || 'Failed', 'error');
-    } else {
-      showToast('Failed to set vision provider', 'error');
-    }
+    showToast(apiErrorMessage(e, 'Failed', 'Failed to set vision provider'), 'error');
   }
 }
 </script>

--- a/frontend/apps/brain/src/views/VisionView.vue
+++ b/frontend/apps/brain/src/views/VisionView.vue
@@ -1,4 +1,116 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { providers } from '../api/providers';
+import type { Provider } from '../api/providers';
+import { useToast } from '../composables/useToast';
+import BrainIcon from '../ui/BrainIcon.vue';
+
+const { show: showToast } = useToast();
+
+const providerList = ref<Provider[]>([]);
+const visionId = ref<number | null>(null);
+const source = ref<string>('none');
+const loading = ref(true);
+
+onMounted(async () => {
+  try {
+    const [provRes, visRes] = await Promise.all([
+      providers.list(),
+      providers.getVision(),
+    ]);
+    providerList.value = provRes.providers ?? [];
+    visionId.value = visRes.provider ? visRes.provider.id : null;
+    source.value = visRes.source || 'none';
+  } catch {
+    showToast('Failed to connect to backend', 'error');
+  }
+  loading.value = false;
+});
+
+async function setVision(id: number): Promise<void> {
+  try {
+    await providers.setVision(id);
+    visionId.value = id;
+    source.value = 'explicit';
+    showToast('Vision provider set', 'success');
+  } catch (e: unknown) {
+    if (e && typeof e === 'object' && 'error' in e) {
+      showToast((e as { error?: string }).error || 'Failed', 'error');
+    } else {
+      showToast('Failed to set vision provider', 'error');
+    }
+  }
+}
+</script>
+
 <template>
-  <div class="panel-header"><h2>Vision</h2></div>
-  <div class="panel-placeholder"><p>Vision panel — implementation in P2b.</p></div>
+  <div class="panel-header">
+    <h2>Vision Provider</h2>
+  </div>
+  <p class="panel-desc">
+    Choose which provider Chalie uses to understand images. Only providers that passed the vision
+    probe can be selected.
+  </p>
+
+  <template v-if="loading">
+    <div class="loading">Loading providers…</div>
+  </template>
+
+  <template v-else-if="providerList.length === 0">
+    <div class="empty-state">
+      <div class="empty-icon">
+        <BrainIcon name="Eye" :size="40" />
+      </div>
+      <h3>No providers</h3>
+      <p>Add an LLM provider first.</p>
+    </div>
+  </template>
+
+  <template v-else>
+    <p v-if="source === 'auto' && visionId !== null" class="panel-desc">
+      Auto-selected the active provider because it supports vision. Pick one explicitly to lock it
+      in.
+    </p>
+
+    <div class="providers-list">
+      <div
+        v-for="p in providerList"
+        :key="p.id"
+        :class="[
+          'provider-card',
+          { selected: p.supports_vision && p.id === visionId },
+          { disabled: !p.supports_vision },
+        ]"
+      >
+        <label class="provider-radio">
+          <input
+            type="radio"
+            name="vis_prov"
+            :value="p.id"
+            :disabled="!p.supports_vision"
+            :checked="p.supports_vision && p.id === visionId"
+            @change="setVision(p.id)"
+          />
+          <span class="radio-dot"></span>
+        </label>
+        <div class="provider-info">
+          <div class="provider-name">{{ p.name }}</div>
+          <div class="provider-meta">
+            <span :class="`badge badge-${p.platform}`">{{ p.platform }}</span>
+            <span>{{ p.model || 'no model' }}</span>
+            <span
+              v-if="p.supports_vision"
+              class="badge badge-success"
+              title="Verified image understanding"
+            >Vision</span>
+            <span
+              v-else
+              class="badge badge-muted"
+              title="Did not pass the vision probe"
+            >No vision</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
 </template>

--- a/frontend/apps/brain/src/views/VisionView.vue
+++ b/frontend/apps/brain/src/views/VisionView.vue
@@ -48,12 +48,12 @@ async function setVision(id: number): Promise<void> {
     <h2>Vision Provider</h2>
   </div>
   <p class="panel-desc">
-    Choose which provider Chalie uses to understand images. Only providers that passed the vision
-    probe can be selected.
+    Pick the provider Chalie uses to understand images. Only providers that passed the vision probe
+    can be selected.
   </p>
 
   <template v-if="loading">
-    <div class="loading">Loading providers…</div>
+    <div class="loading">Loading…</div>
   </template>
 
   <template v-else-if="providerList.length === 0">
@@ -101,7 +101,6 @@ async function setVision(id: number): Promise<void> {
             <span
               v-if="p.supports_vision"
               class="badge badge-success"
-              title="Verified image understanding"
             >Vision</span>
             <span
               v-else

--- a/frontend/apps/brain/src/views/VisionView.vue
+++ b/frontend/apps/brain/src/views/VisionView.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.panelTitle = 'Vision'; shell.subTitle = ''; });
+</script>
+
+<template>
+  <div class="panel-header"><h2>Vision</h2></div>
+  <div class="panel-placeholder"><p>Vision panel — implementation in P2b.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/VisionView.vue
+++ b/frontend/apps/brain/src/views/VisionView.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.panelTitle = 'Vision'; shell.subTitle = ''; });
-</script>
-
 <template>
   <div class="panel-header"><h2>Vision</h2></div>
   <div class="panel-placeholder"><p>Vision panel — implementation in P2b.</p></div>

--- a/frontend/apps/brain/src/views/cognition/CompactionSub.vue
+++ b/frontend/apps/brain/src/views/cognition/CompactionSub.vue
@@ -1,3 +1,46 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { cognition } from '../../api/cognition';
+import type { CompactionEntry } from '../../api/cognition';
+import EmptyState from '../../ui/EmptyState.vue';
+
+const loading = ref(true);
+const loadFailed = ref(false);
+const compaction = ref<CompactionEntry | null>(null);
+
+onMounted(async () => {
+  try {
+    const data = await cognition.compaction();
+    compaction.value = data.compaction || null;
+  } catch {
+    loadFailed.value = true;
+  } finally {
+    loading.value = false;
+  }
+});
+</script>
+
 <template>
-  <div class="panel-placeholder"><p>Compaction sub-panel — implementation in P2b.</p></div>
+  <template v-if="loading"><div class="loading">Loading…</div></template>
+  <template v-else-if="loadFailed"><EmptyState message="Failed to load data." /></template>
+  <template v-else>
+    <template v-if="!compaction?.summary">
+      <p class="panel-desc">The continuity summary the chat carries forward after its context overflows and is compacted.</p>
+      <EmptyState message="No compaction has run yet — the chat context has not overflowed." />
+    </template>
+    <template v-else>
+      <p class="panel-desc">The continuity summary injected into the chat context after the conversation overflowed. This is what Chalie carries forward in place of the older turns.</p>
+      <div class="stat-grid">
+        <div class="stat-card">
+          <div class="stat-value">{{ compaction.compacted_at || '—' }}</div>
+          <div class="stat-label">Last Compacted</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-value">{{ compaction.compacted_up_to_id ? '#' + compaction.compacted_up_to_id : '—' }}</div>
+          <div class="stat-label">Compacted Up To (transcript id)</div>
+        </div>
+      </div>
+      <div class="code-block"><pre><code>{{ compaction.summary }}</code></pre></div>
+    </template>
+  </template>
 </template>

--- a/frontend/apps/brain/src/views/cognition/CompactionSub.vue
+++ b/frontend/apps/brain/src/views/cognition/CompactionSub.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.subTitle = 'Compaction'; });
-</script>
-
 <template>
   <div class="panel-placeholder"><p>Compaction sub-panel — implementation in P2b.</p></div>
 </template>

--- a/frontend/apps/brain/src/views/cognition/CompactionSub.vue
+++ b/frontend/apps/brain/src/views/cognition/CompactionSub.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.subTitle = 'Compaction'; });
+</script>
+
+<template>
+  <div class="panel-placeholder"><p>Compaction sub-panel — implementation in P2b.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/cognition/ErrorsSub.vue
+++ b/frontend/apps/brain/src/views/cognition/ErrorsSub.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.subTitle = 'Errors'; });
-</script>
-
 <template>
   <div class="panel-placeholder"><p>Errors sub-panel — implementation in P2b.</p></div>
 </template>

--- a/frontend/apps/brain/src/views/cognition/ErrorsSub.vue
+++ b/frontend/apps/brain/src/views/cognition/ErrorsSub.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.subTitle = 'Errors'; });
+</script>
+
+<template>
+  <div class="panel-placeholder"><p>Errors sub-panel — implementation in P2b.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/cognition/ErrorsSub.vue
+++ b/frontend/apps/brain/src/views/cognition/ErrorsSub.vue
@@ -1,3 +1,36 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { cognition } from '../../api/cognition';
+import type { ErrorEntry } from '../../api/cognition';
+import { formatDate } from '../../utils/format';
+import EmptyState from '../../ui/EmptyState.vue';
+
+const loading = ref(true);
+const loadFailed = ref(false);
+const errors = ref<ErrorEntry[]>([]);
+
+onMounted(async () => {
+  try {
+    const data = await cognition.errors();
+    errors.value = data.errors || [];
+  } catch {
+    loadFailed.value = true;
+  } finally {
+    loading.value = false;
+  }
+});
+</script>
+
 <template>
-  <div class="panel-placeholder"><p>Errors sub-panel — implementation in P2b.</p></div>
+  <template v-if="loading"><div class="loading">Loading…</div></template>
+  <template v-else-if="loadFailed"><EmptyState message="Failed to load data." /></template>
+  <template v-else>
+    <EmptyState v-if="errors.length === 0" message="No recent errors." />
+    <div v-else class="error-list">
+      <div v-for="(e, i) in errors" :key="i" class="error-item">
+        <span class="error-time">{{ formatDate(e.time || e.timestamp) }}</span>
+        <span class="error-msg">{{ e.message || '' }}</span>
+      </div>
+    </div>
+  </template>
 </template>

--- a/frontend/apps/brain/src/views/cognition/MemorySub.vue
+++ b/frontend/apps/brain/src/views/cognition/MemorySub.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.subTitle = 'Memory'; });
+</script>
+
+<template>
+  <div class="panel-placeholder"><p>Memory sub-panel — implementation in P2b.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/cognition/MemorySub.vue
+++ b/frontend/apps/brain/src/views/cognition/MemorySub.vue
@@ -1,3 +1,103 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { cognition } from '../../api/cognition';
+import type { MemoryRecord } from '../../api/cognition';
+import { formatDate } from '../../utils/format';
+import EmptyState from '../../ui/EmptyState.vue';
+
+const SOURCES = ['episodes', 'user', 'system'] as const;
+
+const source = ref('episodes');
+const search = ref('');
+const records = ref<MemoryRecord[]>([]);
+const hasMore = ref(false);
+const offset = ref(0);
+const loading = ref(false);
+const loadFailed = ref(false);
+
+async function load(): Promise<void> {
+  loading.value = true;
+  loadFailed.value = false;
+  try {
+    const data = await cognition.memory({
+      source: source.value,
+      limit: 50,
+      offset: offset.value,
+      q: search.value || undefined,
+    });
+    records.value = data.rows || [];
+    hasMore.value = data.has_more || false;
+  } catch {
+    loadFailed.value = true;
+  } finally {
+    loading.value = false;
+  }
+}
+
+function selectSource(s: string): void {
+  source.value = s;
+  offset.value = 0;
+  load();
+}
+
+function submitSearch(): void {
+  offset.value = 0;
+  load();
+}
+
+function loadMore(): void {
+  offset.value += 50;
+  load();
+}
+
+onMounted(load);
+</script>
+
 <template>
-  <div class="panel-placeholder"><p>Memory sub-panel — implementation in P2b.</p></div>
+  <template v-if="loading"><div class="loading">Loading…</div></template>
+  <template v-else-if="loadFailed"><EmptyState message="Failed to load data." /></template>
+  <template v-else>
+    <div class="records-controls">
+      <div class="filter-tabs">
+        <button
+          v-for="s in SOURCES"
+          :key="s"
+          class="filter-tab"
+          :class="{ active: source === s }"
+          @click="selectSource(s)"
+        >{{ s.charAt(0).toUpperCase() + s.slice(1) }}</button>
+      </div>
+      <input
+        v-model="search"
+        type="text"
+        class="search-input"
+        placeholder="Search…"
+        @keydown.enter="submitSearch"
+      >
+    </div>
+    <EmptyState v-if="records.length === 0" message="No records found." />
+    <template v-else>
+      <table class="records-table">
+        <thead>
+          <tr>
+            <th>Created</th>
+            <th>Last Accessed</th>
+            <th>{{ source === 'episodes' ? 'Location' : 'Key' }}</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(r, i) in records" :key="i">
+            <td>{{ formatDate(r.created) }}</td>
+            <td>{{ formatDate(r.last_accessed) }}</td>
+            <td class="key-cell">{{ source === 'episodes' ? (r.location || '') : (r.key || '') }}</td>
+            <td class="val-cell">{{ r.value || '' }}</td>
+          </tr>
+        </tbody>
+      </table>
+      <div v-if="hasMore" class="records-footer">
+        <button class="btn btn-secondary" @click="loadMore">Load more</button>
+      </div>
+    </template>
+  </template>
 </template>

--- a/frontend/apps/brain/src/views/cognition/MemorySub.vue
+++ b/frontend/apps/brain/src/views/cognition/MemorySub.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.subTitle = 'Memory'; });
-</script>
-
 <template>
   <div class="panel-placeholder"><p>Memory sub-panel — implementation in P2b.</p></div>
 </template>

--- a/frontend/apps/brain/src/views/cognition/MemorySub.vue
+++ b/frontend/apps/brain/src/views/cognition/MemorySub.vue
@@ -5,9 +5,11 @@ import type { MemoryRecord } from '../../api/cognition';
 import { formatDate } from '../../utils/format';
 import EmptyState from '../../ui/EmptyState.vue';
 
-const SOURCES = ['episodes', 'user', 'system'] as const;
+type MemorySource = 'episodes' | 'user' | 'system';
 
-const source = ref('episodes');
+const SOURCES: MemorySource[] = ['episodes', 'user', 'system'];
+
+const source = ref<MemorySource>('episodes');
 const search = ref('');
 const records = ref<MemoryRecord[]>([]);
 const hasMore = ref(false);
@@ -15,7 +17,10 @@ const offset = ref(0);
 const loading = ref(false);
 const loadFailed = ref(false);
 
+let fetchGen = 0;
+
 async function load(): Promise<void> {
+  const gen = ++fetchGen;
   loading.value = true;
   loadFailed.value = false;
   try {
@@ -25,16 +30,18 @@ async function load(): Promise<void> {
       offset: offset.value,
       q: search.value || undefined,
     });
+    if (gen !== fetchGen) return;
     records.value = data.rows || [];
     hasMore.value = data.has_more || false;
   } catch {
+    if (gen !== fetchGen) return;
     loadFailed.value = true;
   } finally {
-    loading.value = false;
+    if (gen === fetchGen) loading.value = false;
   }
 }
 
-function selectSource(s: string): void {
+function selectSource(s: MemorySource): void {
   source.value = s;
   offset.value = 0;
   load();
@@ -87,7 +94,7 @@ onMounted(load);
           </tr>
         </thead>
         <tbody>
-          <tr v-for="(r, i) in records" :key="i">
+          <tr v-for="r in records" :key="`${r.created}-${r.key ?? r.location ?? ''}`">
             <td>{{ formatDate(r.created) }}</td>
             <td>{{ formatDate(r.last_accessed) }}</td>
             <td class="key-cell">{{ source === 'episodes' ? (r.location || '') : (r.key || '') }}</td>

--- a/frontend/apps/brain/src/views/cognition/PersonalitySub.vue
+++ b/frontend/apps/brain/src/views/cognition/PersonalitySub.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.subTitle = 'Personality'; });
+</script>
+
+<template>
+  <div class="panel-placeholder"><p>Personality sub-panel — implementation in P2b.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/cognition/PersonalitySub.vue
+++ b/frontend/apps/brain/src/views/cognition/PersonalitySub.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.subTitle = 'Personality'; });
-</script>
-
 <template>
   <div class="panel-placeholder"><p>Personality sub-panel — implementation in P2b.</p></div>
 </template>

--- a/frontend/apps/brain/src/views/cognition/PersonalitySub.vue
+++ b/frontend/apps/brain/src/views/cognition/PersonalitySub.vue
@@ -1,3 +1,89 @@
+<script setup lang="ts">
+import { reactive, ref, onMounted } from 'vue';
+import { cognition } from '../../api/cognition';
+import { useToast } from '../../composables/useToast';
+import { HttpError } from '@chalie/shared';
+import EmptyState from '../../ui/EmptyState.vue';
+
+const { show: showToast } = useToast();
+
+const loading = ref(true);
+const loadFailed = ref(false);
+
+const personality = reactive<{
+  warmth: number;
+  mood: number;
+  expressiveness: number;
+  curiosity: number;
+  humor: number;
+}>({ warmth: 0, mood: 0, expressiveness: 0, curiosity: 0, humor: 0 });
+
+const sliders = [
+  { key: 'warmth' as const, label: 'Warmth', left: 'Cool', right: 'Warm' },
+  { key: 'mood' as const, label: 'Mood', left: 'Level-headed', right: 'Moody' },
+  { key: 'expressiveness' as const, label: 'Expressiveness', left: 'Reserved', right: 'Vocal' },
+  { key: 'curiosity' as const, label: 'Curiosity', left: 'Matter-of-fact', right: 'Inquisitive' },
+  { key: 'humor' as const, label: 'Humor', left: 'Dry', right: 'Playful' },
+];
+
+onMounted(async () => {
+  try {
+    const data = await cognition.personality();
+    const t = data.tuple || [0, 0, 0, 0, 0];
+    personality.warmth = t[0];
+    personality.mood = t[1];
+    personality.expressiveness = t[2];
+    personality.curiosity = t[3];
+    personality.humor = t[4];
+  } catch {
+    loadFailed.value = true;
+  } finally {
+    loading.value = false;
+  }
+});
+
+async function save() {
+  const tuple: [number, number, number, number, number] = [
+    personality.warmth,
+    personality.mood,
+    personality.expressiveness,
+    personality.curiosity,
+    personality.humor,
+  ];
+  try {
+    await cognition.setPersonality({ tuple });
+    showToast('Personality saved', 'success');
+  } catch (e: unknown) {
+    showToast(e instanceof HttpError ? 'Failed to save' : 'Network error', 'error');
+  }
+}
+</script>
+
 <template>
-  <div class="panel-placeholder"><p>Personality sub-panel — implementation in P2b.</p></div>
+  <template v-if="loading"><div class="loading">Loading…</div></template>
+  <template v-else-if="loadFailed"><EmptyState message="Failed to load data." /></template>
+  <template v-else>
+    <p class="panel-desc">Adjust how Chalie communicates. Changes take effect on the next message.</p>
+    <div class="personality-grid">
+      <div v-for="s in sliders" :key="s.key" class="personality-row">
+        <span class="pole pole-left">{{ s.left }}</span>
+        <div class="personality-track">
+          <label class="personality-label">{{ s.label }}</label>
+          <input
+            v-model.number="personality[s.key]"
+            type="range"
+            min="-2"
+            max="2"
+            step="1"
+            class="personality-range"
+            :data-key="s.key"
+          />
+        </div>
+        <span class="pole pole-right">{{ s.right }}</span>
+      </div>
+    </div>
+    <div class="personality-actions">
+      <button class="btn btn-primary" @click="save">Save</button>
+    </div>
+  </template>
 </template>

--- a/frontend/apps/brain/src/views/cognition/ToolsSub.vue
+++ b/frontend/apps/brain/src/views/cognition/ToolsSub.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.subTitle = 'Tools'; });
-</script>
-
 <template>
   <div class="panel-placeholder"><p>Tools sub-panel — implementation in P2b.</p></div>
 </template>

--- a/frontend/apps/brain/src/views/cognition/ToolsSub.vue
+++ b/frontend/apps/brain/src/views/cognition/ToolsSub.vue
@@ -1,3 +1,46 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { cognition } from '../../api/cognition';
+import type { Tool } from '../../api/cognition';
+import { formatDate } from '../../utils/format';
+import EmptyState from '../../ui/EmptyState.vue';
+
+const loading = ref(true);
+const loadFailed = ref(false);
+const tools = ref<Tool[]>([]);
+
+onMounted(async () => {
+  try {
+    const data = await cognition.tools();
+    tools.value = data.tools || [];
+  } catch {
+    loadFailed.value = true;
+  } finally {
+    loading.value = false;
+  }
+});
+</script>
+
 <template>
-  <div class="panel-placeholder"><p>Tools sub-panel — implementation in P2b.</p></div>
+  <template v-if="loading"><div class="loading">Loading…</div></template>
+  <template v-else-if="loadFailed"><EmptyState message="Failed to load data." /></template>
+  <template v-else>
+    <EmptyState v-if="tools.length === 0" message="No tools loaded." />
+    <table v-else class="records-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Calls</th>
+          <th>Last Used</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(t, i) in tools" :key="i">
+          <td class="key-cell">{{ t.tool_name || '' }}</td>
+          <td>{{ t.count ?? '—' }}</td>
+          <td>{{ formatDate(t.last_used_at) || '—' }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </template>
 </template>

--- a/frontend/apps/brain/src/views/cognition/ToolsSub.vue
+++ b/frontend/apps/brain/src/views/cognition/ToolsSub.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.subTitle = 'Tools'; });
+</script>
+
+<template>
+  <div class="panel-placeholder"><p>Tools sub-panel — implementation in P2b.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/cognition/UsageSub.vue
+++ b/frontend/apps/brain/src/views/cognition/UsageSub.vue
@@ -1,3 +1,325 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { cognition } from '../../api/cognition';
+import type { UsageResponse } from '../../api/cognition';
+import EmptyState from '../../ui/EmptyState.vue';
+
+// ---------------------------------------------------------------------------
+// Constants — ported verbatim from cognition.js
+// ---------------------------------------------------------------------------
+const _MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const _DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const _TABLE_HEADERS: Record<string, string> = { hour: 'Hour', day: 'Hour', week: 'Day', month: 'Day', lifetime: 'Month' };
+
+type UsageWindow = 'hour' | 'day' | 'week' | 'month' | 'lifetime';
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+const usageWindow = ref<UsageWindow>('day');
+const data = ref<UsageResponse | null>(null);
+const loading = ref(true);
+const loadFailed = ref(false);
+
+// ---------------------------------------------------------------------------
+// _fmtTokens — verbatim port from cognition.js:383-387
+// ---------------------------------------------------------------------------
+function fmtTokens(n: number): string {
+  if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
+  return String(n);
+}
+
+// ---------------------------------------------------------------------------
+// Fetch
+// ---------------------------------------------------------------------------
+async function load(): Promise<void> {
+  loading.value = true;
+  loadFailed.value = false;
+  try {
+    data.value = await cognition.tokenUsage(usageWindow.value);
+  } catch {
+    loadFailed.value = true;
+  } finally {
+    loading.value = false;
+  }
+}
+
+function selectWindow(w: UsageWindow): void {
+  usageWindow.value = w;
+  load();
+}
+
+onMounted(load);
+
+// ---------------------------------------------------------------------------
+// Computed helpers
+// ---------------------------------------------------------------------------
+
+interface BucketValue { input: number; output: number }
+
+/** Build bucketMap from entries — verbatim port of _renderUsage bucketMap logic. */
+const bucketMap = computed((): Record<string, BucketValue> => {
+  const entries = data.value?.entries ?? [];
+  const map: Record<string, BucketValue> = {};
+  for (const e of entries) {
+    const b = e.bucket || '';
+    if (!map[b]) map[b] = { input: 0, output: 0 };
+    map[b].input += (e.tokens_input ?? 0) + (e.tokens_cache_read ?? 0);
+    map[b].output += (e.tokens_output ?? 0) + (e.tokens_thinking ?? 0);
+  }
+  return map;
+});
+
+/** Summary stat cards — verbatim port of _renderUsage summary array. */
+const windowLabels: Record<UsageWindow, string> = {
+  hour: 'Last Hour',
+  day: 'Last 24h',
+  week: 'Last 7 Days',
+  month: 'Last 30 Days',
+  lifetime: 'All Time',
+};
+
+const summaryCards = computed(() => {
+  const rawSummary = data.value?.summary ?? {};
+  return [
+    { value: fmtTokens(rawSummary.total_tokens ?? 0), label: windowLabels[usageWindow.value] ?? 'Total Tokens' },
+    { value: rawSummary.cache_hit_pct != null ? `${rawSummary.cache_hit_pct}%` : 'N/A', label: 'Cache Hit Rate' },
+    { value: fmtTokens(rawSummary.tokens_today ?? 0), label: 'Today (UTC)' },
+    { value: rawSummary.most_active_model || '—', label: 'Top Model' },
+  ];
+});
+
+/** Chart data — verbatim port of chart logic in _renderUsage. */
+interface ChartBar { label: string; input: number; output: number }
+
+const chartData = computed((): ChartBar[] => {
+  return Object.entries(bucketMap.value)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([bucket, v]) => {
+      let label: string;
+      if (usageWindow.value === 'hour' || usageWindow.value === 'day') label = bucket.slice(11, 16);
+      else label = bucket.slice(5, 10);
+      return { label, input: v.input, output: v.output };
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Slot builders — verbatim ports from cognition.js:419-492
+// ---------------------------------------------------------------------------
+
+interface SlotRow { label: string; input: number; output: number }
+
+function buildHourSlots(bm: Record<string, BucketValue>): SlotRow[] {
+  return Object.entries(bm)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => ({ label: k.slice(11, 16), input: v.input, output: v.output }));
+}
+
+function buildDaySlots(bm: Record<string, BucketValue>): SlotRow[] {
+  const todayPrefix = new Date().toISOString().slice(0, 10);
+  const slots: SlotRow[] = [];
+  for (let h = 0; h < 24; h++) {
+    const hh = String(h).padStart(2, '0');
+    const key = `${todayPrefix}T${hh}:00:00`;
+    const d = bm[key] ?? { input: 0, output: 0 };
+    slots.push({ label: `${hh}:00`, input: d.input, output: d.output });
+  }
+  return slots;
+}
+
+function buildWeekSlots(bm: Record<string, BucketValue>, now: Date): SlotRow[] {
+  const slots: SlotRow[] = [];
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date(now);
+    d.setUTCDate(d.getUTCDate() - i);
+    const key = d.toISOString().slice(0, 10);
+    const dd = String(d.getUTCDate()).padStart(2, '0');
+    const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const label = `${_DAY_NAMES[d.getUTCDay()]} ${dd}/${mm}`;
+    const data = bm[key] ?? { input: 0, output: 0 };
+    slots.push({ label, input: data.input, output: data.output });
+  }
+  return slots;
+}
+
+function buildMonthSlots(bm: Record<string, BucketValue>, now: Date): SlotRow[] {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  const daysInMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+  const slots: SlotRow[] = [];
+  for (let day = 1; day <= daysInMonth; day++) {
+    const key = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    const label = `${String(day).padStart(2, '0')} ${_MONTH_NAMES[month]}`;
+    const d = bm[key] ?? { input: 0, output: 0 };
+    slots.push({ label, input: d.input, output: d.output });
+  }
+  return slots;
+}
+
+function buildLifetimeSlots(bm: Record<string, BucketValue>, now: Date): SlotRow[] {
+  const keys = Object.keys(bm).sort();
+  if (keys.length === 0) return [];
+  const monthAgg: Record<string, BucketValue> = {};
+  for (const [k, v] of Object.entries(bm)) {
+    const mk = k.slice(0, 7);
+    if (!monthAgg[mk]) monthAgg[mk] = { input: 0, output: 0 };
+    monthAgg[mk].input += v.input;
+    monthAgg[mk].output += v.output;
+  }
+  const slots: SlotRow[] = [];
+  let [y, m] = keys[0].slice(0, 7).split('-').map(Number) as [number, number];
+  const endY = now.getUTCFullYear();
+  const endM = now.getUTCMonth() + 1;
+  while (y < endY || (y === endY && m <= endM)) {
+    const mk = `${y}-${String(m).padStart(2, '0')}`;
+    const label = `${_MONTH_NAMES[m - 1]} ${String(y).slice(2)}`;
+    const d = monthAgg[mk] ?? { input: 0, output: 0 };
+    slots.push({ label, input: d.input, output: d.output });
+    if (++m > 12) { m = 1; y++; }
+  }
+  return slots;
+}
+
+function buildTableSlots(bm: Record<string, BucketValue>): SlotRow[] {
+  const now = new Date();
+  if (usageWindow.value === 'hour') return buildHourSlots(bm);
+  if (usageWindow.value === 'day') return buildDaySlots(bm);
+  if (usageWindow.value === 'week') return buildWeekSlots(bm, now);
+  if (usageWindow.value === 'month') return buildMonthSlots(bm, now);
+  if (usageWindow.value === 'lifetime') return buildLifetimeSlots(bm, now);
+  return [];
+}
+
+const tableSlots = computed((): SlotRow[] => buildTableSlots(bucketMap.value));
+
+const tableHeader = computed((): string => _TABLE_HEADERS[usageWindow.value] ?? 'Date');
+
+// ---------------------------------------------------------------------------
+// Chart geometry — verbatim port from cognition.js:494-513
+// ---------------------------------------------------------------------------
+
+interface BarGeom {
+  x: number;
+  outputY: number;
+  outputH: number;
+  inputY: number;
+  inputH: number;
+  barW: number;
+  label: string;
+  showLabel: boolean;
+  labelX: number;
+  labelY: number;
+}
+
+const chartGeom = computed(() => {
+  const chart = chartData.value;
+  if (chart.length === 0) return null;
+  const maxVal = Math.max(...chart.map(d => (d.input || 0) + (d.output || 0)), 1);
+  const barW = Math.max(16, Math.floor(600 / chart.length) - 4);
+  const h = 160;
+  const labelH = 40;
+  const showEvery = chart.length > 20 ? Math.ceil(chart.length / 15) : 1;
+  const svgW = chart.length * (barW + 4);
+
+  const bars: BarGeom[] = chart.map((d, i) => {
+    const inputH = ((d.input || 0) / maxVal) * h;
+    const outputH = ((d.output || 0) / maxVal) * h;
+    const x = i * (barW + 4);
+    const showLabel = i % showEvery === 0;
+    return {
+      x,
+      outputY: h - inputH - outputH,
+      outputH,
+      inputY: h - inputH,
+      inputH,
+      barW,
+      label: d.label ?? '',
+      showLabel,
+      labelX: x + barW / 2,
+      labelY: h + 6,
+    };
+  });
+
+  return { bars, svgW, h, labelH };
+});
+</script>
+
 <template>
-  <div class="panel-placeholder"><p>Usage sub-panel — implementation in P2b.</p></div>
+  <template v-if="loading"><div class="loading">Loading…</div></template>
+  <template v-else-if="loadFailed"><EmptyState message="Failed to load data." /></template>
+  <template v-else>
+    <div id="usageWindowTabs" class="filter-tabs">
+      <button
+        v-for="w in (['hour', 'day', 'week', 'month', 'lifetime'] as const)"
+        :key="w"
+        class="filter-tab"
+        :class="{ active: w === usageWindow }"
+        @click="selectWindow(w)"
+      >{{ w.charAt(0).toUpperCase() + w.slice(1) }}</button>
+    </div>
+
+    <div class="stat-grid">
+      <div v-for="card in summaryCards" :key="card.label" class="stat-card">
+        <div class="stat-value">{{ card.value }}</div>
+        <div class="stat-label">{{ card.label }}</div>
+      </div>
+    </div>
+
+    <template v-if="chartGeom">
+      <div class="chart-wrap">
+        <!-- eslint-disable-next-line vue/html-self-closing -->
+        <svg
+          class="usage-chart"
+          :viewBox="`0 0 ${chartGeom.svgW} ${chartGeom.h + chartGeom.labelH}`"
+          preserveAspectRatio="none"
+        >
+          <g v-for="(bar, i) in chartGeom.bars" :key="i">
+            <rect
+              :x="bar.x"
+              :y="bar.outputY"
+              :width="bar.barW"
+              :height="bar.outputH"
+              class="bar-cloud"
+            />
+            <rect
+              :x="bar.x"
+              :y="bar.inputY"
+              :width="bar.barW"
+              :height="bar.inputH"
+              class="bar-local"
+            />
+            <text
+              v-if="bar.showLabel"
+              :x="bar.labelX"
+              :y="bar.labelY"
+              class="bar-label"
+              :transform="`rotate(45 ${bar.labelX} ${bar.labelY})`"
+            >{{ bar.label }}</text>
+          </g>
+        </svg>
+      </div>
+      <div class="chart-legend">
+        <span class="legend-local">Chat</span>
+        <span class="legend-cloud">Subconscious</span>
+      </div>
+    </template>
+
+    <table v-if="tableSlots.length > 0" class="usage-table">
+      <thead>
+        <tr>
+          <th>{{ tableHeader }}</th>
+          <th>Input Tokens</th>
+          <th>Output Tokens</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(slot, i) in tableSlots" :key="i">
+          <td>{{ slot.label }}</td>
+          <td class="num">{{ (slot.input || 0).toLocaleString() }}</td>
+          <td class="num">{{ (slot.output || 0).toLocaleString() }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </template>
 </template>

--- a/frontend/apps/brain/src/views/cognition/UsageSub.vue
+++ b/frontend/apps/brain/src/views/cognition/UsageSub.vue
@@ -33,15 +33,21 @@ function fmtTokens(n: number): string {
 // ---------------------------------------------------------------------------
 // Fetch
 // ---------------------------------------------------------------------------
+let fetchGen = 0;
+
 async function load(): Promise<void> {
+  const gen = ++fetchGen;
   loading.value = true;
   loadFailed.value = false;
   try {
-    data.value = await cognition.tokenUsage(usageWindow.value);
+    const result = await cognition.tokenUsage(usageWindow.value);
+    if (gen !== fetchGen) return;
+    data.value = result;
   } catch {
+    if (gen !== fetchGen) return;
     loadFailed.value = true;
   } finally {
-    loading.value = false;
+    if (gen === fetchGen) loading.value = false;
   }
 }
 
@@ -274,7 +280,7 @@ const chartGeom = computed(() => {
           :viewBox="`0 0 ${chartGeom.svgW} ${chartGeom.h + chartGeom.labelH}`"
           preserveAspectRatio="none"
         >
-          <g v-for="(bar, i) in chartGeom.bars" :key="i">
+          <g v-for="bar in chartGeom.bars" :key="bar.label">
             <rect
               :x="bar.x"
               :y="bar.outputY"
@@ -314,7 +320,7 @@ const chartGeom = computed(() => {
         </tr>
       </thead>
       <tbody>
-        <tr v-for="(slot, i) in tableSlots" :key="i">
+        <tr v-for="slot in tableSlots" :key="slot.label">
           <td>{{ slot.label }}</td>
           <td class="num">{{ (slot.input || 0).toLocaleString() }}</td>
           <td class="num">{{ (slot.output || 0).toLocaleString() }}</td>

--- a/frontend/apps/brain/src/views/cognition/UsageSub.vue
+++ b/frontend/apps/brain/src/views/cognition/UsageSub.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.subTitle = 'Usage'; });
-</script>
-
 <template>
   <div class="panel-placeholder"><p>Usage sub-panel — implementation in P2b.</p></div>
 </template>

--- a/frontend/apps/brain/src/views/cognition/UsageSub.vue
+++ b/frontend/apps/brain/src/views/cognition/UsageSub.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.subTitle = 'Usage'; });
+</script>
+
+<template>
+  <div class="panel-placeholder"><p>Usage sub-panel — implementation in P2b.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/cognition/WorldSub.vue
+++ b/frontend/apps/brain/src/views/cognition/WorldSub.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.subTitle = 'World'; });
+</script>
+
+<template>
+  <div class="panel-placeholder"><p>World sub-panel — implementation in P2b.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/cognition/WorldSub.vue
+++ b/frontend/apps/brain/src/views/cognition/WorldSub.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.subTitle = 'World'; });
-</script>
-
 <template>
   <div class="panel-placeholder"><p>World sub-panel — implementation in P2b.</p></div>
 </template>

--- a/frontend/apps/brain/src/views/cognition/WorldSub.vue
+++ b/frontend/apps/brain/src/views/cognition/WorldSub.vue
@@ -1,3 +1,150 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { cognition } from '../../api/cognition';
+import type { WorldState, WorldTelemetry, WorldSchedule } from '../../api/cognition';
+import { formatDate, escapeHtml } from '../../utils/format';
+import EmptyState from '../../ui/EmptyState.vue';
+import SegmentedControl from '../../ui/SegmentedControl.vue';
+
+const worldState = ref<WorldState>({});
+const viewMode = ref<'formatted' | 'raw'>('formatted');
+const loading = ref(false);
+const loadFailed = ref(false);
+
+async function load(): Promise<void> {
+  loading.value = true;
+  loadFailed.value = false;
+  try {
+    worldState.value = await cognition.worldState();
+  } catch {
+    loadFailed.value = true;
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(load);
+
+const inputs = computed(() => worldState.value.inputs || {});
+const telemetry = computed<WorldTelemetry>(() => inputs.value.telemetry || {});
+const schedule = computed<WorldSchedule[]>(() => inputs.value.schedule || []);
+const signals = computed<Record<string, { label?: string; [k: string]: unknown }>>(() => inputs.value.signals || {});
+const bgProcs = computed<(string | Record<string, unknown>)[]>(() => inputs.value.bg_processes || []);
+
+const deviceInfo = computed(() => telemetry.value.device || {});
+const battery = computed(() => telemetry.value.battery || {});
+const location = computed(() => telemetry.value.location_name || '');
+const localTime = computed(() => telemetry.value.local_time || '');
+const timezone = computed(() => telemetry.value.timezone || '');
+const prefs = computed(() => telemetry.value.preferences || {});
+
+const signalEntries = computed(() => Object.entries(signals.value));
+const pendingSched = computed(() => schedule.value.filter((s) => s.status === 'pending'));
+
+function batteryText(): string {
+  const pct = Math.round((battery.value.level || 0) * 100);
+  return `${pct}%${battery.value.charging ? ' ⚡ charging' : ''}`;
+}
+
+function deviceText(): string {
+  const d = deviceInfo.value;
+  return `${d.class || '—'} · ${d.platform || ''} · ${d.screen_w || '?'}×${d.screen_h || '?'}`;
+}
+
+function mdToHtml(md: string): string {
+  return escapeHtml(md)
+    .replace(/^### (.+)$/gm, '<h3>$1</h3>')
+    .replace(/^## (.+)$/gm, '<h3>$1</h3>')
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/^\* (.+)$/gm, '<li>$1</li>')
+    .replace(/(<li>.*<\/li>\n?)+/g, (m) => `<ul>${m}</ul>`)
+    .replace(/\[([^\]]+)\]/g, '<span class="world-tag">$1</span>')
+    .replace(/\n{2,}/g, '<br>')
+    .replace(/\n/g, '\n');
+}
+</script>
+
 <template>
-  <div class="panel-placeholder"><p>World sub-panel — implementation in P2b.</p></div>
+  <template v-if="loading"><div class="loading">Loading…</div></template>
+  <template v-else-if="loadFailed"><EmptyState message="Failed to load data." /></template>
+  <template v-else>
+    <div class="world-state-grid">
+      <!-- Device & Environment -->
+      <div class="world-section">
+        <h4>Device &amp; Environment</h4>
+        <table class="records-table">
+          <tbody>
+            <tr><td class="key-cell">Location</td><td>{{ location || '—' }}</td></tr>
+            <tr><td class="key-cell">Local Time</td><td>{{ localTime }} ({{ timezone }})</td></tr>
+            <tr><td class="key-cell">Device</td><td>{{ deviceText() }}</td></tr>
+            <tr><td class="key-cell">Battery</td><td>{{ batteryText() }}</td></tr>
+            <tr><td class="key-cell">Network</td><td>{{ telemetry.connection || '—' }}</td></tr>
+            <tr><td class="key-cell">Theme</td><td>{{ prefs.color_scheme || '—' }}</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Pending Schedules (conditional) -->
+      <div v-if="pendingSched.length > 0" class="world-section">
+        <h4>Pending Schedules</h4>
+        <table class="records-table">
+          <thead>
+            <tr><th>Message</th><th>Due</th><th>Recurrence</th></tr>
+          </thead>
+          <tbody>
+            <tr v-for="(s, i) in pendingSched" :key="i">
+              <td class="key-cell">{{ s.message || '' }}</td>
+              <td>{{ formatDate(s.due_at) }}</td>
+              <td>{{ s.recurrence || '—' }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Active Signals (conditional) -->
+      <div v-if="signalEntries.length > 0" class="world-section">
+        <h4>Active Signals</h4>
+        <table class="records-table">
+          <thead>
+            <tr><th>Signal</th><th>Label</th></tr>
+          </thead>
+          <tbody>
+            <tr v-for="([k, v], i) in signalEntries" :key="i">
+              <td class="key-cell">{{ k }}</td>
+              <td>{{ v.label || JSON.stringify(v) }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Background Processes -->
+      <div class="world-section">
+        <h4>Background Processes</h4>
+        <table v-if="bgProcs.length > 0" class="records-table">
+          <tbody>
+            <tr v-for="(p, i) in bgProcs" :key="i">
+              <td>{{ typeof p === 'string' ? p : JSON.stringify(p) }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <p v-else class="panel-desc">None running.</p>
+      </div>
+
+      <!-- What Chalie Sees (conditional) -->
+      <div v-if="worldState.rendered" class="world-section">
+        <div class="world-sees-header">
+          <h4>What Chalie Sees</h4>
+          <SegmentedControl
+            v-model="viewMode"
+            :segments="[{ value: 'formatted', label: 'Formatted' }, { value: 'raw', label: 'Raw' }]"
+          />
+        </div>
+        <div v-if="viewMode === 'raw'" class="code-block">
+          <pre><code>{{ worldState.rendered }}</code></pre>
+        </div>
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <div v-else class="doc-content world-formatted" v-html="mdToHtml(worldState.rendered)"></div>
+      </div>
+    </div>
+  </template>
 </template>

--- a/frontend/apps/brain/src/views/cognition/WorldSub.vue
+++ b/frontend/apps/brain/src/views/cognition/WorldSub.vue
@@ -41,15 +41,15 @@ const prefs = computed(() => telemetry.value.preferences || {});
 const signalEntries = computed(() => Object.entries(signals.value));
 const pendingSched = computed(() => schedule.value.filter((s) => s.status === 'pending'));
 
-function batteryText(): string {
+const batteryText = computed((): string => {
   const pct = Math.round((battery.value.level || 0) * 100);
   return `${pct}%${battery.value.charging ? ' ⚡ charging' : ''}`;
-}
+});
 
-function deviceText(): string {
+const deviceText = computed((): string => {
   const d = deviceInfo.value;
   return `${d.class || '—'} · ${d.platform || ''} · ${d.screen_w || '?'}×${d.screen_h || '?'}`;
-}
+});
 
 function mdToHtml(md: string): string {
   return escapeHtml(md)
@@ -76,8 +76,8 @@ function mdToHtml(md: string): string {
           <tbody>
             <tr><td class="key-cell">Location</td><td>{{ location || '—' }}</td></tr>
             <tr><td class="key-cell">Local Time</td><td>{{ localTime }} ({{ timezone }})</td></tr>
-            <tr><td class="key-cell">Device</td><td>{{ deviceText() }}</td></tr>
-            <tr><td class="key-cell">Battery</td><td>{{ batteryText() }}</td></tr>
+            <tr><td class="key-cell">Device</td><td>{{ deviceText }}</td></tr>
+            <tr><td class="key-cell">Battery</td><td>{{ batteryText }}</td></tr>
             <tr><td class="key-cell">Network</td><td>{{ telemetry.connection || '—' }}</td></tr>
             <tr><td class="key-cell">Theme</td><td>{{ prefs.color_scheme || '—' }}</td></tr>
           </tbody>
@@ -92,7 +92,7 @@ function mdToHtml(md: string): string {
             <tr><th>Message</th><th>Due</th><th>Recurrence</th></tr>
           </thead>
           <tbody>
-            <tr v-for="(s, i) in pendingSched" :key="i">
+            <tr v-for="s in pendingSched" :key="`${s.due_at}-${s.message}`">
               <td class="key-cell">{{ s.message || '' }}</td>
               <td>{{ formatDate(s.due_at) }}</td>
               <td>{{ s.recurrence || '—' }}</td>
@@ -109,7 +109,7 @@ function mdToHtml(md: string): string {
             <tr><th>Signal</th><th>Label</th></tr>
           </thead>
           <tbody>
-            <tr v-for="([k, v], i) in signalEntries" :key="i">
+            <tr v-for="([k, v]) in signalEntries" :key="k">
               <td class="key-cell">{{ k }}</td>
               <td>{{ v.label || JSON.stringify(v) }}</td>
             </tr>

--- a/frontend/apps/brain/src/views/documents/ActiveSub.vue
+++ b/frontend/apps/brain/src/views/documents/ActiveSub.vue
@@ -1,3 +1,4 @@
-<template>
-  <div class="panel-placeholder"><p>Documents Active — implementation in P2c.</p></div>
-</template>
+<script setup lang="ts">
+import DocumentsPanel from './DocumentsPanel.vue';
+</script>
+<template><DocumentsPanel status-filter="active" /></template>

--- a/frontend/apps/brain/src/views/documents/ActiveSub.vue
+++ b/frontend/apps/brain/src/views/documents/ActiveSub.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.subTitle = 'Active'; });
+</script>
+
+<template>
+  <div class="panel-placeholder"><p>Documents Active — implementation in P2c.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/documents/ActiveSub.vue
+++ b/frontend/apps/brain/src/views/documents/ActiveSub.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.subTitle = 'Active'; });
-</script>
-
 <template>
   <div class="panel-placeholder"><p>Documents Active — implementation in P2c.</p></div>
 </template>

--- a/frontend/apps/brain/src/views/documents/DeletedSub.vue
+++ b/frontend/apps/brain/src/views/documents/DeletedSub.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.subTitle = 'Deleted'; });
-</script>
-
 <template>
   <div class="panel-placeholder"><p>Documents Deleted — implementation in P2c.</p></div>
 </template>

--- a/frontend/apps/brain/src/views/documents/DeletedSub.vue
+++ b/frontend/apps/brain/src/views/documents/DeletedSub.vue
@@ -1,3 +1,4 @@
-<template>
-  <div class="panel-placeholder"><p>Documents Deleted — implementation in P2c.</p></div>
-</template>
+<script setup lang="ts">
+import DocumentsPanel from './DocumentsPanel.vue';
+</script>
+<template><DocumentsPanel status-filter="deleted" /></template>

--- a/frontend/apps/brain/src/views/documents/DeletedSub.vue
+++ b/frontend/apps/brain/src/views/documents/DeletedSub.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.subTitle = 'Deleted'; });
+</script>
+
+<template>
+  <div class="panel-placeholder"><p>Documents Deleted — implementation in P2c.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/documents/DocumentsPanel.vue
+++ b/frontend/apps/brain/src/views/documents/DocumentsPanel.vue
@@ -1,0 +1,313 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { documents } from '../../api/documents';
+import type { Document, WatchedFolder } from '../../api/documents';
+import { formatDate } from '../../utils/format';
+import { useToast } from '../../composables/useToast';
+import { useConfirm } from '../../composables/useConfirm';
+import { HttpError } from '@chalie/shared';
+import BrainIcon from '../../ui/BrainIcon.vue';
+
+const props = defineProps<{
+  statusFilter: 'active' | 'processing' | 'uploads' | 'deleted';
+}>();
+
+const { show: showToast } = useToast();
+const { confirm } = useConfirm();
+
+const docs = ref<Document[]>([]);
+const folders = ref<WatchedFolder[]>([]);
+const loading = ref(true);
+const search = ref('');
+const groupBy = ref('all');
+const drillGroup = ref<string | null>(null);
+const viewMode = ref<'list' | 'detail'>('list');
+const detailDoc = ref<Document | null>(null);
+const fileInput = ref<HTMLInputElement | null>(null);
+
+async function load(): Promise<void> {
+  loading.value = true;
+  try {
+    const [docRes, wfRes] = await Promise.all([
+      documents.list(props.statusFilter === 'deleted'),
+      documents.watchedFolders(),
+    ]);
+    docs.value = docRes.items ?? [];
+    folders.value = wfRes.items ?? [];
+  } catch {
+    showToast('Failed to load documents', 'error');
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(load);
+
+const filtered = computed<Document[]>(() => {
+  let result = docs.value;
+  if (props.statusFilter === 'active') {
+    result = result.filter((d) => (d.status as string) === 'ready');
+  } else if (props.statusFilter === 'processing') {
+    result = result.filter((d) =>
+      ['building', 'processing', 'pending'].includes((d.status as string) ?? ''),
+    );
+  } else if (props.statusFilter === 'uploads') {
+    result = result.filter((d) => (d.source_type as string) === 'upload');
+  } else if (props.statusFilter === 'deleted') {
+    result = result.filter((d) => (d.deleted_at as string | null) != null);
+  }
+  if (search.value) {
+    const q = search.value.toLowerCase();
+    result = result.filter(
+      (d) =>
+        ((d.original_name as string) || '').toLowerCase().includes(q) ||
+        ((d.doc_category as string) || '').toLowerCase().includes(q),
+    );
+  }
+  return result;
+});
+
+type GroupEntry = { name: string; count: number };
+
+const groupEntries = computed<GroupEntry[]>(() => {
+  if (groupBy.value === 'all') return [];
+  const key = groupBy.value;
+  const groups: Record<string, number> = {};
+  for (const d of filtered.value) {
+    const k = String(d[key] ?? 'Other') || 'Other';
+    groups[k] = (groups[k] ?? 0) + 1;
+  }
+  return Object.entries(groups)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, count]) => ({ name, count }));
+});
+
+const drillDocs = computed<Document[]>(() => {
+  if (!drillGroup.value) return filtered.value;
+  const key = groupBy.value;
+  const drill = drillGroup.value;
+  return filtered.value.filter((d) => (String(d[key] ?? 'Other') || 'Other') === drill);
+});
+
+function statusClass(status: unknown): string {
+  const map: Record<string, string> = {
+    ready: 'badge-success',
+    building: 'badge-warning',
+    processing: 'badge-warning',
+    failed: 'badge-danger',
+    error: 'badge-danger',
+    deleted: 'badge-muted',
+  };
+  return map[(status as string) ?? ''] ?? 'badge-muted';
+}
+
+function fmtSize(bytes: unknown): string {
+  const n = bytes as number | null | undefined;
+  if (!n) return '—';
+  if (n >= 1048576) return `${(n / 1048576).toFixed(1)} MB`;
+  if (n >= 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${n} B`;
+}
+
+async function onSearch(event: Event): Promise<void> {
+  search.value = (event.target as HTMLInputElement).value;
+  drillGroup.value = null;
+  await load();
+}
+
+async function viewDoc(d: Document): Promise<void> {
+  try {
+    const data = await documents.get(d.id);
+    detailDoc.value = data.item;
+    viewMode.value = 'detail';
+  } catch {
+    showToast('Failed to load document', 'error');
+  }
+}
+
+async function deleteDoc(d: Document): Promise<void> {
+  const ok = await confirm({
+    title: 'Delete Document',
+    desc: `Delete "${(d.original_name as string) || 'this document'}"? This cannot be undone.`,
+    confirmLabel: 'Delete',
+    confirmClass: 'btn-danger',
+  });
+  if (!ok) return;
+  try {
+    await documents.delete(d.id);
+    showToast('Document deleted', 'success');
+    drillGroup.value = null;
+    await load();
+  } catch (e) {
+    showToast(e instanceof HttpError ? 'Delete failed' : 'Network error', 'error');
+  }
+}
+
+async function onUpload(event: Event): Promise<void> {
+  const input = event.target as HTMLInputElement;
+  const file = input.files?.[0];
+  if (!file) return;
+  const fd = new FormData();
+  fd.append('file', file);
+  try {
+    await documents.upload(fd);
+    showToast('Document uploaded', 'success');
+    drillGroup.value = null;
+    await load();
+  } catch (e) {
+    showToast(e instanceof HttpError ? (e.error || 'Upload failed') : 'Network error', 'error');
+  } finally {
+    input.value = '';
+  }
+}
+</script>
+
+<template>
+  <div class="panel-header">
+    <h2>Documents</h2>
+    <div class="panel-header-actions">
+      <input
+        type="text"
+        class="search-input"
+        placeholder="Search documents…"
+        @keydown.enter="onSearch"
+      >
+      <button class="btn btn-secondary" @click="fileInput?.click()">
+        <BrainIcon name="Upload" :size="14" /> Upload
+      </button>
+    </div>
+  </div>
+
+  <input
+    ref="fileInput"
+    type="file"
+    accept=".pdf,.docx,.md,.txt,.csv,.zip"
+    style="display:none"
+    @change="onUpload"
+  >
+
+  <!-- Detail view -->
+  <template v-if="viewMode === 'detail'">
+    <div class="provider-form-page" style="max-width:none">
+      <div class="form-page-header">
+        <button class="btn btn-secondary btn-sm back-btn" @click="viewMode = 'list'">
+          <BrainIcon name="Chevron" :size="14" /> Back
+        </button>
+        <h3>{{ (detailDoc?.original_name as string) || 'Document' }}</h3>
+      </div>
+      <div class="doc-meta-row">
+        <span v-if="detailDoc?.source_type" class="badge badge-muted">{{ detailDoc.source_type }}</span>
+        <span v-if="detailDoc?.doc_category" class="badge badge-violet">{{ detailDoc.doc_category }}</span>
+        <span v-if="detailDoc?.file_size_bytes" class="doc-meta-item">{{ fmtSize(detailDoc.file_size_bytes) }}</span>
+        <span v-if="detailDoc?.created_at" class="doc-meta-item">{{ formatDate(detailDoc.created_at as string) }}</span>
+      </div>
+      <pre class="doc-content">{{ (detailDoc?.summary as string) || 'No content available.' }}</pre>
+    </div>
+  </template>
+
+  <!-- List view -->
+  <template v-else>
+    <!-- Group tabs -->
+    <div class="doc-group-tabs">
+      <button
+        v-for="tab in [
+          { key: 'all', label: 'All' },
+          { key: 'doc_category', label: 'Category' },
+          { key: 'doc_project', label: 'Project' },
+          { key: 'doc_date', label: 'Date' },
+        ]"
+        :key="tab.key"
+        class="group-tab"
+        :class="{ active: groupBy === tab.key }"
+        @click="groupBy = tab.key; drillGroup = null"
+      >
+        {{ tab.label }}
+      </button>
+    </div>
+
+    <!-- Watched folders section -->
+    <div v-if="!drillGroup && folders.length > 0" class="watched-folders-section">
+      <h4 class="section-head">Watched Folders</h4>
+      <div class="watched-folders-list">
+        <div v-for="f in folders" :key="f.id" class="watched-folder-item">
+          <span class="wf-icon"><BrainIcon name="Eye" :size="14" /></span>
+          <span class="wf-label">{{ (f.label as string) || (f.path as string) || '' }}</span>
+          <span class="wf-path">{{ (f.path as string) || '' }}</span>
+          <span class="wf-meta">{{ (f.files as number) || 0 }} files · {{ formatDate(f.last_scan as string) }}</span>
+          <span class="wf-status">
+            <span class="status-dot" :class="{ active: f.active }"></span>
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="loading">Loading…</div>
+
+    <!-- Empty state (takes precedence over grouping when nothing matches) -->
+    <template v-else-if="filtered.length === 0">
+      <div class="empty-state">
+        <div class="empty-icon">
+          <BrainIcon name="Document" :size="40" />
+        </div>
+        <h3>No documents</h3>
+        <p>Upload or watch a folder to get started.</p>
+      </div>
+    </template>
+
+    <!-- Group cards (groupBy !== 'all' and no drill) -->
+    <template v-else-if="groupBy !== 'all' && !drillGroup">
+      <div class="group-cards-grid">
+        <button
+          v-for="entry in groupEntries"
+          :key="entry.name"
+          class="group-card"
+          @click="drillGroup = entry.name"
+        >
+          <div class="group-card-name">{{ entry.name }}</div>
+          <div class="group-card-count">{{ entry.count }} document{{ entry.count === 1 ? '' : 's' }}</div>
+        </button>
+      </div>
+    </template>
+
+    <!-- Table (all docs or drill-down) -->
+    <template v-else>
+      <!-- Drill-down header -->
+      <div v-if="drillGroup" class="form-page-header">
+        <button class="btn btn-secondary btn-sm back-btn" @click="drillGroup = null">
+          <BrainIcon name="Chevron" :size="14" /> Back
+        </button>
+        <h3>{{ drillGroup }}</h3>
+        <span class="doc-meta-item">{{ drillDocs.length }} document{{ drillDocs.length === 1 ? '' : 's' }}</span>
+      </div>
+
+      <table class="records-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Source</th>
+            <th>Status</th>
+            <th>Size</th>
+            <th>Added</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="d in drillDocs" :key="d.id">
+            <td class="key-cell">{{ (d.original_name as string) || '' }}</td>
+            <td><span class="badge badge-muted">{{ (d.source_type as string) || '' }}</span></td>
+            <td><span class="badge" :class="statusClass(d.status)">{{ (d.status as string) || '' }}</span></td>
+            <td>{{ fmtSize(d.file_size_bytes) }}</td>
+            <td>{{ formatDate(d.created_at as string) }}</td>
+            <td class="row-actions">
+              <button class="btn btn-sm btn-secondary" @click="viewDoc(d)">View</button>
+              <button class="btn btn-sm btn-danger" @click="deleteDoc(d)">
+                <BrainIcon name="Trash" :size="12" />
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </template>
+  </template>
+</template>

--- a/frontend/apps/brain/src/views/documents/DocumentsPanel.vue
+++ b/frontend/apps/brain/src/views/documents/DocumentsPanel.vue
@@ -12,6 +12,13 @@ const props = defineProps<{
   statusFilter: 'active' | 'processing' | 'uploads' | 'deleted';
 }>();
 
+const GROUP_TABS = [
+  { key: 'all', label: 'All' },
+  { key: 'doc_category', label: 'Category' },
+  { key: 'doc_project', label: 'Project' },
+  { key: 'doc_date', label: 'Date' },
+] as const;
+
 const { show: showToast } = useToast();
 const { confirm } = useConfirm();
 
@@ -120,8 +127,9 @@ async function viewDoc(d: Document): Promise<void> {
     const data = await documents.get(d.id);
     detailDoc.value = data.item;
     viewMode.value = 'detail';
-  } catch {
-    showToast('Failed to load document', 'error');
+  } catch (e) {
+    // legacy documents.js: non-ok → 'Failed to load document'; network → 'Network error'
+    showToast(e instanceof HttpError ? 'Failed to load document' : 'Network error', 'error');
   }
 }
 
@@ -172,7 +180,7 @@ async function onUpload(event: Event): Promise<void> {
         placeholder="Search documents…"
         @keydown.enter="onSearch"
       >
-      <button class="btn btn-secondary" @click="fileInput?.click()">
+      <button class="btn btn-primary" @click="fileInput?.click()">
         <BrainIcon name="Upload" :size="14" /> Upload
       </button>
     </div>
@@ -210,12 +218,7 @@ async function onUpload(event: Event): Promise<void> {
     <!-- Group tabs -->
     <div class="doc-group-tabs">
       <button
-        v-for="tab in [
-          { key: 'all', label: 'All' },
-          { key: 'doc_category', label: 'Category' },
-          { key: 'doc_project', label: 'Project' },
-          { key: 'doc_date', label: 'Date' },
-        ]"
+        v-for="tab in GROUP_TABS"
         :key="tab.key"
         class="group-tab"
         :class="{ active: groupBy === tab.key }"
@@ -231,11 +234,11 @@ async function onUpload(event: Event): Promise<void> {
       <div class="watched-folders-list">
         <div v-for="f in folders" :key="f.id" class="watched-folder-item">
           <span class="wf-icon"><BrainIcon name="Eye" :size="14" /></span>
-          <span class="wf-label">{{ (f.label as string) || (f.path as string) || '' }}</span>
-          <span class="wf-path">{{ (f.path as string) || '' }}</span>
-          <span class="wf-meta">{{ (f.files as number) || 0 }} files · {{ formatDate(f.last_scan as string) }}</span>
+          <span class="wf-label">{{ f.label || f.folder_path || '' }}</span>
+          <span class="wf-path">{{ f.folder_path || '' }}</span>
+          <span class="wf-meta">{{ f.last_scan_files || 0 }} files · {{ formatDate(f.last_scan_at) }}</span>
           <span class="wf-status">
-            <span class="status-dot" :class="{ active: f.active }"></span>
+            <span class="status-dot" :class="{ active: f.enabled }"></span>
           </span>
         </div>
       </div>

--- a/frontend/apps/brain/src/views/documents/ProcessingSub.vue
+++ b/frontend/apps/brain/src/views/documents/ProcessingSub.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.subTitle = 'Processing'; });
+</script>
+
+<template>
+  <div class="panel-placeholder"><p>Documents Processing — implementation in P2c.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/documents/ProcessingSub.vue
+++ b/frontend/apps/brain/src/views/documents/ProcessingSub.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.subTitle = 'Processing'; });
-</script>
-
 <template>
   <div class="panel-placeholder"><p>Documents Processing — implementation in P2c.</p></div>
 </template>

--- a/frontend/apps/brain/src/views/documents/ProcessingSub.vue
+++ b/frontend/apps/brain/src/views/documents/ProcessingSub.vue
@@ -1,3 +1,4 @@
-<template>
-  <div class="panel-placeholder"><p>Documents Processing — implementation in P2c.</p></div>
-</template>
+<script setup lang="ts">
+import DocumentsPanel from './DocumentsPanel.vue';
+</script>
+<template><DocumentsPanel status-filter="processing" /></template>

--- a/frontend/apps/brain/src/views/documents/UploadsSub.vue
+++ b/frontend/apps/brain/src/views/documents/UploadsSub.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.subTitle = 'Uploads'; });
+</script>
+
+<template>
+  <div class="panel-placeholder"><p>Documents Uploads — implementation in P2c.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/documents/UploadsSub.vue
+++ b/frontend/apps/brain/src/views/documents/UploadsSub.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.subTitle = 'Uploads'; });
-</script>
-
 <template>
   <div class="panel-placeholder"><p>Documents Uploads — implementation in P2c.</p></div>
 </template>

--- a/frontend/apps/brain/src/views/documents/UploadsSub.vue
+++ b/frontend/apps/brain/src/views/documents/UploadsSub.vue
@@ -1,3 +1,4 @@
-<template>
-  <div class="panel-placeholder"><p>Documents Uploads — implementation in P2c.</p></div>
-</template>
+<script setup lang="ts">
+import DocumentsPanel from './DocumentsPanel.vue';
+</script>
+<template><DocumentsPanel status-filter="uploads" /></template>

--- a/frontend/apps/brain/src/views/policies/BackgroundSub.vue
+++ b/frontend/apps/brain/src/views/policies/BackgroundSub.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.subTitle = 'Background'; });
-</script>
-
 <template>
   <div class="panel-placeholder"><p>Policies Background — implementation in P2d.</p></div>
 </template>

--- a/frontend/apps/brain/src/views/policies/BackgroundSub.vue
+++ b/frontend/apps/brain/src/views/policies/BackgroundSub.vue
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+import PoliciesPanel from './PoliciesPanel.vue';
+</script>
+
 <template>
-  <div class="panel-placeholder"><p>Policies Background — implementation in P2d.</p></div>
+  <PoliciesPanel channel="subconscious" />
 </template>

--- a/frontend/apps/brain/src/views/policies/BackgroundSub.vue
+++ b/frontend/apps/brain/src/views/policies/BackgroundSub.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.subTitle = 'Background'; });
+</script>
+
+<template>
+  <div class="panel-placeholder"><p>Policies Background — implementation in P2d.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/policies/ChatSub.vue
+++ b/frontend/apps/brain/src/views/policies/ChatSub.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.subTitle = 'Chat'; });
+</script>
+
+<template>
+  <div class="panel-placeholder"><p>Policies Chat — implementation in P2d.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/policies/ChatSub.vue
+++ b/frontend/apps/brain/src/views/policies/ChatSub.vue
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+import PoliciesPanel from './PoliciesPanel.vue';
+</script>
+
 <template>
-  <div class="panel-placeholder"><p>Policies Chat — implementation in P2d.</p></div>
+  <PoliciesPanel channel="chat" />
 </template>

--- a/frontend/apps/brain/src/views/policies/ChatSub.vue
+++ b/frontend/apps/brain/src/views/policies/ChatSub.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.subTitle = 'Chat'; });
-</script>
-
 <template>
   <div class="panel-placeholder"><p>Policies Chat — implementation in P2d.</p></div>
 </template>

--- a/frontend/apps/brain/src/views/policies/ExternalSub.vue
+++ b/frontend/apps/brain/src/views/policies/ExternalSub.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.subTitle = 'External'; });
+</script>
+
+<template>
+  <div class="panel-placeholder"><p>Policies External — implementation in P2d.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/policies/ExternalSub.vue
+++ b/frontend/apps/brain/src/views/policies/ExternalSub.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.subTitle = 'External'; });
-</script>
-
 <template>
   <div class="panel-placeholder"><p>Policies External — implementation in P2d.</p></div>
 </template>

--- a/frontend/apps/brain/src/views/policies/ExternalSub.vue
+++ b/frontend/apps/brain/src/views/policies/ExternalSub.vue
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+import PoliciesPanel from './PoliciesPanel.vue';
+</script>
+
 <template>
-  <div class="panel-placeholder"><p>Policies External — implementation in P2d.</p></div>
+  <PoliciesPanel channel="external_agent" />
 </template>

--- a/frontend/apps/brain/src/views/policies/PoliciesPanel.vue
+++ b/frontend/apps/brain/src/views/policies/PoliciesPanel.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { policies } from '../../api/policies';
+import type { PolicyRow, BlockedEntry } from '../../api/policies';
+import { formatDate } from '../../utils/format';
+import { HttpError } from '@chalie/shared';
+import { useToast } from '../../composables/useToast';
+
+const props = defineProps<{ channel: 'chat' | 'subconscious' | 'external_agent' }>();
+
+const { show: showToast } = useToast();
+
+const SETTINGS = ['allow', 'ask', 'deny'] as const;
+const cap = (v: string): string => v.charAt(0).toUpperCase() + v.slice(1);
+
+const rows = ref<PolicyRow[]>([]);
+const blocked = ref<BlockedEntry[]>([]);
+const loading = ref(true);
+const blockedOpen = ref(false);
+
+interface PolicyCategory {
+  cat: string;
+  isMcp: boolean;
+  rows: { r: PolicyRow; label: string }[];
+}
+
+const categories = computed<PolicyCategory[]>(() => {
+  const byCat: Record<string, PolicyCategory> = {};
+  for (const r of rows.value) {
+    if (r.channel !== props.channel) continue;
+    const isMcp = !!r.group;
+    const cat = r.group || r.permission.split('.')[0];
+    const label = r.label || r.permission;
+    (byCat[cat] ??= { cat, isMcp, rows: [] }).rows.push({ r, label });
+  }
+  return Object.values(byCat).sort((a, b) => a.cat.localeCompare(b.cat));
+});
+
+async function load(): Promise<void> {
+  loading.value = true;
+  try {
+    const [polRes, blockRes] = await Promise.allSettled([policies.list(), policies.blocked()]);
+    if (polRes.status === 'fulfilled') rows.value = polRes.value.policies ?? [];
+    if (blockRes.status === 'fulfilled') blocked.value = blockRes.value.entries ?? [];
+    const networkFailure = [polRes, blockRes].some(
+      (r) => r.status === 'rejected' && !(r.reason instanceof HttpError),
+    );
+    if (networkFailure) showToast('Failed to load policies', 'error');
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function setPermission(r: PolicyRow, value: string): Promise<void> {
+  const previous = r.setting;
+  r.setting = value;
+  try {
+    await policies.update({ channel: props.channel, permission: r.permission, setting: value });
+    showToast(`${r.permission} → ${value}`, 'success');
+  } catch (e) {
+    r.setting = previous;
+    showToast(e instanceof HttpError ? 'Failed to update policy' : 'Network error', 'error');
+  }
+}
+
+async function setAll(setting: string): Promise<void> {
+  const targets = rows.value.filter((r) => r.channel === props.channel && r.setting !== setting);
+  if (targets.length === 0) {
+    showToast(`All already ${setting}`, 'success');
+    return;
+  }
+  const results = await Promise.all(
+    targets.map((r) =>
+      policies
+        .update({ channel: props.channel, permission: r.permission, setting })
+        .then(() => true)
+        .catch(() => false),
+    ),
+  );
+  targets.forEach((r, i) => {
+    if (results[i]) r.setting = setting;
+  });
+  const ok = results.filter(Boolean).length;
+  if (ok === targets.length) showToast(`All ${props.channel} → ${setting} (${ok})`, 'success');
+  else showToast(`Updated ${ok}/${targets.length} — some failed`, 'error');
+}
+
+onMounted(load);
+</script>
+
+<template>
+  <div class="panel-header">
+    <h2>Policies</h2>
+    <div class="panel-header-actions">
+      <div class="segmented policy-bulk" title="Set every permission in this channel">
+        <button
+          v-for="v in SETTINGS"
+          :key="v"
+          class="seg-btn"
+          @click="setAll(v)"
+        >{{ cap(v) }}</button>
+      </div>
+    </div>
+  </div>
+
+  <div v-if="loading" class="loading">Loading…</div>
+
+  <div v-else class="policies-grid">
+    <div
+      v-for="c in categories"
+      :key="c.cat"
+      class="policy-category"
+    >
+      <h4 class="section-head">
+        <span v-if="c.isMcp" class="badge badge-cyan">MCP</span>
+        {{ c.cat }}
+      </h4>
+      <div
+        v-for="{ r, label } in c.rows"
+        :key="r.permission"
+        class="policy-rule"
+      >
+        <span class="policy-label">{{ label }}</span>
+        <div class="segmented" :data-permission="r.permission">
+          <button
+            v-for="v in SETTINGS"
+            :key="v"
+            class="seg-btn"
+            :class="{ active: v === r.setting }"
+            @click="setPermission(r, v)"
+          >{{ cap(v) }}</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div v-if="blocked.length > 0" class="blocked-section">
+    <button class="blocked-toggle" @click="blockedOpen = !blockedOpen">
+      Blocked Actions Log {{ blockedOpen ? '▴' : '▾' }}
+    </button>
+    <div v-if="blockedOpen" class="blocked-list">
+      <div
+        v-for="(b, idx) in blocked"
+        :key="idx"
+        class="blocked-item"
+      >
+        <span class="badge badge-danger">{{ b.action_id || '' }}</span>
+        <span>{{ b.context || '' }}</span>
+        <span class="blocked-time">{{ formatDate(b.created_at) }}</span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/apps/brain/src/views/scheduler/AllSub.vue
+++ b/frontend/apps/brain/src/views/scheduler/AllSub.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.subTitle = 'All'; });
+</script>
+
+<template>
+  <div class="panel-placeholder"><p>Scheduler All — implementation in P2c.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/scheduler/AllSub.vue
+++ b/frontend/apps/brain/src/views/scheduler/AllSub.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.subTitle = 'All'; });
-</script>
-
 <template>
   <div class="panel-placeholder"><p>Scheduler All — implementation in P2c.</p></div>
 </template>

--- a/frontend/apps/brain/src/views/scheduler/AllSub.vue
+++ b/frontend/apps/brain/src/views/scheduler/AllSub.vue
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+import SchedulerPanel from './SchedulerPanel.vue';
+</script>
+
 <template>
-  <div class="panel-placeholder"><p>Scheduler All — implementation in P2c.</p></div>
+  <SchedulerPanel status-filter="all" />
 </template>

--- a/frontend/apps/brain/src/views/scheduler/CancelledSub.vue
+++ b/frontend/apps/brain/src/views/scheduler/CancelledSub.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.subTitle = 'Cancelled'; });
+</script>
+
+<template>
+  <div class="panel-placeholder"><p>Scheduler Cancelled — implementation in P2c.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/scheduler/CancelledSub.vue
+++ b/frontend/apps/brain/src/views/scheduler/CancelledSub.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.subTitle = 'Cancelled'; });
-</script>
-
 <template>
   <div class="panel-placeholder"><p>Scheduler Cancelled — implementation in P2c.</p></div>
 </template>

--- a/frontend/apps/brain/src/views/scheduler/CancelledSub.vue
+++ b/frontend/apps/brain/src/views/scheduler/CancelledSub.vue
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+import SchedulerPanel from './SchedulerPanel.vue';
+</script>
+
 <template>
-  <div class="panel-placeholder"><p>Scheduler Cancelled — implementation in P2c.</p></div>
+  <SchedulerPanel status-filter="cancelled" />
 </template>

--- a/frontend/apps/brain/src/views/scheduler/FailedSub.vue
+++ b/frontend/apps/brain/src/views/scheduler/FailedSub.vue
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+import SchedulerPanel from './SchedulerPanel.vue';
+</script>
+
 <template>
-  <div class="panel-placeholder"><p>Scheduler Failed — implementation in P2c.</p></div>
+  <SchedulerPanel status-filter="failed" />
 </template>

--- a/frontend/apps/brain/src/views/scheduler/FailedSub.vue
+++ b/frontend/apps/brain/src/views/scheduler/FailedSub.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.subTitle = 'Failed'; });
-</script>
-
 <template>
   <div class="panel-placeholder"><p>Scheduler Failed — implementation in P2c.</p></div>
 </template>

--- a/frontend/apps/brain/src/views/scheduler/FailedSub.vue
+++ b/frontend/apps/brain/src/views/scheduler/FailedSub.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.subTitle = 'Failed'; });
+</script>
+
+<template>
+  <div class="panel-placeholder"><p>Scheduler Failed — implementation in P2c.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/scheduler/FiredSub.vue
+++ b/frontend/apps/brain/src/views/scheduler/FiredSub.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.subTitle = 'Fired'; });
+</script>
+
+<template>
+  <div class="panel-placeholder"><p>Scheduler Fired — implementation in P2c.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/scheduler/FiredSub.vue
+++ b/frontend/apps/brain/src/views/scheduler/FiredSub.vue
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+import SchedulerPanel from './SchedulerPanel.vue';
+</script>
+
 <template>
-  <div class="panel-placeholder"><p>Scheduler Fired — implementation in P2c.</p></div>
+  <SchedulerPanel status-filter="fired" />
 </template>

--- a/frontend/apps/brain/src/views/scheduler/FiredSub.vue
+++ b/frontend/apps/brain/src/views/scheduler/FiredSub.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.subTitle = 'Fired'; });
-</script>
-
 <template>
   <div class="panel-placeholder"><p>Scheduler Fired — implementation in P2c.</p></div>
 </template>

--- a/frontend/apps/brain/src/views/scheduler/PendingSub.vue
+++ b/frontend/apps/brain/src/views/scheduler/PendingSub.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useShellStore } from '../../stores/shell';
+
+const shell = useShellStore();
+onMounted(() => { shell.subTitle = 'Pending'; });
+</script>
+
+<template>
+  <div class="panel-placeholder"><p>Scheduler Pending — implementation in P2c.</p></div>
+</template>

--- a/frontend/apps/brain/src/views/scheduler/PendingSub.vue
+++ b/frontend/apps/brain/src/views/scheduler/PendingSub.vue
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+import SchedulerPanel from './SchedulerPanel.vue';
+</script>
+
 <template>
-  <div class="panel-placeholder"><p>Scheduler Pending — implementation in P2c.</p></div>
+  <SchedulerPanel status-filter="pending" />
 </template>

--- a/frontend/apps/brain/src/views/scheduler/PendingSub.vue
+++ b/frontend/apps/brain/src/views/scheduler/PendingSub.vue
@@ -1,11 +1,3 @@
-<script setup lang="ts">
-import { onMounted } from 'vue';
-import { useShellStore } from '../../stores/shell';
-
-const shell = useShellStore();
-onMounted(() => { shell.subTitle = 'Pending'; });
-</script>
-
 <template>
   <div class="panel-placeholder"><p>Scheduler Pending — implementation in P2c.</p></div>
 </template>

--- a/frontend/apps/brain/src/views/scheduler/SchedulerPanel.vue
+++ b/frontend/apps/brain/src/views/scheduler/SchedulerPanel.vue
@@ -61,7 +61,7 @@ function openForm(item: ScheduleItem | null): void {
 }
 
 async function save(): Promise<void> {
-  const body: ScheduleInput & { recurrence?: string | null } = {
+  const body: ScheduleInput = {
     message: formMsg.value.trim(),
     due_at: formDue.value,
     type: formType.value,

--- a/frontend/apps/brain/src/views/scheduler/SchedulerPanel.vue
+++ b/frontend/apps/brain/src/views/scheduler/SchedulerPanel.vue
@@ -1,0 +1,202 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { scheduler } from '../../api/scheduler';
+import type { ScheduleItem, ScheduleInput } from '../../api/scheduler';
+import { formatDate } from '../../utils/format';
+import { apiErrorMessage } from '../../api/http';
+import { useToast } from '../../composables/useToast';
+import { useConfirm } from '../../composables/useConfirm';
+import BrainIcon from '../../ui/BrainIcon.vue';
+
+const props = defineProps<{ statusFilter: 'all' | 'pending' | 'fired' | 'failed' | 'cancelled' }>();
+
+const { show: showToast } = useToast();
+const { confirm } = useConfirm();
+
+const items = ref<ScheduleItem[]>([]);
+const loading = ref(true);
+
+// Inline form state
+type FormMode = 'list' | 'form';
+const formMode = ref<FormMode>('list');
+const editingId = ref<string | number | null>(null);
+const formMsg = ref('');
+const formDue = ref('');
+const formType = ref<'notification' | 'prompt'>('notification');
+const formRecur = ref('');
+
+const filtered = computed<ScheduleItem[]>(() =>
+  props.statusFilter === 'all' ? items.value : items.value.filter((s) => s.status === props.statusFilter),
+);
+
+function statusClass(status: string | null | undefined): string {
+  const map: Record<string, string> = {
+    pending: 'badge-warning',
+    fired: 'badge-success',
+    failed: 'badge-danger',
+    cancelled: 'badge-muted',
+  };
+  return map[status ?? ''] ?? 'badge-muted';
+}
+
+async function load(): Promise<void> {
+  loading.value = true;
+  try {
+    const data = await scheduler.list();
+    items.value = data.schedules ?? data.items ?? [];
+  } catch {
+    showToast('Failed to load schedules', 'error');
+  } finally {
+    loading.value = false;
+  }
+}
+
+function openForm(item: ScheduleItem | null): void {
+  formMsg.value = item?.message ?? item?.prompt ?? '';
+  formDue.value = item?.due_at ? item.due_at.slice(0, 16) : '';
+  formType.value = item?.type === 'prompt' || item?.item_type === 'prompt' ? 'prompt' : 'notification';
+  formRecur.value = item?.recurrence ?? '';
+  editingId.value = item?.id ?? null;
+  formMode.value = 'form';
+}
+
+async function save(): Promise<void> {
+  const body: ScheduleInput & { recurrence?: string | null } = {
+    message: formMsg.value.trim(),
+    due_at: formDue.value,
+    type: formType.value,
+    recurrence: formRecur.value || null,
+  };
+  try {
+    if (editingId.value != null) {
+      await scheduler.update(editingId.value, body);
+    } else {
+      await scheduler.create(body);
+    }
+    showToast(editingId.value != null ? 'Schedule updated' : 'Schedule created', 'success');
+    formMode.value = 'list';
+    await load();
+  } catch (e) {
+    showToast(apiErrorMessage(e, 'Save failed'), 'error');
+  }
+}
+
+async function cancelSchedule(s: ScheduleItem): Promise<void> {
+  const ok = await confirm({
+    title: 'Cancel Schedule',
+    desc: 'Cancel this scheduled item?',
+    confirmLabel: 'Cancel Item',
+    confirmClass: 'btn-danger',
+  });
+  if (!ok) return;
+  try {
+    await scheduler.delete(s.id);
+    showToast('Schedule cancelled', 'success');
+    await load();
+  } catch (e) {
+    showToast(apiErrorMessage(e, 'Cancel failed'), 'error');
+  }
+}
+
+onMounted(load);
+</script>
+
+<template>
+  <div class="panel-header">
+    <h2>Scheduler</h2>
+    <button class="btn btn-primary" @click="openForm(null)">
+      <BrainIcon name="Plus" :size="14" /> New Schedule
+    </button>
+  </div>
+
+  <div v-if="loading" class="loading">Loading…</div>
+
+  <template v-else-if="formMode === 'form'">
+    <div class="provider-form-page">
+      <div class="form-page-header">
+        <button class="btn btn-secondary btn-sm back-btn" @click="formMode = 'list'">
+          <BrainIcon name="Chevron" :size="14" /> Back
+        </button>
+        <h3>{{ editingId != null ? 'Edit Schedule' : 'New Schedule' }}</h3>
+      </div>
+      <form @submit.prevent="save">
+        <div class="form-group">
+          <label for="schedMsg">Prompt / Message</label>
+          <textarea
+            id="schedMsg"
+            v-model="formMsg"
+            rows="3"
+            maxlength="1000"
+            placeholder="What Chalie should do when this fires"
+            required
+          ></textarea>
+        </div>
+        <div class="form-group">
+          <label for="schedDue">Due Date &amp; Time</label>
+          <input id="schedDue" v-model="formDue" type="datetime-local" required>
+        </div>
+        <div class="form-group">
+          <label for="schedType">Type</label>
+          <select id="schedType" v-model="formType">
+            <option value="notification">Notification</option>
+            <option value="prompt">Prompt</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="schedRecur">Recurrence</label>
+          <select id="schedRecur" v-model="formRecur">
+            <option value="">None (one-time)</option>
+            <option value="interval">Every X minutes</option>
+            <option value="hourly">Hourly</option>
+            <option value="daily">Daily</option>
+            <option value="weekdays">Weekdays</option>
+            <option value="weekly">Weekly</option>
+            <option value="monthly">Monthly</option>
+          </select>
+        </div>
+        <div class="form-actions">
+          <button type="button" class="btn btn-secondary" @click="formMode = 'list'">Cancel</button>
+          <button type="submit" class="btn btn-primary">Save</button>
+        </div>
+      </form>
+    </div>
+  </template>
+
+  <template v-else-if="filtered.length === 0">
+    <div class="empty-state">
+      <div class="empty-icon">
+        <BrainIcon name="Calendar" :size="40" />
+      </div>
+      <h3>No schedules</h3>
+      <p>Create your first scheduled task.</p>
+    </div>
+  </template>
+
+  <template v-else>
+    <table class="records-table">
+      <thead>
+        <tr>
+          <th>Message</th>
+          <th>Status</th>
+          <th>Due</th>
+          <th>Recurrence</th>
+          <th>Type</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="s in filtered" :key="s.id">
+          <td class="key-cell">{{ s.message || s.prompt || '' }}</td>
+          <td><span class="badge" :class="statusClass(s.status)">{{ s.status || '' }}</span></td>
+          <td>{{ formatDate(s.due_at || s.due) }}</td>
+          <td>{{ s.recurrence || '—' }}</td>
+          <td><span class="badge badge-muted">{{ s.type || 'notification' }}</span></td>
+          <td class="row-actions">
+            <button class="btn btn-sm btn-secondary" @click="openForm(s)">Edit</button>
+            <button v-if="s.status === 'pending'" class="btn btn-sm btn-danger" @click="cancelSchedule(s)">Cancel</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </template>
+</template>

--- a/frontend/apps/brain/tests/global-setup.ts
+++ b/frontend/apps/brain/tests/global-setup.ts
@@ -1,0 +1,19 @@
+import { request } from '@playwright/test';
+import { mkdirSync } from 'node:fs';
+
+// Authenticate once against the real Chalie instance and persist the session
+// cookie. The Brain SPA is auth-gated at the serve layer (/brain-next/ redirects
+// to /login/ without a valid session) AND in the router beforeEach gate, so every
+// spec needs a live login cookie to reach a panel.
+export default async function globalSetup(): Promise<void> {
+  const baseURL = process.env.CHALIE_BASE_URL!;
+  const username = process.env.CHALIE_TEST_USERNAME ?? 'admin';
+  const password = process.env.CHALIE_TEST_PASSWORD;
+  if (!password) throw new Error('CHALIE_TEST_PASSWORD must be set for the auth fixture');
+  const ctx = await request.newContext({ baseURL });
+  const res = await ctx.post('/auth/login', { data: { username, password } });
+  if (!res.ok()) throw new Error(`Login failed: ${res.status()} ${await res.text()}`);
+  mkdirSync('.auth', { recursive: true });
+  await ctx.storageState({ path: '.auth/state.json' });
+  await ctx.dispose();
+}

--- a/frontend/apps/brain/tests/lists-crud.spec.ts
+++ b/frontend/apps/brain/tests/lists-crud.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+// A real CRUD round-trip against the live backend: create a list via the modal
+// (POST /api/lists), assert the new card renders, then delete it via the card's
+// Delete button + the confirm dialog (DELETE /api/lists/:id) and assert the card
+// is gone. No mocks — the list genuinely persists and is genuinely removed, so a
+// break anywhere in the request → render → delete chain fails loudly. The test
+// cleans up after itself (the list it creates is the list it deletes).
+
+test.describe('Brain SPA — Lists CRUD round-trip', () => {
+  test('create a list, see it, delete it', async ({ page }) => {
+    const name = `pw-e2e-${Date.now()}`;
+
+    await page.goto('/brain-next/lists');
+    await expect(page.getByRole('heading', { name: 'Lists', exact: true })).toBeVisible();
+
+    // Open the create modal and submit.
+    await page.locator('.panel-header').getByRole('button', { name: 'New List' }).click();
+    const nameInput = page.locator('#newListName');
+    await expect(nameInput).toBeVisible();
+    await nameInput.fill(name);
+    await page.locator('.modal').getByRole('button', { name: 'Create' }).click();
+
+    // The new card renders with the typed name (real POST round-trip).
+    const card = page.locator('.list-card', { has: page.getByText(name, { exact: true }) });
+    await expect(card).toBeVisible();
+
+    // Delete it → confirm dialog → DELETE round-trip → card disappears.
+    await card.getByRole('button', { name: 'Delete' }).click();
+    await page.locator('.modal-actions button.btn-danger').click();
+    await expect(card).toHaveCount(0);
+  });
+});

--- a/frontend/apps/brain/tests/routing.spec.ts
+++ b/frontend/apps/brain/tests/routing.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Verifies the SPA history-fallback contract end-to-end: a deep link typed into
+// the address bar (and a hard reload of it) is served index.html by the backend
+// /brain-next/ route, Vue Router boots, the auth gate passes, and the correct
+// panel renders. This is the real production deep-link path — a 404 or a wrong
+// panel on reload would fail loudly here.
+
+/** Goto a deep route, assert its anchor, hard-reload, assert it survives. */
+async function deepLinkSurvivesReload(
+  page: Page,
+  path: string,
+  assertPanel: () => Promise<void>,
+): Promise<void> {
+  await page.goto(path);
+  await assertPanel();
+  await page.reload();
+  await assertPanel();
+}
+
+test.describe('Brain SPA — routing & deep-link reload', () => {
+  test('Lists deep link + reload', async ({ page }) => {
+    await deepLinkSurvivesReload(page, '/brain-next/lists', async () => {
+      await expect(page).toHaveURL(/\/brain-next\/lists(\/|$|\?)/);
+      await expect(page.getByRole('heading', { name: 'Lists', exact: true })).toBeVisible();
+    });
+  });
+
+  test('MCP deep link + reload', async ({ page }) => {
+    await deepLinkSurvivesReload(page, '/brain-next/mcp', async () => {
+      await expect(page).toHaveURL(/\/brain-next\/mcp(\/|$|\?)/);
+      await expect(page.getByRole('heading', { name: 'MCP', exact: true })).toBeVisible();
+    });
+  });
+
+  test('Skills deep link + reload renders skill cards', async ({ page }) => {
+    await deepLinkSurvivesReload(page, '/brain-next/skills', async () => {
+      await expect(page).toHaveURL(/\/brain-next\/skills(\/|$|\?)/);
+      await expect(page.getByRole('heading', { name: 'Skills', exact: true })).toBeVisible();
+      // Curated skills ship with the install → at least one card must render.
+      await expect(page.locator('.skill-card').first()).toBeVisible();
+    });
+  });
+
+  test('Brain panel deep link + reload', async ({ page }) => {
+    await deepLinkSurvivesReload(page, '/brain-next/brain', async () => {
+      await expect(page).toHaveURL(/\/brain-next\/brain(\/|$|\?)/);
+      // Brain backup/restore panel — Import/Export actions are its anchor.
+      await expect(page.locator('#panelRoot')).toContainText(/Export|Import|Backup/i);
+    });
+  });
+
+  test('Nested route (cognition/memory) deep link + reload', async ({ page }) => {
+    await deepLinkSurvivesReload(page, '/brain-next/cognition/memory', async () => {
+      await expect(page).toHaveURL(/\/brain-next\/cognition\/memory(\/|$|\?)/);
+      // CognitionView shell heading + the active sub-nav prove the route resolved…
+      await expect(page.getByRole('heading', { name: 'Cognition' })).toBeVisible();
+      await expect(page.locator('[data-nav="cognition"].active')).toBeVisible();
+      await expect(page.locator('[data-sub="memory"].active')).toBeVisible();
+      // …and MemorySub's own content proves the nested <RouterView> actually
+      // rendered the child (not just that the route matched). The filter tabs
+      // render only after a successful load — a silent child crash shows nothing,
+      // a failed fetch shows "Failed to load data." instead — so the Episodes tab
+      // being present AND active is a real end-to-end signal the panel mounted.
+      await expect(page.locator('.records-controls .filter-tab.active')).toHaveText('Episodes');
+    });
+  });
+
+  test('Unknown route falls through catch-all to providers', async ({ page }) => {
+    await page.goto('/brain-next/this-route-does-not-exist');
+    // Catch-all redirect → /providers (does not 404, does not white-screen).
+    await expect(page).toHaveURL(/\/brain-next\/providers(\/|$|\?)/);
+    await expect(page.getByRole('heading', { name: 'LLM Providers' })).toBeVisible();
+  });
+});

--- a/frontend/apps/brain/tests/skill-toggle-double-fire.spec.ts
+++ b/frontend/apps/brain/tests/skill-toggle-double-fire.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+
+// Double-fire hypothesis — browser-verified against the real backend.
+//
+// SkillsView and CapabilitiesView faithfully port a NESTED <label> structure
+// from the legacy code (skills.js:164-167/196-199, capabilities.js:97-100):
+//
+//   <label class="switch-label skill-toggle-wrap">   ← outer label
+//     <label class="switch">                          ← inner label
+//       <input type="checkbox" class="skill-toggle">  ← the control
+//       <span class="switch-track"></span>            ← what the user clicks
+//     </label>
+//   </label>
+//
+// Nested labels are invalid HTML and have historically double-activated their
+// control (one user click → two `change` events → the checkbox flips twice and
+// nets back to its original state). The skill toggle auto-saves on `change`
+// (toggleSkill → PUT /api/skills/:id/toggle), so a double-fire would surface as
+// TWO PUTs and NO net state change. This test clicks the visible track exactly
+// once and proves a single user click produces exactly one toggle + one flip.
+//
+// The proof is a request counter installed via page.on('request') BEFORE the
+// click. Double-activation is SYNCHRONOUS — both `change` events fire within the
+// single click dispatch, so both PUTs are dispatched at click time. The counter
+// increments on request dispatch, and we then await the first PUT's RESPONSE;
+// since a request event always precedes its response, a synchronous second PUT
+// is already counted by the time the first response lands. So `puts` is final
+// the instant we read it — no fixed settle delay needed, and the counter cannot
+// miss an extra PUT the way a post-hoc waitForResponse could.
+//
+// (The McpView switches use a single, un-nested <label class="switch"> — also
+// faithful to legacy mcp.js — so they are not at double-fire risk and need no
+// separate probe.)
+
+test.describe('Brain SPA — nested-label switch does not double-fire', () => {
+  test('one click on a skill toggle = one PUT and one state flip', async ({ page }) => {
+    let puts = 0;
+    page.on('request', (req) => {
+      if (req.method() === 'PUT' && /\/api\/skills\/[^/]+\/toggle$/.test(req.url())) puts++;
+    });
+
+    await page.goto('/brain-next/skills');
+    const wrap = page.locator('.skill-toggle-wrap').first();
+    await expect(wrap).toBeVisible();
+
+    const input = wrap.locator('input.skill-toggle');
+    const track = wrap.locator('.switch-track');
+    const initial = await input.isChecked();
+
+    // Single user click on the visible track.
+    const firstResp = page.waitForResponse(
+      (r) => /\/api\/skills\/[^/]+\/toggle$/.test(r.url()) && r.request().method() === 'PUT',
+    );
+    await track.click();
+    await firstResp;
+
+    // The control flipped once…
+    await expect(input).toBeChecked({ checked: !initial });
+    // …and exactly one PUT was dispatched (a synchronous double-fire would have
+    // already pushed the counter to 2 by the time the first response landed).
+    expect(puts).toBe(1);
+
+    // Restore env state — and confirm the inverse click is also single-fire.
+    const secondResp = page.waitForResponse(
+      (r) => /\/api\/skills\/[^/]+\/toggle$/.test(r.url()) && r.request().method() === 'PUT',
+    );
+    await track.click();
+    await secondResp;
+    await expect(input).toBeChecked({ checked: initial });
+    expect(puts).toBe(2);
+  });
+});

--- a/frontend/apps/brain/tests/smoke.spec.ts
+++ b/frontend/apps/brain/tests/smoke.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+
+// Boots the real Brain SPA served by Chalie at /brain-next/ and proves the
+// shell chrome + every top-level nav entry actually renders. Drives the real
+// production serve route + Vue Router boot + auth gate (the storageState cookie
+// from global-setup carries a live session, and the QA env has a provider, so
+// providersOnly is off and panels are reachable). No mocks: the assertions are
+// against the DOM the user sees.
+
+const NAV_IDS = [
+  'providers',
+  'vision',
+  'cognition',
+  'scheduler',
+  'lists',
+  'documents',
+  'capabilities',
+  'policies',
+  'skills',
+  'mcp',
+  'brain',
+] as const;
+
+test.describe('Brain SPA — smoke', () => {
+  test('boots at /brain-next/, redirects to providers, shell + nav render', async ({ page }) => {
+    await page.goto('/brain-next/');
+
+    // Router "/" → "/providers" redirect (BrainView default).
+    await expect(page).toHaveURL(/\/brain-next\/providers(\/|$|\?)/);
+
+    // Shell grid chrome.
+    await expect(page.locator('#appShell')).toBeVisible();
+    await expect(page.locator('aside.sidebar')).toBeVisible();
+    await expect(page.locator('#topbar')).toBeVisible();
+    await expect(page.locator('main.main #panelRoot')).toBeVisible();
+
+    // Brand wordmark.
+    await expect(page.locator('.sidebar-brand .wordmark')).toHaveText('Chalie');
+    await expect(page.locator('.sidebar-brand .wordmark-sub')).toHaveText('Brain');
+
+    // All 11 top-level nav items present (Cognition + System groups).
+    for (const id of NAV_IDS) {
+      await expect(page.locator(`[data-nav="${id}"]`)).toBeVisible();
+    }
+
+    // The Providers panel really rendered (not an empty router outlet).
+    await expect(page.getByRole('heading', { name: 'LLM Providers' })).toBeVisible();
+  });
+});

--- a/frontend/apps/brain/tests/theme.spec.ts
+++ b/frontend/apps/brain/tests/theme.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+// Rule 7: every frontend feature supports dark AND light. The theme store
+// (packages/shared/src/stores/theme.ts) flips html[data-theme] and persists the
+// choice to localStorage key 'chalie-theme', re-adopted on init(). This drives
+// the real toggle button and a real reload — no mocking of storage or the DOM.
+
+test.describe('Brain SPA — theme parity (Rule 7)', () => {
+  test('toggle flips html[data-theme], persists across reload, shell renders in both', async ({
+    page,
+  }) => {
+    await page.goto('/brain-next/providers');
+    await expect(page.locator('aside.sidebar')).toBeVisible();
+
+    const html = page.locator('html');
+    const initial = await html.getAttribute('data-theme');
+    expect(initial === 'dark' || initial === 'light').toBe(true);
+    const flipped = initial === 'dark' ? 'light' : 'dark';
+
+    // Toggle via the real sidebar-footer button.
+    await page.locator('button.theme-toggle').click();
+    await expect(html).toHaveAttribute('data-theme', flipped);
+    // Shell still fully rendered in the flipped theme.
+    await expect(page.locator('aside.sidebar')).toBeVisible();
+    await expect(page.locator('#topbar')).toBeVisible();
+
+    // localStorage caught the choice…
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem('chalie-theme')))
+      .toBe(flipped);
+
+    // …and init() re-adopts it on a hard reload (no flash back to default).
+    await page.reload();
+    await expect(html).toHaveAttribute('data-theme', flipped);
+    await expect(page.locator('aside.sidebar')).toBeVisible();
+
+    // Toggle back → returns to the original theme, shell still renders.
+    await page.locator('button.theme-toggle').click();
+    await expect(html).toHaveAttribute('data-theme', initial!);
+    await expect(page.locator('aside.sidebar')).toBeVisible();
+  });
+});

--- a/frontend/packages/shared/src/services/ApiClient.ts
+++ b/frontend/packages/shared/src/services/ApiClient.ts
@@ -8,7 +8,11 @@ export class AuthError extends Error {
 }
 
 export class HttpError extends Error {
-  constructor(public readonly status: number) {
+  constructor(
+    public readonly status: number,
+    public readonly error?: string,   // server-provided message parsed from a JSON {error} body, if any
+    public readonly body?: unknown,    // the full parsed JSON error body, if any
+  ) {
     super(`HTTP ${status}`);
     this.name = 'HttpError';
   }
@@ -23,6 +27,16 @@ export class ApiClient {
     return host ? host.replace(/\/$/, '') + path : path;
   }
 
+  /** Parse the response body and throw an HttpError carrying the server message, if any. */
+  private async throwHttp(res: Response): Promise<never> {
+    const body = await res.json().catch(() => null);
+    const msg =
+      body && typeof body === 'object' && 'error' in body && typeof (body as { error?: unknown }).error === 'string'
+        ? (body as { error?: string }).error
+        : undefined;
+    throw new HttpError(res.status, msg, body ?? undefined);
+  }
+
   private async request<T>(path: string, init?: RequestInit): Promise<T> {
     const res = await fetch(this.buildUrl(path), {
       credentials: 'same-origin',
@@ -30,7 +44,7 @@ export class ApiClient {
       headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
     });
     if (res.status === 401) throw new AuthError();
-    if (!res.ok) throw new HttpError(res.status);
+    if (!res.ok) return this.throwHttp(res);
     return (await res.json()) as T;
   }
 
@@ -50,7 +64,7 @@ export class ApiClient {
       headers: { 'Content-Type': 'application/json' },
     });
     if (res.status === 401) throw new AuthError();
-    if (!res.ok) throw new HttpError(res.status);
+    if (!res.ok) return this.throwHttp(res);
     return (await res.json().catch(() => ({}))) as T;
   }
 
@@ -62,7 +76,7 @@ export class ApiClient {
       body: formData,
     });
     if (res.status === 401) throw new AuthError();
-    if (!res.ok) throw new HttpError(res.status);
+    if (!res.ok) return this.throwHttp(res);
     return (await res.json()) as T;
   }
 

--- a/frontend/packages/shared/src/services/ApiClient.ts
+++ b/frontend/packages/shared/src/services/ApiClient.ts
@@ -80,6 +80,22 @@ export class ApiClient {
     return (await res.json()) as T;
   }
 
+  /**
+   * POST returning the raw Response (for binary/blob downloads).
+   * Throws AuthError on 401; does NOT throw on other non-ok statuses —
+   * the caller inspects res.ok and reads .blob()/.json() itself.
+   */
+  async download(path: string, body?: unknown): Promise<Response> {
+    const res = await fetch(this.buildUrl(path), {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body ?? {}),
+    });
+    if (res.status === 401) throw new AuthError();
+    return res;
+  }
+
   // ── Foundation endpoints (feature endpoints added in P1/P2) ──────────────
   health(): Promise<{ status: string } | null> {
     return fetch(this.buildUrl('/health'), { credentials: 'same-origin' })

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@chalie/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@fontsource/inter':
+        specifier: ^5.2.8
+        version: 5.2.8
       pinia:
         specifier: ^2.2.0
         version: 2.3.1(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3))
@@ -60,6 +63,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: ^5.1.0
         version: 5.2.4(vite@5.4.21(sass@1.101.0))(vue@3.5.38(typescript@5.9.3))
+      sass:
+        specifier: ^1.80.0
+        version: 1.101.0
       vite:
         specifier: ^5.4.0
         version: 5.4.21(sass@1.101.0)

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
         specifier: ^4.4.0
         version: 4.6.4(vue@3.5.38(typescript@5.9.3))
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@vitejs/plugin-vue':
         specifier: ^5.1.0
         version: 5.2.4(vite@5.4.21(sass@1.101.0))(vue@3.5.38(typescript@5.9.3))


### PR DESCRIPTION
## Summary

Phase 2 of the frontend migration: a faithful 1:1 port of the hand-rolled Brain admin (vanilla HTML/CSS/JS under `frontend/brain/`) to **Vue 3 `<script setup>` + TypeScript-strict + Pinia + Vue Router + SCSS** at `frontend/apps/brain/`, building on the shared package and the interface app from P1.

All **11 panels** are ported, each replacing its P2a stub with real CRUD against the live backend:

- **Providers** + **Vision** (reactive provider grid, live model fetch)
- **Cognition** — 7 sub-views on a nested `<RouterView>`: Memory, World, Tools, Personality, Errors, Usage, Compaction
- **Scheduler**, **Lists**, **Documents**
- **Capabilities** + **Policies**
- **Skills**, **MCP**, **Brain** (export / import / backup)

The app is served at `/brain-next/` via a new auth-gated Flask route with SPA history-fallback (`backend/api/__init__.py`), coexisting with the untouched legacy `/brain/`. DOM structure, CSS class names, copy, toast strings, and validation are preserved so behaviour matches the legacy UI exactly; deviations were made only where a real bug was found and the fix did not regress faithfulness.

Additive only — nothing outside `frontend/` and the additive `/brain-next/` serve route + its tests is changed. Stacked on the P1 branch (`feat/frontend-vue-p1`); merge to the release branch / `main` remains a manual step.

## What's included

- 81 files, +8779/-14 vs the P1 base.
- Backend: `/brain-next/` serve route + 4 feature tests (`backend/tests/test_brain_next_static_serving.py`).
- Per-commit gate green throughout: `vue-tsc` typecheck 0 / `eslint src` 0 / `vite build` clean; backend `pytest -m unit` green.

## Test plan

Playwright feature tests run against a real Chalie instance (zero mocks) — **10/10 passing**:

- [x] **smoke** — boots `/brain-next/`, redirects to providers, shell chrome + all 11 nav items + Providers panel render.
- [x] **routing** — deep-link + hard-reload survival for Lists / MCP / Skills / Brain / nested cognition-memory, plus catch-all → providers. The nested case asserts `MemorySub`'s own content, so a silent child-render failure cannot pass.
- [x] **theme parity (Rule 7)** — toggle flips `html[data-theme]`, persists across reload, shell renders in both themes.
- [x] **Lists CRUD** — real create → render → delete round-trip (POST + DELETE).
- [x] **double-fire probe** — proves the faithfully-ported nested `<label>` skill switch fires exactly one `PUT /api/skills/:id/toggle` per click (the legacy structure does not double-activate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)