### PR TITLE
fix(voice): require auth on /voice/* — close unauthenticated LAN STT/TTS (TKT-1100)

### DIFF
--- a/backend/api/voice.py
+++ b/backend/api/voice.py
@@ -42,6 +42,8 @@ if TYPE_CHECKING:
 from services.file_mapper_service import FileMapperService
 from services.markup import extract_plaintext, markdown_to_html
 
+from .auth import require_auth
+
 logger = logging.getLogger(__name__)
 
 voice_bp = Blueprint("voice", __name__)
@@ -593,6 +595,7 @@ def _transcribe_sync(data: bytes) -> str:
 # ── Routes ──────────────────────────────────────────────────────────────────
 
 @voice_bp.route("/voice/health", methods=["GET"])
+@require_auth
 def voice_health() -> "ResponseReturnValue":
     """Voice service health check.
 
@@ -627,6 +630,7 @@ def voice_health() -> "ResponseReturnValue":
 
 
 @voice_bp.route("/voice/synthesize", methods=["POST"])
+@require_auth
 def voice_synthesize() -> "ResponseReturnValue":
     if not _VOICE_AVAILABLE:
         return jsonify(_voice_unavailable_payload()), 503
@@ -684,6 +688,7 @@ def voice_synthesize() -> "ResponseReturnValue":
 
 
 @voice_bp.route("/voice/transcribe", methods=["POST"])
+@require_auth
 def voice_transcribe() -> "ResponseReturnValue":
     if not _VOICE_AVAILABLE:
         return jsonify(_voice_unavailable_payload()), 503

--- a/backend/tests/test_voice_auth.py
+++ b/backend/tests/test_voice_auth.py
@@ -1,0 +1,75 @@
+"""Feature test: the /voice/* endpoints enforce authentication.
+
+The server binds 0.0.0.0, so before the ``@require_auth`` guard was added these
+routes were reachable by any host on the LAN — free STT/TTS compute and a
+``/voice/health`` response that leaked absolute model-file paths. Each test
+drives the real Flask app built by ``create_app()`` through the real
+``require_auth`` decorator (cookie-session → bearer fallback) and, where a
+logged-in caller is needed, a real bearer token minted into the test DB. No
+mocks, no auth bypass — the unauthenticated cases hit the production guard for
+real, exactly as a LAN attacker would.
+"""
+
+import io
+import sqlite3
+
+import pytest
+from flask.testing import FlaskClient
+
+from services.wrapper_auth_service import WrapperAuthService
+
+
+pytestmark = pytest.mark.unit
+
+
+def _make_client() -> FlaskClient:
+    # Real, unauthenticated app — require_auth runs its real cookie+bearer path
+    # (the authed_client conftest fixture patches validate_session, which would
+    # hide the very guard these tests exist to prove).
+    from api import create_app
+    app = create_app()
+    app.config['TESTING'] = True
+    return app.test_client()
+
+
+# ── The security contract: no session, no voice ─────────────────────────────
+# Each of these FAILED before the guard existed — the routes answered 200/503,
+# never 401 — and now returns the canonical require_auth rejection.
+
+class TestVoiceEndpointsRejectUnauthenticated:
+    def test_health_requires_auth(self, db: sqlite3.Connection) -> None:
+        resp = _make_client().get('/voice/health')
+        assert resp.status_code == 401
+        assert resp.get_json() == {"error": "Authentication required"}
+
+    def test_synthesize_requires_auth(self, db: sqlite3.Connection) -> None:
+        resp = _make_client().post('/voice/synthesize', json={"text": "hello"})
+        assert resp.status_code == 401
+        assert resp.get_json() == {"error": "Authentication required"}
+
+    def test_transcribe_requires_auth(self, db: sqlite3.Connection) -> None:
+        # A would-be attacker POSTs audio; the guard rejects before the body runs.
+        resp = _make_client().post(
+            '/voice/transcribe',
+            data={"file": (io.BytesIO(b"RIFF....WAVE"), "clip.wav")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 401
+        assert resp.get_json() == {"error": "Authentication required"}
+
+
+# ── The other half of the contract: a valid session still gets through ───────
+# Proves the guard lets legitimate traffic reach the handler (so the real
+# frontend mic/TTS feature keeps working) rather than blocking everyone.
+
+class TestVoiceEndpointsAllowAuthenticated:
+    def test_health_with_bearer_reaches_handler(self, db: sqlite3.Connection) -> None:
+        raw_token, _wrapper_id = WrapperAuthService().create_token(
+            name="voice-auth-test", permissions={},
+        )
+        resp = _make_client().get(
+            '/voice/health', headers={"Authorization": f"Bearer {raw_token}"},
+        )
+        assert resp.status_code == 200
+        # The real handler ran: it always reports a concrete status.
+        assert resp.get_json()["status"] in ("ok", "loading", "unavailable")


### PR DESCRIPTION
## What

Adds the canonical `@require_auth` decorator to the three voice routes in `backend/api/voice.py`:

- `GET /voice/health`
- `POST /voice/synthesize`
- `POST /voice/transcribe`

## Why

On a `0.0.0.0`-bound server (the default `run.py --host`, port published by compose) these routes had **no auth and no `before_request` guard** — any host on the LAN could:

- POST audio to `/voice/transcribe` or text to `/voice/synthesize` for free STT/TTS compute, and
- read `/voice/health`, which leaks absolute model-file paths and dependency names.

Every other functional blueprint authenticates. This was an original omission since the voice blueprint's first commit (`04b177d7`), **not a regression** — git history shows no decorator was ever removed.

This is **H2** of the [TKT-1093] project-wide hardening sweep.

## How

`@require_auth` (cookie-session → bearer fallback, the same guard used by `/chat` and `/documents/upload`) on each route, plus the `from .auth import require_auth` import. **+5 LOC.** The frontend already sends `credentials:'same-origin'`, so no frontend change is needed.

## Tests

New `backend/tests/test_voice_auth.py` — a feature test that drives the real `create_app()` Flask app through the real `require_auth` path (zero mocks; a real bearer token minted into the test DB via the prod-shared `WrapperAuthService` factory):

- 3× unauthenticated → `401 {"error": "Authentication required"}`
- 1× authenticated (valid bearer) → reaches the handler, `200` with a concrete status

Proven **3 failed / 1 passed before** the guard, **4 passed after**.

Gates: full `pytest -m unit` green (1364 passed / 0 failed) · ruff clean · vulture no new findings · `/self-review` 8/8.

Tracked in TKT-1100 (related to TKT-1093 H2).