### PR TITLE
fix(browser): screenshots self-describe via the shared document ingest

### DIFF
--- a/backend/abilities/browser.py
+++ b/backend/abilities/browser.py
@@ -6,8 +6,9 @@ The model thinks as little as possible: it names WHAT to act on by visible text
 delegate run (key = the invoking mp's transcript uid); every successful call
 returns the same JSON envelope DICT with a mechanical `changed` diff (the
 dispatcher renders it as compact JSON — never a pre-dumped JSON string).
-Screenshots ingest through the document pipeline into a screenshots/ subdir and
-surface as doc_ids the `vision` tool can read.
+Screenshots ingest through the same document pipeline chat attachments use, so
+the page's vision description is produced at ingest time and rides back inline in
+the screenshot result — the agent sees the page without a separate vision call.
 
 Every result is an :class:`abilities._result.ToolResult` built only via
 ``ok()`` / ``err()``. Errors carry a STABLE KEBAB-CASE ``code`` (never the
@@ -199,12 +200,13 @@ class BrowserAbility(Ability):
 
         page: dict[str, object] = cast("dict[str, object]", grabbed["page"])
         host = urlparse(cast("str", page["url"])).hostname or "page"
+        doc_svc = DocumentService(get_shared_db_service())
         tmp = new_tmp_path(f"{token_hex(4)}.png")
         try:
             with open(tmp, "wb") as fh:
                 fh.write(cast("bytes", grabbed["png"]))
             ingested = ingest_file(
-                DocumentService(get_shared_db_service()),
+                doc_svc,
                 tmp,
                 name=f"screenshot-{host}.png",
                 subdir="screenshots",
@@ -213,23 +215,36 @@ class BrowserAbility(Ability):
         finally:
             if os.path.isfile(tmp):
                 os.remove(tmp)
-        if ingested.get("error"):
+        if ingested.get("error") or ingested.get("status") != "ready":
             return ToolResult.err(
-                f"Screenshot ingest failed: {ingested['error']}",
+                f"Screenshot ingest failed: {ingested.get('error') or ingested.get('status')}",
                 code="screenshot-ingest-failed",
-                hint="The page was captured but could not be stored; retry the "
-                     "screenshot.",
+                hint="The page was captured but could not be stored or read; retry "
+                     "the screenshot.",
                 url=cast("str", page["url"]),
             )
 
         record_screenshot(self._session_key(), cast("str", ingested["id"]), cast("str", page["url"]))
+        # The shared ingest already ran the page through vision (images route to
+        # describe_image inside _run_upload_extraction), storing the description as
+        # the document's clean_text — the same content document(action='view')
+        # surfaces. Hand it back inline so the agent sees the page directly.
+        doc = doc_svc.get_document(cast("str", ingested["id"]))
+        if doc is None:
+            return ToolResult.err(
+                "Screenshot stored but its document record vanished before it "
+                "could be read.",
+                code="screenshot-doc-missing",
+                hint="Retry the screenshot.",
+                url=cast("str", page["url"]),
+            )
         return ToolResult.ok({
             "page": page,
             "data": {
                 "doc_id": ingested["id"],
                 "name": ingested["name"],
                 "status": ingested["status"],
-                "note": "Use the vision tool with image=<doc_id> to see this screenshot.",
+                "vision": doc.get("clean_text") or "",
             },
             "changed": {"navigated": False, "dialog": None, "popup": None, "summary": ""},
             "error": None,

--- a/backend/configs/channels/web_browse.py
+++ b/backend/configs/channels/web_browse.py
@@ -34,10 +34,12 @@ _WEB_BROWSE_SYSTEM_PROMPT = (
     "and fill what you need by visible text, then read the result. Every call "
     "returns JSON describing the page and what changed — trust it over your "
     "assumptions, and never invent content, URLs, or results.\n\n"
-    "Screenshots are saved as documents; use the `vision` tool with the "
-    "returned doc_id to see one. Use `memory` to recall user preferences when "
-    "the task needs them. If a page demands a login or CAPTCHA, report that "
-    "plainly instead of trying to get past it.\n\n"
+    "Each screenshot comes back with a full visual description of the page "
+    "inline, so you can see what is on screen directly; the `vision` tool is "
+    "only for a focused follow-up question about a saved screenshot. Use "
+    "`memory` to recall user preferences when the task needs them. If a page "
+    "demands a login or CAPTCHA, report that plainly instead of trying to get "
+    "past it.\n\n"
     "STOP RULE: the moment you can answer the goal — or know you cannot — stop "
     "calling tools and give your final answer, citing the pages you actually "
     "visited."
@@ -100,7 +102,7 @@ class WebBrowseConfig(ProcessorConfig):
         shots = screenshot_ledger(getattr(mp, "uid", None) or 0)
         if shots:
             lines = "\n".join(f"- doc_id={doc_id} ({url})" for doc_id, url in shots)
-            parts.append(f"Screenshots captured this run (view with the vision tool):\n{lines}")
+            parts.append(f"Screenshots captured this run (each was described inline when taken):\n{lines}")
         trail = render_trail(mp)
         if trail:
             parts.append(trail)

--- a/backend/tests/e2e/test_browser_live.py
+++ b/backend/tests/e2e/test_browser_live.py
@@ -40,5 +40,18 @@ def test_full_browse_flow_on_one_persistent_page() -> None:
     env = _run({"action": "back"})
     assert "example.com" in cast(str, cast(dict[str, object], env["page"])["url"])
 
+    # A screenshot self-describes: the shared document ingest runs the page
+    # through vision and the description rides back inline as data["vision"] —
+    # no separate vision-tool round-trip. The old "use the vision tool" note is
+    # gone, proving the result shape was rewired.
+    env = _run({"action": "screenshot"})
+    assert env["error"] is None, env
+    data = cast(dict[str, object], env["data"])
+    assert data["doc_id"], data
+    assert "note" not in data, data
+    vision = cast(str, data["vision"])
+    assert vision.strip(), "screenshot must carry the page description inline"
+    assert "domain" in vision.lower(), vision
+
     from tools.browser.session import close_session
     close_session(_Mp.uid)

--- a/backend/tests/test_browser_screenshot_ingest.py
+++ b/backend/tests/test_browser_screenshot_ingest.py
@@ -68,6 +68,10 @@ def test_screenshot_ingest_lands_in_screenshots_subdir_and_vision_reads_it(db: s
     assert ingested["status"] == "ready", ingested
     doc = cast(dict[str, object], service.get_document(cast(str, ingested["id"])))
     assert doc["source_type"] == "screenshot"
+    # The exact field BrowserAbility._screenshot hands back inline as data["vision"]:
+    # ingest ran the png through the image extractor (OCR here, vision in prod) and
+    # stored the readable content as clean_text — proving the screenshot self-describes.
+    assert "INVOICE" in cast(str, doc.get("clean_text") or ""), doc.get("clean_text")
     assert cast(str, doc["file_path"]).startswith("screenshots/"), doc["file_path"]
     stored = FileMapperService.get_documents_path(cast(str, doc["file_path"]))
     assert stored.is_file(), f"file missing on disk: {stored}"


### PR DESCRIPTION
## Problem

The web-browse delegate drove blind. `browser action='screenshot'` returned only `{doc_id, name, status, note:"Use the vision tool..."}` — the page's pixels never reached the browsing model, so it looped trying to act on a page it could not see.

## Fix

Screenshots already ingest through the **same `ingest_file` pipeline chat attachments use**, which runs images through `describe_image` at ingest time and stores the rich description as the document's `clean_text` (synchronously, before `ingest_file` returns `ready`). The fix surfaces that **existing** prose inline as `data["vision"]` — the same content `document(action='view')` returns — rather than adding a redundant second vision call.

- `abilities/browser.py::_screenshot` — read back `clean_text`, return it as `data["vision"]`; drop the old vision-tool `note`.
- `configs/channels/web_browse.py` — delegate system prompt + ledger blurb updated: screenshots come back described inline; the `vision` tool is repositioned as a focused follow-up tool (retained, non-breaking).

### Hardening
A vision-provider failure is caught by `ingest_file` into `status='failed'` with **no `error` key**, so an `error`-only guard would have surfaced an empty description silently. Now:
- gate on `status != "ready"` (mirrors `_handle_upload`), and
- guard a missing document record —

both return a structured `ToolResult.err` instead of a silent empty `vision`.

## Tests
- `tests/e2e/test_browser_live.py` (chromium-gated) — asserts the inline `data["vision"]` wire end-to-end and that the old `note` is gone.
- `tests/test_browser_screenshot_ingest.py` (unit, runs in CI) — strengthened to assert `clean_text` carries the extracted text, locking the exact field the screenshot reads.

## Compatibility
Traced every consumer of the screenshot result shape: only the delegate's act-trail consumed it; `doc_id` is preserved; the screenshot ledger path is independent of the result dict. No breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)