### PR TITLE
feat(browser): add `style` verb — read an element's exact computed CSS by visible text

### DIFF
--- a/backend/abilities/browser.py
+++ b/backend/abilities/browser.py
@@ -1,4 +1,4 @@
-"""BrowserAbility — drive one persistent web page with nine flat verbs.
+"""BrowserAbility — drive one persistent web page with ten flat verbs.
 
 The model thinks as little as possible: it names WHAT to act on by visible text
 ("Sign in", "Email") and the code resolves WHERE mechanically
@@ -42,7 +42,8 @@ class BrowserAbility(Ability):
         return (
             "Drive a web page step by step: open a URL, read it, find text on it, "
             "click buttons and links by their visible label, fill and submit forms, "
-            "scroll, go back, and capture screenshots into the document store. The "
+            "scroll, go back, read an element's exact computed colours and fonts, "
+            "and capture screenshots into the document store. The "
             "page stays open between calls; every action returns the same JSON "
             "envelope describing the page and what just changed."
         )
@@ -56,7 +57,7 @@ class BrowserAbility(Ability):
             "take a screenshot of this page",
             "choose a country from the dropdown on this form",
             "scroll down and read the rest of the article",
-            "go back to the previous page",
+            "get the exact colour of the heading on this page",
         ]
 
     def get_search_tooltip(self) -> str:
@@ -69,7 +70,7 @@ class BrowserAbility(Ability):
                 "type": "string",
                 "enum": [
                     "open", "read", "find", "click", "fill",
-                    "select", "scroll", "back", "screenshot",
+                    "select", "scroll", "back", "screenshot", "style",
                 ],
                 "description": (
                     "What to do. 'open' a URL first; every other action works on "
@@ -85,7 +86,7 @@ class BrowserAbility(Ability):
                 "description": (
                     "Visible text of the element to act on — a button or link "
                     "label, or a form field's label/placeholder (e.g. 'Sign in', "
-                    "'Email'). Used by click/fill/select."
+                    "'Email'). Used by click/fill/select/style."
                 ),
             },
             Keys.value: {
@@ -114,7 +115,7 @@ class BrowserAbility(Ability):
 
     # Required params per action — consumed by the dispatcher's ACTION_REQUIRED
     # pre-gate (BEFORE the policy gate and BEFORE run()): an unknown action →
-    # code=unknown-action whose valid= names all nine verbs; a known action
+    # code=unknown-action whose valid= names all ten verbs; a known action
     # missing a required param → one code=missing-params naming it. run() never
     # sees either case.
     ACTION_REQUIRED: ClassVar[dict[str, tuple[str, ...]]] = {
@@ -127,6 +128,7 @@ class BrowserAbility(Ability):
         "scroll": (Keys.direction,),
         "back": (),
         "screenshot": (),
+        "style": (Keys.target,),
     }
 
     # verb -> params forwarded to the session layer (the required half is the
@@ -141,6 +143,7 @@ class BrowserAbility(Ability):
         "scroll": (Keys.direction,),
         "back": (),
         "screenshot": (),
+        "style": (Keys.target,),
     }
 
     def run(self, params: dict[str, object]) -> ToolResult:

--- a/backend/tests/e2e/test_browser_live.py
+++ b/backend/tests/e2e/test_browser_live.py
@@ -1,6 +1,6 @@
 # Requires network + chromium; run with: pytest -m e2e tests/e2e/test_browser_live.py
 
-import json
+import sqlite3
 from typing import cast
 
 import pytest
@@ -16,10 +16,12 @@ class _Mp:
 
 
 def _run(params: dict[str, object]) -> dict[str, object]:
-    return cast(dict[str, object], json.loads(cast(str, cast(dict[str, object], BrowserAbility(mp=_Mp()).run(params))["result"])))
+    """Drive the real ability entry point; a successful call's body IS the
+    wire envelope dict (ToolResult.ok(envelope))."""
+    return cast(dict[str, object], BrowserAbility(mp=_Mp()).run(params).body)
 
 
-def test_full_browse_flow_on_one_persistent_page() -> None:
+def test_full_browse_flow_on_one_persistent_page(db: sqlite3.Connection) -> None:  # noqa: ARG001 — fixture patches the shared DB so screenshot ingest finds the documents table
     env = _run({"action": "open", "url": "https://example.com"})
     assert env["error"] is None, env
     assert cast(dict[str, object], env["page"])["status"] == 200
@@ -29,16 +31,26 @@ def test_full_browse_flow_on_one_persistent_page() -> None:
     env = _run({"action": "read"})
     assert "Example Domain" in cast(str, cast(dict[str, object], env["data"])["text"])
 
-    env = _run({"action": "find", "query": "More information"})
+    env = _run({"action": "find", "query": "Learn more"})
     assert cast(dict[str, object], env["data"])["interactive"], env
 
-    env = _run({"action": "click", "target": "More information"})
+    env = _run({"action": "click", "target": "Learn more"})
     assert cast(dict[str, object], env["changed"])["navigated"] is True, env
     assert "iana.org" in cast(str, cast(dict[str, object], env["page"])["url"])
     assert env["data"], "navigation diff must carry the new page's read view"
 
     env = _run({"action": "back"})
     assert "example.com" in cast(str, cast(dict[str, object], env["page"])["url"])
+
+    # `style` reads the element's EXACT computed CSS by visible text — colours
+    # come back as precise rgb() values, so a model never has to guess a colour
+    # from a screenshot or hunt the page source for it.
+    env = _run({"action": "style", "target": "Example Domain"})
+    assert env["error"] is None, env
+    computed = cast(dict[str, object], env["data"])
+    assert cast(str, computed["color"]).startswith("rgb"), computed
+    assert cast(str, computed["background-color"]).startswith("rgb"), computed
+    assert cast(str, computed["font-size"]).endswith("px"), computed
 
     # A screenshot self-describes: the shared document ingest runs the page
     # through vision and the description rides back inline as data["vision"] —

--- a/backend/tests/test_browser_ability.py
+++ b/backend/tests/test_browser_ability.py
@@ -1,4 +1,4 @@
-"""Feature tests: the rebuilt 9-verb browser ability.
+"""Feature tests: the rebuilt 10-verb browser ability.
 
 Drives the REAL production hot path — ``ToolDispatcher.dispatch()`` on a real
 ``MessageProcessor`` bound to ``WebBrowseConfig`` (where ``browser`` is
@@ -25,7 +25,7 @@ from services.processor_config import ProcessorConfig
 
 pytestmark = pytest.mark.unit
 
-_VERBS = ["open", "read", "find", "click", "fill", "select", "scroll", "back", "screenshot"]
+_VERBS = ["open", "read", "find", "click", "fill", "select", "scroll", "back", "screenshot", "style"]
 
 
 def _browse_mp() -> MessageProcessor:
@@ -39,7 +39,7 @@ def _dispatch(params: dict[str, object]) -> str:
     return ToolDispatcher(_browse_mp()).dispatch("browser", params)
 
 
-def test_schema_is_nine_flat_verbs() -> None:
+def test_schema_is_ten_flat_verbs() -> None:
     schema = BrowserAbility(mp=None).get_input_schema()
     params = cast("dict[str, object]", schema["input_schema"])
     assert cast("dict[str, object]", cast("dict[str, object]", params["properties"])["action"])["enum"] == _VERBS

--- a/backend/tools/browser/session.py
+++ b/backend/tools/browser/session.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
         def click(self, *, timeout: int) -> None: ...
         def fill(self, value: str, *, timeout: int) -> None: ...
         def select_option(self, *, label: str | None = None, value: str | None = None, timeout: int = 0) -> object: ...
+        def evaluate(self, expression: str, arg: object = None) -> object: ...
 
     class _Page(Protocol):
         url: str
@@ -278,6 +279,13 @@ class PageSession:
         self._settle()
         return self._envelope(data=self._read_view(), changed=self._changed(before))
 
+    def style(self, target: str) -> dict[str, object]:
+        locator, err = self._locate(target, self._CLICK_ROLES, text_fallback=True)
+        if err:
+            return err
+        computed = cast("_Locator", locator).evaluate(_COMPUTED_STYLE_JS)
+        return self._envelope(data=computed)
+
     def grab(self) -> dict[str, object]:
         """Viewport PNG + page info — NOT an envelope; the ability layer ingests it."""
         return {
@@ -467,4 +475,13 @@ _FIND_JS = """({q, limit, ctx}) => {
     }
   }
   return {matches, interactive};
+}"""
+
+_COMPUTED_STYLE_JS = """(el) => {
+  const cs = getComputedStyle(el);
+  const out = {};
+  for (const k of ['color', 'background-color', 'border-color',
+                   'font-size', 'font-family', 'font-weight'])
+    out[k] = cs.getPropertyValue(k);
+  return out;
 }"""


### PR DESCRIPTION
## What

Adds a tenth flat verb, **`style`**, to the persistent-page `browser` tool. It resolves an element by its **visible text** (the same locator `click` uses) and reads its computed CSS in-page via `getComputedStyle`, returning a flat map:

```json
{ "color": "rgb(...)", "background-color": "rgb(...)", "border-color": "rgb(...)",
  "font-size": "16px", "font-family": "...", "font-weight": "400" }
```

## Why

Reading an exact colour or font previously meant the model either eyeballed a screenshot (imprecise) or detoured through the page source/CSS (unbounded). `style` gives any model/user the exact rendered values directly — colours as precise `rgb()`.

## Surface

- `tools/browser/session.py` — `style()` verb + `_COMPUTED_STYLE_JS`; `evaluate` added to the `_Locator` protocol.
- `abilities/browser.py` — enum, `ACTION_REQUIRED` + `_FORWARDED`, summary, `target` description, one example, nine→ten verb wording.
- No `abilities.sqlite` rebuild needed: `browser` is `DISCOVERABLE=False`, so it is not indexed in the ability DB.

## Tests

- Unit: schema test now asserts the ten-verb enum (`test_schema_is_ten_flat_verbs`).
- Feature (e2e, real Chromium): the live flow drives `open → read → find → click → back → style → screenshot` and asserts the `style` envelope returns `rgb()` / `px` computed values. The test now requests the converged `db` fixture so the screenshot ingest finds the `documents` table (revives e2e coverage that was previously unrun).

## Verification

- e2e `test_full_browse_flow_on_one_persistent_page`: **passed** (real browser).
- Full `pytest -m unit`: **1390 passed**; the 4 failures are pre-existing/env-artifacts (snapshot root-chmod-bypass, static-typing-gate stub env, internal-dev-gate env flag) — none in the changed files.
- `ruff` clean, `mypy` clean on both changed source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)