### PR TITLE
fix(contacts): isolate contact index in its own data_graph kind

### DIFF
--- a/backend/abilities/contacts.py
+++ b/backend/abilities/contacts.py
@@ -145,7 +145,7 @@ class ContactsAbility(CapabilityAbility):
             contacts = resolve(query, limit=limit)
         else:
             rows = self._dgs().fetch(
-                kinds=["user_specific"], order_by="key ASC", limit=limit
+                kinds=["contact"], order_by="key ASC", limit=limit
             )
             contacts = [
                 c

--- a/backend/capabilities/contact_resolver.py
+++ b/backend/capabilities/contact_resolver.py
@@ -1,13 +1,17 @@
 """ContactResolver — passive people index from IMAP and CardDAV data.
 
-Two storage formats coexist under ``kind='user_specific'``:
+Two storage formats coexist under ``kind='contact'``:
 
 * **IMAP senders** (lightweight): ``key='contact:<email>'``,
   ``value='<display_name>'``.  Written by :func:`index_person`.
 * **CardDAV profiles** (rich): ``key='contact:<Display Name>'``,
   ``value='<JSON profile object>'``.  Written by :func:`index_contact_profile`.
 
-:func:`resolve` transparently handles both formats.
+Contacts live in their own data_graph kind (``kind='contact'``) rather than the
+shared ``user_specific`` namespace so contact reads (:func:`resolve`, the
+contacts ability's ``list``/``get``) can be scoped to ``kind='contact'`` and
+never get crowded out of a shared top-N recall/fetch window by unrelated user
+facts / traits. :func:`resolve` transparently handles both storage formats.
 """
 
 from __future__ import annotations
@@ -45,7 +49,7 @@ def index_person(email: str, name: str | None = None, source: str = "unknown") -
         return
     try:
         _dgs().store(
-            kind="user_specific",
+            kind="contact",
             key=f"{_CONTACT_KEY_PREFIX}{email.strip().lower()}",
             value=display,
             source=source,
@@ -65,7 +69,7 @@ def index_contact_profile(profile: dict[str, object], source: str = "carddav") -
         return
     try:
         _dgs().store(
-            kind="user_specific",
+            kind="contact",
             key=f"{_CONTACT_KEY_PREFIX}{fn}",
             value=json.dumps(profile, ensure_ascii=False),
             source=source,
@@ -76,8 +80,6 @@ def index_contact_profile(profile: dict[str, object], source: str = "carddav") -
 
 def _parse_contact_row(key: str, raw_value: str) -> dict[str, object] | None:
     """Parse a single data_graph row into a contact dict."""
-    if not key.startswith(_CONTACT_KEY_PREFIX):
-        return None
     try:
         profile = json.loads(raw_value)
         if isinstance(profile, dict):
@@ -90,13 +92,16 @@ def _parse_contact_row(key: str, raw_value: str) -> dict[str, object] | None:
 
 def resolve(identifier: str, limit: int = 5) -> list[dict[str, object]]:
     """Look up person entries matching *identifier* via RRF across key/value vec + FTS5.
+
+    Scoped to ``kind='contact'`` so non-contact user facts / traits sharing the
+    data_graph cannot crowd a real contact out of the top-N window.
     """
     if not identifier or not str(identifier).strip():
         return []
     try:
         rows = _dgs().recall(
             query=identifier.strip(),
-            kinds=["user_specific"],
+            kinds=["contact"],
             limit=limit,
         )
         contacts = []

--- a/backend/capabilities/mail_capability/carddav_handler.py
+++ b/backend/capabilities/mail_capability/carddav_handler.py
@@ -204,7 +204,7 @@ class CarddavHandler:
             return {"contacts": matches, "count": len(matches)}
 
         try:
-            rows = _dgs().fetch(kinds=["user_specific"], order_by="key ASC", limit=limit)
+            rows = _dgs().fetch(kinds=["contact"], order_by="key ASC", limit=limit)
             contacts: list[dict[str, object]] = []
             for r in rows:
                 parsed = _parse_contact_row(cast(str, r.get("key", "")), cast(str, r.get("value", "")))

--- a/backend/services/data_graph_service.py
+++ b/backend/services/data_graph_service.py
@@ -29,6 +29,13 @@ KIND_MISC = 'misc'
 KIND_DOCUMENT = 'document'
 KIND_BEHAVIORAL_PATTERN = 'behavioral_pattern'
 KIND_PLACE = 'place'
+# Contacts (CardDAV profiles + IMAP sender identities) get their own kind so
+# contact reads can be scoped to kind='contact' and never get crowded out of a
+# shared top-N recall/fetch window by unrelated user facts / traits. Without
+# isolation, a freshly synced card can lose the top-5 recall race against a
+# bloated user_specific namespace and the contacts ability reports a false
+# not-found (the model then fabricates from memory).
+KIND_CONTACT = 'contact'
 # 'discovery' is the proactive-research lane: timely findings the subconscious
 # research loop turns up about the user's interests. Recallable like any fact (it
 # joins generic data_graph recall + the turn-0 flashback) but ephemeral — it
@@ -40,7 +47,7 @@ KIND_DISCOVERY = 'discovery'
 # the hole where any channel could write any kind.
 VALID_KINDS = frozenset({
     KIND_USER_SPECIFIC, KIND_SYSTEM, KIND_MISC,
-    KIND_DOCUMENT, KIND_BEHAVIORAL_PATTERN, KIND_PLACE, KIND_DISCOVERY,
+    KIND_DOCUMENT, KIND_BEHAVIORAL_PATTERN, KIND_PLACE, KIND_CONTACT, KIND_DISCOVERY,
 })
 
 _SELECT_ACTIVE_BY_KIND_KEY_SQL = (
@@ -88,6 +95,10 @@ _KIND_POLICY: dict[str, dict[str, object]] = {
     # reinforced on re-save of same coords, superseded when the user renames/moves a
     # place, only removed on explicit user request. Low decay, moderate salience floor.
     KIND_PLACE:              {'ttl_days': None,  'reinforce': True,  'contradiction': 'cosine_supersede', 'deletion': 'explicit', 'd_base': 0.05, 'salience_floor': 0.5},
+    # contact: CardDAV profiles + IMAP sender identities. Persistent, reinforced
+    # on re-sync, no contradiction reconciliation (each card is authoritative),
+    # soft-deleted so a removed card lingers briefly for its decay window.
+    KIND_CONTACT:            {'ttl_days': None,  'reinforce': True,  'contradiction': None,               'deletion': 'soft',     'd_base': 0.1,  'salience_floor': 0.3},
     # discovery: timely research findings from the proactive loop. Each is an
     # independent item (no contradiction reconciliation); reinforced if re-found,
     # decays like a user trait so it fades after ~2 weeks, soft-deleted on forget.

--- a/backend/tests/test_ability_contacts.py
+++ b/backend/tests/test_ability_contacts.py
@@ -38,7 +38,7 @@ def _seed_contact(
     title: str = "",
 ) -> dict[str, object]:
     """Must use ``contact_resolver.index_contact_profile`` (CardDAV ingest entry
-    point) so the contact lands as a ``user_specific`` data_graph row resolvable by
+    point) so the contact lands as a ``contact`` data_graph row resolvable by
     the ability."""
     from capabilities.contact_resolver import index_contact_profile
 


### PR DESCRIPTION
## Summary

Contacts (CardDAV profiles + IMAP sender identities) were stored under `kind='user_specific'` alongside general user facts, traits, and memory. Contact reads (`resolve` / `contacts.list` / `contacts.get`) used unscoped top-N `recall`/`fetch` over that shared namespace then post-filtered `contact:` keys client-side — so a freshly synced card could be crowded out of the top-5 recall window by unrelated rows, or truncated past the fetch limit behind alphabetically-earlier non-contact keys.

The result was a **false not-found / empty list for a server-present contact**, which the model took at face value and **fabricated an answer from memory** instead of reading the real card. This recurred across every driver model on the contacts-recall scenario.

## Fix

- Add `KIND_CONTACT='contact'` to `VALID_KINDS` + `_KIND_POLICY` (persistent, reinforced on re-sync, soft-deleted).
- Route all contact writers (`index_person`, `index_contact_profile`) to `kind='contact'`.
- Scope every contact read (`resolve`, `contacts._list`, `carddav_handler.list_contacts`) to `kind='contact'` — contact retrieval now never competes with non-contact rows.
- Drop the now-redundant `contact:` prefix guard in `_parse_contact_row` (the kind isolates; the prefix survives on the key for readability and suffix extraction).

Legacy `user_specific` rows with `contact:` keys self-heal on the next subconscious sync tick — the writers re-index them to the new kind, so no backfill migration is needed.

## Evidence

Nightly run 995 (glm-5.2, best model, score 0.91) — scenario 012-contacts-recall:
- `contacts.get "Priya Sharma"` → `not-found` despite the seeded card being server-present and the sync step reporting `synced=['mail']`.
- Model then fabricated `priya.sharma@meridian-group.com` from cross-scenario memory; the real seeded address never appeared.
- Same false-empty recurred in runs 990, 993, 994 — the judge in run 990 literally noted "the seeded CardDAV cards did not actually land in local state."

Tracked in TKT-1137 (hypothesis refined with this evidence).

## Test plan

- [x] `pytest -m unit -q` — 1402 passed (2 pre-existing mypy-not-installed env failures deselected, unrelated to this change)
- [x] `ruff check` on all changed files — clean
- [x] Contacts ability tests (`test_ability_contacts.py`) — 5/5 pass against the new kind
- [ ] Post-merge nightly run on scenario 012 to confirm the score moves

🤖 Generated with Claude Code