### PR TITLE
Fix folder_watcher using isolated MemoryStore instead of shared singleton

### DIFF
--- a/backend/services/folder_watcher_service.py
+++ b/backend/services/folder_watcher_service.py
@@ -192,9 +192,8 @@ class FolderWatcherService:
 
     def trigger_scan(self, folder_id: str) -> None:
         """Request an out-of-schedule immediate scan for a watched folder."""
-        from services.memory_store import MemoryStore
-        store = MemoryStore()
-        store.set(f"watcher:scan_now:{folder_id}", "1", ex=600)
+        from services.memory_client import MemoryClientService
+        MemoryClientService.create_connection().set(f"watcher:scan_now:{folder_id}", "1", ex=600)
 
     # ─────────────────────────────────────────────
     # Directory browsing
@@ -255,8 +254,8 @@ class FolderWatcherService:
 
     def is_scan_requested(self, folder_id: str) -> bool:
         """Check if an immediate scan was requested via trigger_scan()."""
-        from services.memory_store import MemoryStore
-        store = MemoryStore()
+        from services.memory_client import MemoryClientService
+        store = MemoryClientService.create_connection()
         val = store.get(f"watcher:scan_now:{folder_id}")
         if val:
             store.delete(f"watcher:scan_now:{folder_id}")
@@ -265,8 +264,8 @@ class FolderWatcherService:
 
     def scan_folder(self, folder: Dict[str, object]) -> Dict[str, object]:
         """Scan a watched folder for changes."""
-        from services.memory_store import MemoryStore
-        store = MemoryStore()
+        from services.memory_client import MemoryClientService
+        store = MemoryClientService.create_connection()
         lock_key = f"watcher:scanning:{folder['id']}"
 
         # Skip if already scanning
@@ -598,8 +597,8 @@ class FolderWatcherService:
 
     def _clear_scan_cache(self, folder_id: str) -> None:
         """Clear the MemoryStore scan-state cache for a folder."""
-        from services.memory_store import MemoryStore
-        store = MemoryStore()
+        from services.memory_client import MemoryClientService
+        store = MemoryClientService.create_connection()
         store.delete(f"watcher:state:{folder_id}")
         store.delete(f"watcher:scan_now:{folder_id}")
 


### PR DESCRIPTION
Closes #1887

## Problem
`FolderWatcherService` constructed raw `MemoryStore()` objects at four sites instead of using the shared process-wide singleton returned by `MemoryClientService.create_connection()` → `get_shared_store()`. Because each `MemoryStore` instance owns private dicts, cross-call state never persisted:

- **Manual "scan now" silently dropped** — `trigger_scan` wrote `watcher:scan_now:<id>` to instance X; `is_scan_requested` read a different empty instance Y.
- **Re-entrancy lock was a no-op** — the `watcher:scanning:<id>` guard checked/set a fresh instance, so concurrent `scan_folder` calls collided.
- **Scan-state cache layer was inert** — `_save_scan_cache` wrote to a soon-to-be-GC'd instance; `_load_scan_cache` cold-rebuilt from the DB each cycle.

## Fix
Route all four construction sites through `MemoryClientService.create_connection()`:
- `trigger_scan` (folder_watcher_service.py:194)
- `is_scan_requested` (folder_watcher_service.py:256)
- `scan_folder` (folder_watcher_service.py:265)
- `_clear_scan_cache` (folder_watcher_service.py:598)

The cache helpers `_load_scan_cache`/`_save_scan_cache` already receive `store` as a parameter from `scan_folder`, so they now transparently use the shared singleton.

## Verification
- `ruff` / `pyflakes` clean.
- `pytest -m unit -q` — 1400 passed.


Part of #1883 audit, raised by @rygel


