### PR TITLE
fix(search-expander): eliminate lost-wakeup race in run() loop

### DIFF
--- a/backend/services/search_expander_service.py
+++ b/backend/services/search_expander_service.py
@@ -69,12 +69,12 @@ class SearchExpanderService:
 
         while True:
             self._event.wait()
+            self._event.clear()
             while True:
                 item = self._dequeue()
                 if item is None:
                     break
                 self._process(item)
-            self._event.clear()
 
     # ── Private: queue ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes a lost-wakeup race in `SearchExpanderService.run()` (`backend/services/search_expander_service.py:65-77`).

## Problem

`run()` called `self._event.clear()` *after* draining the queue, while `enqueue()` does `rpush` then `set()`. An enqueue interleaving between the final `_dequeue()` returning `None` and `clear()` had its `set()` wiped → `_event.wait()` re-blocked with an unprocessed item stranded in the queue until the next unrelated `enqueue()` `set()` or a process-restart `_self_heal()`.

## Fix

Move `self._event.clear()` to **before** the drain loop (clear → drain ordering). Any `set()` that fires after the clear is now guaranteed to survive until the next `wait()` returns and triggers a re-drain.

```diff
 while True:
     self._event.wait()
+    self._event.clear()
     while True:
         item = self._dequeue()
         if item is None:
             break
         self._process(item)
-    self._event.clear()
 ```

## Verification

- **Scope:** Minor bugfix — localized ordering fix, no new cross-step behavior, no UI surface. No new automated tests added: a deterministic repro of this timing race would require mocking that would not capture a real regression.
- **Lint:** ruff + vulture clean on the changed file.
- **Unit gate:** `pytest -m unit -q` → 1400 passed / 0 failed / 134 deselected.
- Net change: +1 / -1 LOC.

Closes #1888


Part of #1883 audit, raised by @rygel
