### PR TITLE
fix(draft): persist compose text + beforeunload guard for attachments

### DIFF
--- a/frontend/apps/interface/src/components/layout/InputDock.vue
+++ b/frontend/apps/interface/src/components/layout/InputDock.vue
@@ -5,7 +5,7 @@
  * WS single-owner rule: send/stop go through the session store; this component
  * never touches the WebSocket directly.
  */
-import { ref, computed, onMounted, onBeforeUnmount, nextTick } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { on } from '../../composables/useEventBus';
 import { useSessionStore } from '../../stores/session';
@@ -14,6 +14,7 @@ import { useAttachmentsStore } from '../../stores/attachments';
 import { useContextUsageStore } from '../../stores/contextUsage';
 import { useAmbientSensor } from '../../composables/useAmbientSensor';
 import { system } from '../../api/system';
+import { lsGet, lsSet } from '../../utils/storage';
 import type { AttachmentPreview as ConvoAttachmentPreview } from '../../stores/conversation';
 import ImageAttachStrip from '../upload/ImageAttachStrip.vue';
 import { FileText, Image, Plus, Mic, Send, X, AlertTriangle } from '@lucide/vue';
@@ -35,6 +36,12 @@ const THINKING_ITEMS = [
 
 const textareaRef = ref<HTMLTextAreaElement | null>(null);
 const text = ref('');
+
+// Restore draft: persisted on every change so a reload/close/navigate recovers it.
+const DRAFT_KEY = 'chalie:draft';
+const stored = lsGet(DRAFT_KEY);
+if (stored) text.value = stored;
+watch(text, (v) => lsSet(DRAFT_KEY, v));
 
 const attachMenuOpen = ref(false);
 const attachBtnRef = ref<HTMLButtonElement | null>(null);
@@ -135,6 +142,16 @@ function onWindowScroll(): void {
   if (attachMenuOpen.value) attachMenuOpen.value = false;
 }
 
+// Raw File objects are structurally non-persistable, so the only loss the
+// draft-restoration above doesn't cover is a discard of pending attachments.
+// Warn on beforeunload so an accidental reload/close/navigate confirms first.
+function onBeforeUnload(e: BeforeUnloadEvent): void {
+  if (attachments.getFiles().length > 0) {
+    e.preventDefault();
+    e.returnValue = '';
+  }
+}
+
 function onTurnInterrupted(e: Event): void {
   const detail = (e as CustomEvent<{ text: string }>).detail;
   text.value = detail.text ?? '';
@@ -170,6 +187,7 @@ onMounted(() => {
   _unsubVoiceTranscript = on('chalie:voice-transcript', onVoiceTranscript);
   document.addEventListener('click', onDocumentClick);
   globalThis.addEventListener('scroll', onWindowScroll, { passive: true });
+  globalThis.addEventListener('beforeunload', onBeforeUnload);
 
   // Behavioral signals: typing cadence feeds the ambient snapshot.
   if (textareaRef.value) ambient.bindTypingInput(textareaRef.value);
@@ -193,6 +211,7 @@ onBeforeUnmount(() => {
   _unsubVoiceTranscript?.();
   document.removeEventListener('click', onDocumentClick);
   globalThis.removeEventListener('scroll', onWindowScroll);
+  globalThis.removeEventListener('beforeunload', onBeforeUnload);
   voiceStore.destroyRecorder();
 });
 </script>


### PR DESCRIPTION
## Summary

Unsent compose drafts and pending attachments were silently discarded on reload / navigate / OS-back / accidental close (#1889).

- **Draft text** — persisted to `localStorage` via a `watch` on the compose `text` ref (covers typing, voice transcript restore, and turn-interrupt restore), and restored on mount. The empty-string write after a successful send naturally clears it.
- **Pending attachments** — raw `File` objects are structurally non-persistable, so a `beforeunload` confirmation guard fires when any attachment is staged, prompting the user before the loss happens.

Uses the existing safe `lsGet` / `lsSet` wrappers (handles private-browsing `SecurityError`). Restored draft only triggers on mount; the warning only triggers when there are pending attachments, so draft recovery itself stays frictionless.

## Scope

Localized bugfix — no new ability/tool/capability or cross-step flow. Touches only the compose surface in `InputDock.vue`.

## Verification

- `pnpm typecheck` (vue-tsc) ✅
- `eslint` on touched file ✅
- No new lint/type issues introduced.

Closes #1889


Part of #1883 audit, raised by @rygel
