### PR TITLE
fix(auth): hash session tokens in SQLite

### DIFF
--- a/backend/services/auth_session_service.py
+++ b/backend/services/auth_session_service.py
@@ -5,6 +5,7 @@ MemoryStore is checked first for speed; SQLite is the fallback that
 survives container restarts. Cookie: ``chalie_session`` (HTTP-only,
 SameSite=Lax).
 """
+import hashlib
 import os
 import secrets
 import logging
@@ -20,16 +21,24 @@ SESSION_TTL = 30 * 24 * 60 * 60  # 30 days in seconds
 SESSION_KEY_PREFIX = 'auth_session:'
 
 
+def _hash_session_token(raw_token: str) -> str:
+    """SHA-256 of the raw session token; the SQLite row stores only the hash."""
+    return hashlib.sha256(raw_token.encode('utf-8')).hexdigest()
+
+
 def _persist_session_to_sqlite(token: str) -> None:
-    """Write session to SQLite so it survives MemoryStore wipes (restart)."""
+    """Write session to SQLite so it survives MemoryStore wipes (restart).
+
+    Only the SHA-256 hash of the token is persisted — never the raw token —
+    mirroring the wrapper-auth path so a DB leak cannot yield live tokens.
+    """
     try:
         from services.database_service import get_shared_db_service
         db = get_shared_db_service()
-        utc_now().isoformat()
         db.execute(
             """INSERT OR REPLACE INTO auth_sessions (token, created_at, expires_at)
                VALUES (?, ?, datetime('now', '+30 days'))""",
-            (token, utc_now().isoformat())
+            (_hash_session_token(token), utc_now().isoformat())
         )
     except Exception as e:
         logger.error(f"[Session] SQLite persist failed: {e}")
@@ -40,7 +49,7 @@ def _delete_session_from_sqlite(token: str) -> None:
     try:
         from services.database_service import get_shared_db_service
         db = get_shared_db_service()
-        db.execute("DELETE FROM auth_sessions WHERE token = ?", (token,))
+        db.execute("DELETE FROM auth_sessions WHERE token = ?", (_hash_session_token(token),))
     except Exception as e:
         logger.debug(f"[Session] SQLite delete failed: {e}")
 
@@ -54,7 +63,7 @@ def _validate_session_in_sqlite(token: str) -> bool:
             """SELECT token FROM auth_sessions
                WHERE token = ? AND expires_at > datetime('now')
                LIMIT 1""",
-            (token,)
+            (_hash_session_token(token),)
         )
         if rows:
             # Rehydrate MemoryStore so subsequent requests are fast


### PR DESCRIPTION
## What

Fixes #1890 — plaintext session tokens were persisted verbatim into `auth_sessions.token`. Any read access to the SQLite file (backup leak, snapshot, path traversal, RCE) yielded live bearer tokens valid for 30 days → full account takeover.

## Fix

Store only `sha256(session_token)` in `auth_sessions.token`, mirroring the existing wrapper-auth path (`wrapper_auth_service.py`). Lookup and delete hash the raw cookie token before querying SQLite. MemoryStore (hot cache, in-memory only) still holds the raw token — it is not the leak vector.

- `_persist_session_to_sqlite` → stores `_hash_session_token(token)`
- `_validate_session_in_sqlite` → looks up `_hash_session_token(token)`
- `_delete_session_from_sqlite` → deletes `_hash_session_token(token)`
- Added `_hash_session_token` helper (sha256, mirrors `WrapperAuthService._hash_token`)
- Dropped a dead `utc_now().isoformat()` no-op call in the persist path

## Scope

Minor security bugfix — localized to `backend/services/auth_session_service.py`, no new cross-step behavior, no UI surface. No new automated test added (no existing coverage to regress against); verified against the existing auth feature tests listed below.

## Verification

- `ruff` clean, `vulture` hits are pre-existing public-API false positives.
- Existing feature tests on the real stack (no mocks) pass:
  `test_brain_static_serving.py` (mints a real session via `create_session`, hits the cookie-authed route end-to-end), `test_websocket_bearer_handshake.py`, `test_auth_username.py` — 10 passed.

Closes #1890



Part of #1883 audit, raised by @rygel

