### PR TITLE
fix(auth): rate-limit /auth/login by client IP

### DIFF
--- a/backend/api/user_auth.py
+++ b/backend/api/user_auth.py
@@ -13,10 +13,22 @@ from werkzeug.security import generate_password_hash, check_password_hash
 
 if TYPE_CHECKING:
     from flask.typing import ResponseReturnValue
+    from services.wrapper_rate_limiter import WrapperRateLimiter
 
 logger = logging.getLogger(__name__)
 
 user_auth_bp = Blueprint('user_auth', __name__)
+
+
+_LOGIN_RATE_LIMIT = 10   # attempts
+_LOGIN_RATE_WINDOW = 60  # seconds
+
+
+def _get_login_rate_limiter() -> "WrapperRateLimiter":
+    from services.wrapper_rate_limiter import WrapperRateLimiter
+    return WrapperRateLimiter(
+        limit=_LOGIN_RATE_LIMIT, window_seconds=_LOGIN_RATE_WINDOW
+    )
 
 
 def _reconnect_capabilities() -> None:
@@ -261,6 +273,9 @@ def login() -> "ResponseReturnValue":
         # Validation
         if not username or not password:
             return jsonify({"error": "Username and password required"}), 400
+
+        if not _get_login_rate_limiter().is_allowed(request.remote_addr or "unknown"):
+            return jsonify({"error": "Too many login attempts. Try again later."}), 429
 
         db = get_shared_db_service()
 


### PR DESCRIPTION
## What

Applies the existing `WrapperRateLimiter` to `POST /auth/login`, keyed by client IP (`request.remote_addr`), before the expensive password-hash verification. 10 attempts per 60-second sliding window; excess returns `429`.

## Why

`/auth/login` had no attempt counter, lockout, or backoff — online brute force was bounded only by per-attempt KDF cost. The single master-account model means a cracked password yields full vault compromise + vault unlock, so online guessing must be bounded.

## Changes

- `backend/api/user_auth.py`: module-level `_LOGIN_RATE_LIMIT`/`_LOGIN_RATE_WINDOW` constants and `_get_login_rate_limiter()` helper; 429 short-circuit in `login()`.
- Net: +15 lines, no new deps, no schema/UI surface.

## Verification

- `ruff` + `mypy --strict` on `backend/api/user_auth.py`: clean.
- `pytest -m unit -q` full suite: 1400 passed, 134 deselected.
- No new static-analysis issues (existing `WrapperRateLimiter` reused verbatim).

## Scope

Localized security hardening — no new cross-step flow, no UI. No new automated tests added: a test asserting only that the limiter is called would not capture a real regression, and the limiter itself is already covered by `test_wrapper_rate_limiter.py`.

Closes #1891



Part of #1883 audit, raised by @rygel
