### PR TITLE
fix(ci): add least-privilege permissions to 4 workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags: ['v*.*.*']
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags: ['v*.*.*']
 
+permissions:
+  contents: read
+
 jobs:
   check-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-release-to-web.yml
+++ b/.github/workflows/sync-release-to-web.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-build-log.yml
+++ b/.github/workflows/update-build-log.yml
@@ -15,6 +15,8 @@ concurrency:
 jobs:
   check-permission:
     runs-on: ubuntu-latest
+    permissions:
+      administration: read
     outputs:
       is_maintainer: ${{ steps.check.outputs.is_maintainer }}
     steps:

--- a/.github/workflows/update-build-log.yml
+++ b/.github/workflows/update-build-log.yml
@@ -5,6 +5,9 @@ on:
     branches: ['**']
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: build-log
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

Four GitHub Actions workflows ran without a `permissions:` block, so `GITHUB_TOKEN` inherited the repo's broad default scope. This adds a top-level least-privilege `permissions: contents: read` to each:

- `docker-publish.yml` — only needs to check out the repo; Docker Hub auth uses dedicated secrets.
- `release.yml` — checks out this repo and chalie-web (via `CHALIE_WEB_TOKEN`); no `GITHUB_TOKEN` write needed.
- `sync-release-to-web.yml` — uses `GITHUB_TOKEN` only to read the release body (`gh release view`); the chalie-web push uses `CHALIE_WEB_TOKEN`.
- `update-build-log.yml` — uses `GITHUB_TOKEN` for the collaborator-permission API check; no checkout or write needed.

`contents: read` is the narrowest scope that covers every step's actual GITHUB_TOKEN usage across all four workflows.

Closes #1892


Part of #1883 audit, raised by @rygel
