### PR TITLE
ci: add pull_request unit + mypy quality gate (closes #1893)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: denoland/setup-deno@v2
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282  # v2.0.4
         with:
           deno-version: v2.x
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test & Type Gate
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    name: Unit suite + mypy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/pyproject.toml
+
+      - name: Install backend (editable)
+        run: pip install -e backend
+
+      - name: Unit tests + strict typing gate
+        run: python -m pytest -m unit -q
+        working-directory: backend

--- a/backend/capabilities/home_capability/ha_rest_handler.py
+++ b/backend/capabilities/home_capability/ha_rest_handler.py
@@ -5,13 +5,21 @@ than storing them -- the caller (HomeCapability) owns credential lifecycle.
 """
 
 import logging
-from typing import cast
+from typing import Mapping, Sequence, TypeAlias, Union, cast
 
 import requests
 
 logger = logging.getLogger(__name__)
 
 _TIMEOUT = 15
+
+# Recursive JSON value type, mirroring requests' ``JsonType``: the payload a
+# ``requests.post(json=...)`` call must carry. Local alias keeps it portable
+# across requests versions (``_types`` arrived only in 2.34).
+_Json: TypeAlias = Union[
+    None, bool, int, float, str,
+    Sequence["_Json"], Mapping[str, "_Json"],
+]
 
 
 def _headers(token: str) -> dict[str, str]:
@@ -39,7 +47,7 @@ def _post(
     resp = requests.post(
         f"{url.rstrip('/')}{path}",
         headers=_headers(token),
-        json=body or {},
+        json=cast("_Json", body or {}),
         verify=verify_ssl,
         timeout=_TIMEOUT,
     )

--- a/backend/services/llm_clients/ollama.py
+++ b/backend/services/llm_clients/ollama.py
@@ -20,7 +20,7 @@ import json
 import logging
 import re
 import time
-from typing import ClassVar, Optional, cast
+from typing import ClassVar, Mapping, Optional, Sequence, TypeAlias, Union, cast
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -44,6 +44,14 @@ logger = logging.getLogger(__name__)
 # trip py/clear-text-logging-sensitive-data on the config-derived value.
 _MODEL_NAME_RE = re.compile(r"^[A-Za-z0-9._:\-/]+$")
 _ALLOWED_HOST_SCHEMES = frozenset({"http", "https"})
+
+# Recursive JSON value type mirroring requests' ``JsonType`` — the payload a
+# ``requests.post(json=...)`` call must carry. Local alias stays portable across
+# requests versions (``_types`` arrived only in 2.34).
+_Json: TypeAlias = Union[
+    None, bool, int, float, str,
+    Sequence["_Json"], Mapping[str, "_Json"],
+]
 
 
 def _validate_model(raw_model: object) -> str:
@@ -232,7 +240,7 @@ class OllamaClient(ProviderClient):
         start = time.time()
         try:
             resp = requests.post(
-                url, json=payload,
+                url, json=cast("_Json", payload),
                 headers=self._user_agent(),
                 timeout=PROVIDER_CALL_TIMEOUT_S,
             )


### PR DESCRIPTION
Closes #1893.

## Problem

All 5 existing workflows ran with **zero `pull_request` triggers**, and none invoked pytest/mypy or any test/type command. `pytest>=8.0.0` and `mypy>=1.8.0` were declared in `backend/pyproject.toml` but the suite existed only as a **manual/local** pre-merge gate (per the project's contributing guidelines). Releases gated on tag push with no automated test/type check — a direct quality-gap.

## Fix

Adds `.github/workflows/test.yml` — the repo's first `pull_request`-triggered workflow. It runs on every PR:

1. `actions/checkout@v4`
2. `actions/setup-python@v5` (Python 3.12, matching the Dockerfile runtime image; pip cache keyed on `backend/pyproject.toml`)
3. `pip install -e backend` (the canonical install path used by `install.sh`)
4. `python -m pytest -m unit -q` — the backend unit suite, which **includes the strict `mypy --strict` typing gate** via `tests/test_static_typing_gate.py` (and the per-ability `ToolResult` return-type gate in `tests/test_ability_returns_tool_result.py`).

A `permissions: contents: read` block follows least-privilege hygiene.

The suite is 1400 unit tests + the full-tree strict typing gate; verified green in both a local env (requests 2.32.5) and a clean-room venv with the latest requests (2.34.2).

## Pre-existing type gaps surfaced by the gate

Running the gate on a fresh install (requests ≥ 2.34, which tightened the `JsonType` stub) exposed **two pre-existing latent `arg-type` errors** that the absence of CI had let slip. Both ship `dict[str, object]` to `requests.post(json=...)`, whose value type `object` is not provably JSON-serializable under the newer stub. These are not from another issue/PR — they are blockers for this gate to be green, so they are fixed here:

- `backend/services/llm_clients/ollama.py:243` — cast the `/api/chat` payload to a local recursive `_Json` alias before `requests.post(json=...)`.
- `backend/capabilities/home_capability/ha_rest_handler.py:50` — same for the Home Assistant REST `_post` body.

The `_Json` alias mirrors `requests`' `JsonType` (recursive: `None | bool | int | float | str | Sequence[_Json] | Mapping[str, _Json]`) but is defined locally per-file so it stays **portable across requests versions** — `requests._types` (where `JsonType` lives) only exists from 2.34 onward, and `pyproject.toml` pins `requests>=2.32.5`. No `Any` is used (the typing-ratchet bans it); the cast follows the sanctioned "inline cast at the point of use" pattern from `docs/typing-ratchet.md`. The casts are runtime no-ops.

## Verification

- `pytest -m unit -q` → **1400 passed, 134 deselected** (local + clean-room venv with latest requests).
- `mypy --strict` over the full first-party tree → **zero errors** (the two fixed files now pass).
- Workflow YAML validated.
- No user-facing behaviour changed (CI config + type-only casts); no companion docs PR needed.

## Scope note

No fixes from other issues/PRs are carried. The two typing fixes are intrinsic to making the #1893 gate functional — without them the workflow would be permanently red on pre-existing debt.



Part of #1883 audit, raised by @rygel
