### PR TITLE
fix(docker): forward SIGTERM to Python child for graceful shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG BRANCH=
 ARG TAG=
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends curl ca-certificates bash tar \
+ && apt-get install -y --no-install-recommends curl ca-certificates bash tar tini \
  && rm -rf /var/lib/apt/lists/* \
  && curl -fsSL https://raw.githubusercontent.com/chalie-ai/chalie/main/installer/install.sh -o /tmp/install.sh \
  && bash /tmp/install.sh ${BRANCH:+--branch="$BRANCH"} ${TAG:+--tag="$TAG"} \
@@ -30,5 +30,11 @@ EXPOSE 31025
 
 # Voice and playwright are installed at runtime by RuntimeDepsService
 # based on user settings — not baked into the image.
-ENTRYPOINT ["bash", "/root/.chalie/app/run.sh"]
+#
+# tini as PID 1 reaps orphaned threads/zombies and forwards signals to the
+# bash entrypoint; run.sh's TERM/INT trap then forwards to the Python child
+# so the graceful-shutdown handlers in consumer.py actually fire on
+# `docker stop` instead of relying on SIGKILL after the grace period.
+ENTRYPOINT ["tini", "--", "bash", "/root/.chalie/app/run.sh"]
+STOPSIGNAL SIGTERM
 CMD ["--port=31025", "--host=0.0.0.0"]

--- a/run.sh
+++ b/run.sh
@@ -82,7 +82,14 @@ while true; do
   _EXIT=0
   "$PYTHON" "$SCRIPT_DIR/backend/run.py" --port="$_PORT" --host="$_HOST" &
   _CHILD_PID=$!
-  wait "$_CHILD_PID" || _EXIT=$?
+  # `wait` returns >128 immediately when interrupted by a trapped signal (bash
+  # SIGNALS) — the trap forwards SIGTERM but control would otherwise fall through
+  # and exit while the child is still draining. Re-wait until the child is truly
+  # reaped so its graceful-shutdown handler completes before we exit (and tini
+  # tears the container down). The final `wait` yields the child's real exit code.
+  while kill -0 "$_CHILD_PID" 2>/dev/null; do
+    wait "$_CHILD_PID" && _EXIT=0 || _EXIT=$?
+  done
   _CHILD_PID=""
   if [[ "$_EXIT" -ne 42 ]]; then
     exit $_EXIT

--- a/run.sh
+++ b/run.sh
@@ -64,11 +64,26 @@ _install -e "$SCRIPT_DIR/backend"
 # ─── Launch ──────────────────────────────────────────────────────────────────
 # Loop: Python exits with code 42 to request a restart (e.g. after in-place update).
 # Any other exit code passes through normally.
+#
+# Signal forwarding: when run as PID 1 (e.g. under Docker), bash does not forward
+# SIGTERM to its children, so the graceful-shutdown handlers installed in
+# consumer.py would never fire and `docker stop` would SIGKILL after the grace
+# period. The trap below propagates SIGTERM to the active Python child so its
+# own handler can drain the WAL write-queue and stop workers cleanly.
+_CHILD_PID=""
+_forward_term() {
+  [[ -n "$_CHILD_PID" ]] && kill -TERM "$_CHILD_PID" 2>/dev/null || true
+}
+trap _forward_term TERM INT
+
 while true; do
   # set -e would kill the script on run.py's non-zero exit before we could
   # read it, defeating the restart loop. Capture via `||` (exempt from errexit).
   _EXIT=0
-  "$PYTHON" "$SCRIPT_DIR/backend/run.py" --port="$_PORT" --host="$_HOST" || _EXIT=$?
+  "$PYTHON" "$SCRIPT_DIR/backend/run.py" --port="$_PORT" --host="$_HOST" &
+  _CHILD_PID=$!
+  wait "$_CHILD_PID" || _EXIT=$?
+  _CHILD_PID=""
   if [[ "$_EXIT" -ne 42 ]]; then
     exit $_EXIT
   fi


### PR DESCRIPTION
## Summary

bash as PID 1 does not forward SIGTERM to its children, so the graceful-shutdown handlers installed in `backend/consumer.py` (`signal.SIGINT`/`signal.SIGTERM` at `consumer.py:108-109`) never fired on `docker stop`. The container was always SIGKilled after the grace period, making the graceful-shutdown path dead code and risking loss of in-flight uncommitted work.

`run.sh` launches `python run.py` as a child (it cannot use `exec` because the child is wrapped in a restart loop watching for exit code 42), so the signal never reached the Python process.

## Fix

Two-part, as recommended in #1895 (tini + signal-forwarding trap):

- **`run.sh`** — background the Python child, `wait` on it (preserving the exit-42 restart loop), and install a `TERM`/`INT` trap that forwards the signal to the active child PID. The Python child's own handler then drains the WAL write-queue and stops workers cleanly.
- **`Dockerfile`** — install `tini` and use it as PID 1 (`ENTRYPOINT ["tini", "--", "bash", ...]`); it reaps orphaned threads/zombies and forwards signals to the bash entrypoint. Add `STOPSIGNAL SIGTERM` for explicitness.

The restart loop still works: `wait` returns the child's exit status, and on 42 the loop re-syncs deps and relaunches exactly as before. Non-42 exit codes pass through unchanged.

## Why this is safe

Decisive writes already go through the sync WAL write-queue and SQLite WAL is crash-safe, so the previous hard-kill only lost in-flight uncommitted work (~10s wasted grace), not data integrity. This fix makes the existing graceful-shutdown code path actually reachable, eliminating that in-flight loss.

## Verification

- `bash -n run.sh` passes (syntax check).
- No behavioral change to the restart loop or exit-code semantics.
- No changes to `consumer.py` — the existing handlers now actually receive the signal.

Closes #1895


Part of #1883 audit, raised by @rygel
