### PR TITLE
Fix /chat/interrupt missing bearer token on paired clients

### DIFF
--- a/frontend/apps/interface/src/stores/session.ts
+++ b/frontend/apps/interface/src/stores/session.ts
@@ -6,13 +6,12 @@
  * Everything else goes through this store or the event bus.
  */
 import { defineStore } from 'pinia';
-import { getWebSocket, useConnectionStore, AuthError } from '@chalie/shared';
+import { getWebSocket, useConnectionStore, AuthError, api, HttpError } from '@chalie/shared';
 import type { WsInboundEvent, WsPushEvent, WsMessageEvent } from '@chalie/shared';
 import { on } from '../composables/useEventBus';
 import { extractText } from '../composables/useMarkup';
 import { conversation } from '../api/conversation';
 import { moments } from '../api/moments';
-import { getHost } from '../api/index';
 import { showToast } from '../utils/toast';
 import { useConversationStore } from './conversation';
 import type { AttachmentPreview } from './conversation';
@@ -382,19 +381,18 @@ export const useSessionStore = defineStore('session', {
       await this._postInterrupt();
     },
 
-    /** POST /chat/interrupt — best-effort, never throws. */
+    /** POST /chat/interrupt via the central ApiClient (carries the bearer). */
     async _postInterrupt(): Promise<void> {
       try {
-        const host = getHost();
-        const base = host ? host.replace(/\/$/, '') : '';
-        await fetch(base + '/chat/interrupt', {
-          method: 'POST',
-          credentials: 'same-origin',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({}),
-        });
-      } catch {
-        // Best-effort — swallow.
+        await api.post('/chat/interrupt', {});
+      } catch (err) {
+        if (err instanceof AuthError) {
+          this._onAuthFailure?.();
+          return;
+        }
+        const msg = err instanceof HttpError ? err.error ?? `HTTP ${err.status}` : 'Stop signal failed';
+        console.error('[Session] /chat/interrupt failed:', err);
+        showToast(msg);
       }
     },
 


### PR DESCRIPTION
## Summary

`_postInterrupt()` in `frontend/apps/interface/src/stores/session.ts` issued a raw `fetch('/chat/interrupt')` with only `credentials: 'same-origin'` and no `Authorization` header, bypassing the central ApiClient that attaches `Authorization: Bearer`. The route is `@require_auth` (cookie **or** bearer). On a cross-origin paired client (bearer-only, no cookie) the POST got 401 and the `catch {}` swallowed it, so the backend kept running the turn the user asked to stop.

## Fix

- Route the interrupt POST through the shared `ApiClient` singleton (`api` from `@chalie/shared`), which attaches the bearer header via `getToken()` and keeps the same-origin cookie path unchanged.
- Surface failures instead of swallowing: `AuthError` (401) triggers the registered auth-failure callback (consistent with `loadHistory`); other errors log + show a toast. The call stays non-throwing since the WS abort already happened client-side.
- Removed the now-unused `getHost` import.

## Why edge-case / dev-only today

The native/paired client surface is gated behind `CHALIE_INTERNAL_DEV`, which released images never set. The shipping same-origin web client authenticates via cookie, so this is dev-only today — but routing through ApiClient is the correct long-term path and costs nothing for the cookie path.

Closes #1896


Part of #1883 audit, raised by @rygel
