### PR TITLE
Fix scheduler embed re-entrancy breaking claim atomicity

### DIFF
--- a/backend/services/scheduler_service.py
+++ b/backend/services/scheduler_service.py
@@ -36,6 +36,12 @@ _SCHEDULED_SOURCE = "scheduled"
 # named ``scheduled-work-<item_id>``.
 _SCHEDULED_WORK_THREAD_PREFIX = "scheduled-work"
 
+# Daemon-thread name prefix for offloaded scheduled-item embedding. The poll
+# loop is mid-transaction claiming/marking items on its thread-local
+# connection; a nested ``db.connection()`` would commit mid-loop and break the
+# claim atomicity. Embedding runs on its own thread to get a fresh connection.
+_SCHEDULED_EMBED_THREAD_PREFIX = "scheduled-embed"
+
 # How a fired scheduled prompt's worked result is framed when it is handed to
 # the user-facing turn that actually surfaces (Stage 2). The placeholder is
 # filled with the work loop's synthesis.
@@ -200,7 +206,17 @@ def _poll_and_fire() -> None:
                             now_iso, item.get("group_id") or item["id"],
                             1 if item.get("is_prompt") else 0,
                         ))
-                        embed_scheduled_item(next_id, item["message"])
+                        # Offload embedding to a daemon thread: embed_scheduled_item
+                        # re-enters the shared thread-local connection and would
+                        # commit the in-progress 'fired' UPDATE mid-loop, breaking
+                        # claim atomicity. A separate thread gets its own
+                        # thread-local connection.
+                        threading.Thread(
+                            target=embed_scheduled_item,
+                            args=(next_id, item["message"]),
+                            daemon=True,
+                            name=f"{_SCHEDULED_EMBED_THREAD_PREFIX}-{next_id}",
+                        ).start()
 
                 except Exception as e:
                     logger.error(f"{LOG_PREFIX} Failed to fire {item['id']}: {e}")


### PR DESCRIPTION
## Summary

`embed_scheduled_item` was called synchronously inside `_poll_and_fire`'s
`with db.connection()` loop (`scheduler_service.py:203`). Because
`DatabaseService.connection()` is a thread-local context manager that
unconditionally commits on exit (`database_service.py:277`) with no nesting
guard, the nested `db.connection()` inside `embed_scheduled_item` flushed the
in-progress `fired` UPDATE / next-occurrence INSERT mid-loop — breaking
batch-claim atomicity on a mid-loop crash. This is the same hazard the team
already avoided for prompt items by offloading them to a daemon thread
(`:336-347`); the embedding path got no such treatment.

## Fix

Offload `embed_scheduled_item` to a daemon thread, mirroring the prompt-item
pattern. A separate thread gets its own thread-local DB connection, so the
poll loop's in-flight transaction is never committed prematurely.

The two other `embed_scheduled_item` call sites are unaffected and intentionally
left synchronous:
- `api/scheduler.py:283` — already runs on its own daemon thread (`:287`).
- `abilities/schedule.py:629` — runs after its `db.connection()` block has
  committed and exited, so there is no re-entrancy.

## Verification

- `ruff check services/scheduler_service.py` — passes
- `pytest -m unit -q` (full suite, 1400 tests) — passes
- `pytest tests/test_api_scheduler.py tests/test_ability_schedule.py -m unit` — 22 passed

Closes #1897


Part of #1883 audit, raised by @rygel
