### PR TITLE
fix(auth): purge prior sessions on login to invalidate stolen tokens

### DIFF
--- a/backend/api/user_auth.py
+++ b/backend/api/user_auth.py
@@ -215,7 +215,7 @@ def register() -> "ResponseReturnValue":
 
         # Create session and set cookie
         resp = make_response(jsonify({"ok": True, "vault_state": "unlocked"}), 201)
-        create_session(resp)
+        create_session(resp, username)
         return resp
     except Exception as e:
         logger.error(f"[REST API] Register error: {e}")
@@ -248,7 +248,7 @@ def login() -> "ResponseReturnValue":
     """
     try:
         from services.database_service import get_shared_db_service
-        from services.auth_session_service import create_session
+        from services.auth_session_service import create_session, purge_user_sessions
         from services.vault_service import (
             get_vault_service, OUTCOME_UNRECOVERABLE,
         )
@@ -277,6 +277,10 @@ def login() -> "ResponseReturnValue":
             if not row or not check_password_hash(row[0], password):
                 return jsonify({"error": "Invalid credentials"}), 401
 
+        # Invalidate every prior session for this user before minting a new one,
+        # so a stolen/old token cannot outlive the re-authentication.
+        purge_user_sessions(username)
+
         # The password is now verified against the account hash. Open the vault
         # with it, recovering from a filesystem backup if the live vault_config
         # row is missing or corrupt. If neither the row nor any backup
@@ -293,7 +297,7 @@ def login() -> "ResponseReturnValue":
                 jsonify({"ok": True, "vault_state": "locked"}),
                 200,
             )
-            create_session(resp)
+            create_session(resp, username)
             return resp
 
         if outcome == OUTCOME_UNRECOVERABLE:
@@ -319,7 +323,7 @@ def login() -> "ResponseReturnValue":
             jsonify({"ok": True, "vault_state": vault_state}),
             200,
         )
-        create_session(resp)
+        create_session(resp, username)
         return resp
     except Exception as e:
         logger.error(f"[REST API] Login error: {e}")

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -76,11 +76,13 @@ CREATE VIRTUAL TABLE IF NOT EXISTS episodes_fts USING fts5(
 -- ────────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS auth_sessions (
     token TEXT PRIMARY KEY,
+    username TEXT,
     created_at TEXT NOT NULL,
     expires_at TEXT NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_auth_sessions_expires ON auth_sessions(expires_at);
+CREATE INDEX IF NOT EXISTS idx_auth_sessions_username ON auth_sessions(username);
 
 -- ────────────────────────────────────────────────────────────────
 -- VAULT — envelope-encryption key store

--- a/backend/services/auth_session_service.py
+++ b/backend/services/auth_session_service.py
@@ -20,16 +20,15 @@ SESSION_TTL = 30 * 24 * 60 * 60  # 30 days in seconds
 SESSION_KEY_PREFIX = 'auth_session:'
 
 
-def _persist_session_to_sqlite(token: str) -> None:
+def _persist_session_to_sqlite(token: str, username: str | None) -> None:
     """Write session to SQLite so it survives MemoryStore wipes (restart)."""
     try:
         from services.database_service import get_shared_db_service
         db = get_shared_db_service()
-        utc_now().isoformat()
         db.execute(
-            """INSERT OR REPLACE INTO auth_sessions (token, created_at, expires_at)
-               VALUES (?, ?, datetime('now', '+30 days'))""",
-            (token, utc_now().isoformat())
+            """INSERT OR REPLACE INTO auth_sessions (token, username, created_at, expires_at)
+               VALUES (?, ?, ?, datetime('now', '+30 days'))""",
+            (token, username, utc_now().isoformat())
         )
     except Exception as e:
         logger.error(f"[Session] SQLite persist failed: {e}")
@@ -69,7 +68,7 @@ def _validate_session_in_sqlite(token: str) -> bool:
         return False
 
 
-def create_session(response: Response) -> str:
+def create_session(response: Response, username: str | None = None) -> str:
     """Generates a cryptographically secure random token, stores it in both
     MemoryStore (fast path) and SQLite (durable), and attaches the
     ``chalie_session`` HTTP-only cookie to the given response object."""
@@ -79,7 +78,7 @@ def create_session(response: Response) -> str:
     store = MemoryClientService.create_connection()
     store.setex(f"{SESSION_KEY_PREFIX}{token}", SESSION_TTL, "1")
 
-    _persist_session_to_sqlite(token)
+    _persist_session_to_sqlite(token, username)
 
     secure = os.environ.get('COOKIE_SECURE', 'false').lower() == 'true'
     response.set_cookie(
@@ -92,6 +91,40 @@ def create_session(response: Response) -> str:
     )
     logger.info("[Session] Created new session")
     return token
+
+
+def purge_user_sessions(username: str) -> None:
+    """Destroy every session belonging to ``username`` (both MemoryStore and
+    SQLite). Called on login so a freshly re-authenticated user evicts any
+    previously-issued token — e.g. one obtained by an attacker — instead of
+    letting it run out its full TTL."""
+    from services.memory_client import MemoryClientService
+
+    try:
+        from services.database_service import get_shared_db_service
+        db = get_shared_db_service()
+        rows = db.fetch_all(
+            "SELECT token FROM auth_sessions WHERE username = ?",
+            (username,)
+        )
+    except Exception as e:
+        logger.error("[Session] SQLite purge lookup failed: %s", e)
+        rows = []
+
+    if not rows:
+        return
+
+    store = MemoryClientService.create_connection()
+    tokens = [str(row["token"]) for row in rows]
+    for token in tokens:
+        store.delete(f"{SESSION_KEY_PREFIX}{token}")
+
+    try:
+        db.execute("DELETE FROM auth_sessions WHERE username = ?", (username,))
+    except Exception as e:
+        logger.error("[Session] SQLite purge delete failed: %s", e)
+
+    logger.info("[Session] Purged %d prior session(s) for user '%s'", len(rows), username)
 
 
 def validate_session(request: Request) -> bool:

--- a/backend/tests/test_login_session_invalidation.py
+++ b/backend/tests/test_login_session_invalidation.py
@@ -1,0 +1,143 @@
+"""Feature test: re-authentication on /auth/login invalidates prior sessions.
+
+Regression coverage for the security gap where a previously-issued session
+token (e.g. one obtained by an attacker) stayed valid for its full 30-day TTL
+after the legitimate user logged in again.  Login must now purge every prior
+session belonging to that user from both the MemoryStore hot cache and the
+durable SQLite store before minting the fresh token.
+
+Exercises the real production path end-to-end: the Flask test client hits the
+real ``/auth/login`` route, the real ``auth_session_service`` writes to the
+real SQLite ``auth_sessions`` table and the real in-process MemoryStore.  No
+mocks of the session service or login handler.
+"""
+
+import secrets
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+from typing import cast
+
+import pytest
+from flask import Flask, Response as FlaskResponse
+from flask.testing import FlaskClient
+from werkzeug.security import generate_password_hash
+
+import services.vault_service as _vault_mod
+from api.user_auth import user_auth_bp
+from services.auth_session_service import (
+    SESSION_COOKIE_NAME,
+    create_session,
+    validate_session,
+)
+from services.file_mapper_service import FileMapperService
+from services.vault_service import _vault_state
+
+
+def _seed_account(raw_conn: sqlite3.Connection, password: str = "testpassword123") -> str:
+    raw_conn.execute(
+        "INSERT INTO master_account (username, password_hash) VALUES (?, ?)",
+        ("admin", generate_password_hash(password)),
+    )
+    raw_conn.commit()
+    return password
+
+
+@pytest.fixture(autouse=True)
+def _reset_vault_singletons() -> Iterator[None]:
+    _vault_state.dek = None
+    _vault_mod._vault_service_instance = None
+    yield
+    _vault_state.dek = None
+    _vault_mod._vault_service_instance = None
+
+
+@pytest.fixture
+def secure_dir(tmp_path: Path) -> Path:
+    return tmp_path / "secure"
+
+
+@pytest.fixture
+def auth_client(
+    db: sqlite3.Connection, store: object, secure_dir: Path
+) -> Iterator[tuple[FlaskClient, sqlite3.Connection]]:
+    monkeypatch_target = FileMapperService
+    monkeypatch_target._SECURE_DIR = secure_dir
+    app = Flask(__name__)
+    app.secret_key = secrets.token_hex(32)
+    app.config["TESTING"] = True
+    app.register_blueprint(user_auth_bp)
+    with app.test_client() as client:
+        yield client, db
+
+
+@pytest.mark.unit
+class TestLoginInvalidatesPriorSession:
+
+    def test_prior_session_is_invalidated_after_relogin(
+        self,
+        auth_client: tuple[FlaskClient, sqlite3.Connection],
+        secure_dir: Path,
+    ) -> None:
+        client, raw_conn = auth_client
+        pw = _seed_account(raw_conn)
+
+        # Initialise the vault so the login's unlock_or_restore succeeds.
+        vault = _vault_mod.get_vault_service()
+        vault.initialize(pw)
+        _vault_state.dek = None
+        _vault_mod._vault_service_instance = None
+
+        # Mint a PRIOR session for the same user, as an attacker would have.
+        prior_resp = FlaskResponse()
+        prior_token = create_session(prior_resp, "admin")
+        assert prior_token, "prior session token must be minted"
+
+        # Sanity: the prior token validates before re-login.
+        from flask import Request
+        from io import BytesIO
+
+        def _request_with_cookie(token: str) -> Request:
+            environ = {
+                "REQUEST_METHOD": "GET",
+                "SERVER_NAME": "localhost",
+                "SERVER_PORT": "80",
+                "PATH_INFO": "/",
+                "wsgi.input": BytesIO(b""),
+                "HTTP_COOKIE": f"{SESSION_COOKIE_NAME}={token}",
+            }
+            return Request(environ)
+
+        assert validate_session(_request_with_cookie(prior_token)) is True, (
+            "prior token must be valid before re-login"
+        )
+
+        # Re-authenticate — the real login route purges prior sessions.
+        resp = client.post(
+            "/auth/login",
+            json={"username": "admin", "password": pw},
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["ok"] is True
+
+        # The prior token must no longer validate — purged from both stores.
+        assert validate_session(_request_with_cookie(prior_token)) is False, (
+            "a prior session token must be invalidated after the user re-logs in"
+        )
+
+        # And it must be gone from the durable SQLite store too.
+        rows = raw_conn.execute(
+            "SELECT COUNT(*) FROM auth_sessions WHERE token = ?",
+            (prior_token,),
+        ).fetchone()
+        assert cast(tuple[int, ...], rows)[0] == 0, (
+            "prior session row must be deleted from auth_sessions"
+        )
+
+        # The fresh token issued by this login must still be valid.
+        fresh_cookie = resp.headers.get("Set-Cookie", "")
+        assert SESSION_COOKIE_NAME in fresh_cookie, "login must issue a fresh cookie"
+        assert prior_token not in fresh_cookie, (
+            "login must mint a new token, not reuse the prior one"
+        )


### PR DESCRIPTION
## Summary

On successful login, `create_session` minted a fresh random token without deleting any prior session. A previously-issued (e.g. attacker-obtained) token stayed valid for its full 30-day TTL, and each re-validation slid that TTL — so re-authenticating could not evict a stolen token. There was no per-user session scope (`auth_sessions` had no user column), only per-token deletion.

## Fix

- Add a `username` column + index to `auth_sessions` (schema.sql; convergence adds the column to existing DBs).
- `create_session(response, username)` now records the owning user on the durable row.
- New `purge_user_sessions(username)` destroys every session belonging to that user from both the MemoryStore hot cache and the SQLite durable store.
- `/auth/login` calls `purge_user_sessions(username)` after the password check passes and before minting the new token, so a fresh re-authentication evicts all previously-issued tokens for that user. `/auth/register` also records the username on its session.

Single-master-account self-hosted model makes the "re-auth to evict a stolen token" concern a narrow edge-case, but the gap was factually correct and is now closed.

## Test coverage

New feature test `backend/tests/test_login_session_invalidation.py` exercises the real `/auth/login` route end-to-end (real Flask test client, real auth_session_service, real SQLite + MemoryStore — zero mocks of the session/login path): it mints a prior session for the user, re-logs in, and asserts the prior token no longer validates (MemoryStore miss + SQLite row gone) while the fresh token is issued.

Closes #1899


Part of #1883 audit, raised by @rygel
