### PR TITLE
fix(ws): carry the bearer token in the first WS frame, not the URL

### DIFF
--- a/backend/api/websocket.py
+++ b/backend/api/websocket.py
@@ -31,34 +31,26 @@ def _drain_capability_alerts(store: MemoryStore) -> None:
         logger.debug("[WS] Failed to scan capability alerts: %s", exc)
 
 
-def _authenticate_ws(flask_request: object) -> bool:
-    """Authenticate a ``/ws`` handshake.
-
-    Cookie session first (the browser path, unchanged). If that fails, fall back
-    to the bearer token supplied as the ``?token=`` query arg — the mobile app
-    cannot send a cookie over a WebSocket, so it passes the raw wrapper token in
-    the URL. ``validate_bearer`` expects an ``Authorization: Bearer`` header, so
-    the query token is wrapped into that header form before reuse. A missing or
-    invalid token yields no wrapper id => caller closes the handshake unchanged.
-    """
+def _validate_cookie_session(flask_request: object) -> bool:
+    """The browser path: a signed session cookie rides the HTTP upgrade."""
     from flask import Request
     from services.auth_session_service import validate_session
-    from services.feature_flags import internal_dev_enabled
 
-    if validate_session(cast("Request", flask_request)):
-        return True
+    return validate_session(cast(Request, flask_request))
 
-    # Bearer-over-WS (the ``?token=`` arg) is a native-client-only path; with
-    # in-development features disabled the handshake stays cookie-only.
-    if not internal_dev_enabled():
-        return False
 
-    token = cast("Request", flask_request).args.get("token", "")
-    if not token:
-        return False
-
+def _validate_bearer_frame(token: str) -> bool:
+    """The native-client path: a raw wrapper token arrives as the first WS
+    frame (``{"type":"auth","token":...}``) instead of in the URL, so it never
+    leaks into reverse-proxy/access logs or ``Referer``. ``validate_bearer``
+    expects an ``Authorization: Bearer`` header, so the frame token is wrapped
+    into that header form before reuse."""
+    from flask import Request
     from services.wrapper_auth_service import WrapperAuthService
     from services.database_service import get_shared_db_service
+
+    if not token:
+        return False
 
     bearer_request = cast(Request, Request.from_values(
         headers={"Authorization": "Bearer " + token}
@@ -72,19 +64,25 @@ def _authenticate_ws(flask_request: object) -> bool:
 
 def _ws_handler(ws: object) -> None:
     from flask import request as flask_request
+    from services.feature_flags import internal_dev_enabled
 
     broker = WebSocketBroker()
+    ws_typed = cast(_WS, ws)
 
-    if not _authenticate_ws(flask_request):
-        try:
-            cast(_WS, ws).send(json.dumps({"type": "error", "message": "Unauthorized"}))
-        except Exception:
-            pass
-        try:
-            cast(_WS, ws).close()
-        except Exception as exc:
-            logger.debug("[WS] Close after auth failure failed: %s", exc)
-        return
+    # Cookie session first (the browser path) — checked at handshake time, as
+    # before. A native client has no cookie, so it authenticates with the first
+    # WS frame instead of a query-string token (see ``_handshake_bearer``).
+    if not _validate_cookie_session(flask_request):
+        if not internal_dev_enabled() or not _handshake_bearer(ws_typed):
+            try:
+                ws_typed.send(json.dumps({"type": "error", "message": "Unauthorized"}))
+            except Exception:
+                pass
+            try:
+                ws_typed.close()
+            except Exception as exc:
+                logger.debug("[WS] Close after auth failure failed: %s", exc)
+            return
 
     connection_id = str(uuid.uuid4())
     set_correlation_id(connection_id)
@@ -96,7 +94,6 @@ def _ws_handler(ws: object) -> None:
     store = MemoryClientService.create_connection()
     _drain_capability_alerts(store)
 
-    ws_typed = cast(_WS, ws)
     try:
         while True:
             raw = ws_typed.receive(timeout=60)
@@ -108,6 +105,30 @@ def _ws_handler(ws: object) -> None:
         logger.debug("[WS] Connection closed: %s", exc)
     finally:
         broker.disconnect(cast(_WebSocket, ws))
+
+
+def _handshake_bearer(ws: _WS) -> bool:
+    """Native-client auth: wait for the first WS frame, expect
+    ``{"type":"auth","token":"<raw>"}``, validate the bearer, and close the
+    handshake on any other outcome. The token travels in a frame, never in the
+    URL, so it cannot leak into reverse-proxy/access logs or ``Referer``."""
+    try:
+        raw = ws.receive(timeout=10)
+    except Exception as exc:
+        logger.debug("[WS] Auth frame receive failed: %s", exc)
+        return False
+    if raw is None:
+        return False
+    try:
+        payload = json.loads(raw)
+    except (ValueError, TypeError):
+        return False
+    if not isinstance(payload, dict) or payload.get("type") != "auth":
+        return False
+    token = payload.get("token")
+    if not isinstance(token, str):
+        return False
+    return _validate_bearer_frame(token)
 
 
 def register_websocket(sock: "Sock") -> None:

--- a/backend/tests/test_websocket_bearer_handshake.py
+++ b/backend/tests/test_websocket_bearer_handshake.py
@@ -10,14 +10,17 @@
 token across both surfaces it talks to:
 
   * the WebSocket handshake, where a mobile socket cannot carry a cookie, so it
-    passes the raw token as the ``?token=`` query parameter on ``/ws``; and
+    presents the raw token as the FIRST WS frame
+    (``{"type":"auth","token":...}``) on ``/ws`` — never in the URL, so the
+    credential cannot leak into reverse-proxy/access logs, ``Referer``, or
+    history; and
   * ordinary HTTP requests, where the same token rides ``Authorization: Bearer``.
 
 These exercise the REAL production path with zero mocks:
   * the real ``WrapperAuthService.create_token`` mints the token (the exact call
     ``POST /api/wrappers`` makes), persisted in the real ``db`` SQLite fixture;
   * the real ``validate_session`` runs first and genuinely fails (no cookie),
-    so the bearer fallback is genuinely exercised;
+    so the bearer-first-frame fallback is genuinely exercised;
   * a real consumer object at the WS boundary fulfils the same
     ``send(raw)`` / ``close()`` / ``receive()`` contract the browser socket
     fulfils — the same pattern as test_websocket_broadcast_fanout.py;
@@ -25,9 +28,9 @@ These exercise the REAL production path with zero mocks:
     proves the token authenticates an HTTP request too.
 
 Against the pre-fix handler (cookie-only ``validate_session`` at
-websocket.py:40, no ``?token=`` fallback) the bearer-only handshake is closed
-``Unauthorized`` — ``test_ws_handshake_accepts_bearer_token_query_param`` fails
-RED. It passes GREEN once the fallback lands.
+websocket.py:40, no bearer fallback) the bearer-only handshake is closed
+``Unauthorized`` — ``test_ws_handshake_accepts_bearer_token_first_frame`` fails
+RED. It passes GREEN once the first-frame fallback lands.
 """
 
 import json
@@ -52,14 +55,15 @@ def _enable_internal_dev(monkeypatch: pytest.MonkeyPatch) -> None:
 class _BoundarySocket:
     """A real consumer at the WS boundary — the same ``send`` / ``close`` /
     ``receive`` contract the production browser socket fulfils. Records sent
-    frames and whether it was closed. ``receive`` returns ``None`` once (so the
-    handler's loop emits a single ping) then raises to end the loop, mirroring a
-    browser socket that drops the connection."""
+    frames and whether it was closed. ``receive`` yields a programmable sequence
+    of inbound frames (the auth frame first, then ``None`` for one broker ping)
+    then raises to end the loop, mirroring a browser socket that drops the
+    connection."""
 
-    def __init__(self) -> None:
+    def __init__(self, inbound: list[str | None] | None = None) -> None:
         self.sent: list[str] = []
         self.closed = False
-        self._receives = 0
+        self._receives = list(inbound or [])
 
     def send(self, raw: str) -> None:
         self.sent.append(raw)
@@ -67,11 +71,10 @@ class _BoundarySocket:
     def close(self) -> None:
         self.closed = True
 
-    def receive(self, timeout: int = 60) -> None:
-        self._receives += 1
-        if self._receives == 1:
-            return None  # triggers one broker ping, then we end the loop
-        raise RuntimeError("socket closed")
+    def receive(self, timeout: int = 60) -> str | None:
+        if not self._receives:
+            raise RuntimeError("socket closed")
+        return self._receives.pop(0)
 
     def sent_types(self) -> list[str]:
         return [cast(str, json.loads(m).get("type")) for m in self.sent]
@@ -100,14 +103,18 @@ def _mint_token(name: str) -> str:
     return raw_token
 
 
-def test_ws_handshake_accepts_bearer_token_query_param(
+def _auth_frame(raw: str) -> str:
+    return json.dumps({"type": "auth", "token": raw})
+
+
+def test_ws_handshake_accepts_bearer_token_first_frame(
     db: sqlite3.Connection, broker: WebSocketBroker
 ) -> None:
-    """A handshake carrying a valid raw token as ``/ws?token=<raw>`` (no cookie,
-    as a mobile socket has) must authenticate: the handler must NOT send the
-    ``Unauthorized`` error frame and must NOT close the socket, and the
-    connection must be registered with the broker. Pre-fix the cookie-only check
-    closes it — RED here."""
+    """A handshake with NO cookie (as a mobile socket has) that presents a valid
+    raw token as its first WS frame must authenticate: the handler must NOT send
+    the ``Unauthorized`` error frame and must NOT close the socket, and the
+    connection must be registered with the broker. The URL carries no token.
+    Pre-fix the cookie-only check closes it — RED here."""
     from api import create_app
     from api.websocket import _ws_handler
 
@@ -115,22 +122,23 @@ def test_ws_handshake_accepts_bearer_token_query_param(
 
     app = create_app()
     app.config["TESTING"] = True
-    socket = _BoundarySocket()
+    # Auth frame first, then None (one broker ping), then the loop ends.
+    socket = _BoundarySocket([_auth_frame(raw), None])
 
-    with app.test_request_context("/ws?token=" + raw):
+    with app.test_request_context("/ws"):
         _ws_handler(socket)
 
     assert not socket.closed, (
-        "the handshake carried a valid bearer token via ?token= but the socket "
-        "was closed — the bearer fallback did not run"
+        "the handshake carried a valid bearer token in its first frame but the "
+        "socket was closed — the bearer fallback did not run"
     )
     assert "error" not in socket.sent_types(), (
-        "an Unauthorized error frame was sent despite a valid ?token=; the only "
-        f"frame on a healthy handshake is the broker ping. Got: {socket.sent_types()}"
+        "an Unauthorized error frame was sent despite a valid first-frame token; "
+        f"the only frame on a healthy handshake is the broker ping. Got: {socket.sent_types()}"
     )
     # The broker's connect() + broadcast({"type": "ping"}) runs inside the
     # handler's loop; the finally block disconnects cleanly on loop exit (the
-    # _BoundarySocket.receive() raises on the 2nd call to end the loop).  So
+    # _BoundarySocket.receive() raises once the inbound queue drains).  So
     # after the handler returns the socket is no longer in _connections — correct
     # production behaviour.  We prove it WAS registered by the fact the ping
     # frame was delivered to it (the broker only fans out to registered sockets).
@@ -143,21 +151,32 @@ def test_ws_handshake_accepts_bearer_token_query_param(
 def test_ws_handshake_rejects_missing_and_invalid_token(
     db: sqlite3.Connection, broker: WebSocketBroker
 ) -> None:
-    """One common path / self-no-op: no cookie AND no usable token => the
-    existing Unauthorized close fires unchanged. Covers a token-less handshake
-    and a garbage ``?token=`` — neither must authenticate."""
+    """No cookie AND no usable first frame => the existing Unauthorized close
+    fires unchanged. Covers a token-less handshake (no auth frame at all), a
+    garbage token, a non-auth frame, and a malformed frame — none must
+    authenticate, and no token may appear in the URL."""
     from api import create_app
     from api.websocket import _ws_handler
 
     app = create_app()
     app.config["TESTING"] = True
 
-    for url in ("/ws", "/ws?token=not-a-real-token"):
-        socket = _BoundarySocket()
+    cases: list[tuple[str, _BoundarySocket]] = [
+        # No auth frame — receive() returns nothing usable; the handler's
+        # _handshake_bearer times out/raises and closes.
+        ("/ws", _BoundarySocket([])),
+        # Garbage token in a well-formed auth frame.
+        ("/ws", _BoundarySocket([_auth_frame("not-a-real-token")])),
+        # A non-auth first frame (e.g. a stray pong) must not authenticate.
+        ("/ws", _BoundarySocket([json.dumps({"type": "pong"})])),
+        # A malformed first frame.
+        ("/ws", _BoundarySocket(["not-json"])),
+    ]
+    for url, socket in cases:
         with app.test_request_context(url):
             _ws_handler(socket)
         assert socket.closed, (
-            f"handshake {url!r} carried no valid auth and must be closed"
+            f"handshake {url!r} carried no valid auth frame and must be closed"
         )
         assert "error" in socket.sent_types(), (
             f"handshake {url!r} must receive the Unauthorized error frame; got "
@@ -167,6 +186,31 @@ def test_ws_handshake_rejects_missing_and_invalid_token(
             f"an unauthenticated handshake {url!r} must NOT be registered with "
             f"the broker — no ping may be delivered. Got: {socket.sent_types()}"
         )
+
+
+def test_ws_handshake_url_carries_no_token(
+    db: sqlite3.Connection, broker: WebSocketBroker
+) -> None:
+    """The bearer token must NEVER appear in the request URL — that is the
+    regression this suite guards. A valid first-frame handshake authenticates
+    while the request path stays a bare ``/ws`` with no query string."""
+    from api import create_app
+    from api.websocket import _ws_handler
+    from flask import request as flask_request
+
+    raw = _mint_token("Mobile — url hygiene")
+
+    app = create_app()
+    app.config["TESTING"] = True
+    socket = _BoundarySocket([_auth_frame(raw), None])
+
+    with app.test_request_context("/ws"):
+        _ws_handler(socket)
+        assert "token" not in flask_request.args, (
+            "the bearer token must not travel in the URL query string — it "
+            f"leaks into logs/Referer. Saw ?{flask_request.query_string.decode()}"
+        )
+    assert not socket.closed
 
 
 def test_same_minted_token_authenticates_http_bearer_request(

--- a/frontend/apps/interface/tests/bearer-attach.spec.ts
+++ b/frontend/apps/interface/tests/bearer-attach.spec.ts
@@ -2,8 +2,13 @@ import { test, expect } from '@playwright/test';
 
 // Real-hot-path feature test for the shared bearer-attach. Drives the
 // genuine ApiClient / WebSocketService singletons against the live backend and
-// observes the ACTUAL outbound HTTP headers + the ACTUAL /ws handshake URL.
-// Zero mocks: localStorage is the real token store, the clients are the real ones.
+// observes the ACTUAL outbound HTTP headers + the ACTUAL /ws handshake. Zero
+// mocks: localStorage is the real token store, the clients are the real ones.
+//
+// Security invariant: the bearer token must NEVER travel in the /ws URL — a
+// query-string credential leaks into reverse-proxy/access logs, Referer, and
+// history. The native client sends it as the FIRST WS frame
+// ({"type":"auth","token":...}) instead.
 
 const TEST_TOKEN = 'feature-test-bearer-token-xyz';
 
@@ -14,7 +19,7 @@ test.beforeEach(async ({ page }) => {
   await page.evaluate(() => localStorage.removeItem('chalie_access_token'));
 });
 
-test('no token => web path unchanged: no Authorization header, no ?token on /ws', async ({
+test('no token => web path unchanged: no Authorization header, no token on /ws', async ({
   page,
 }) => {
   // 1) HTTP: drive the REAL ApiClient singleton and capture the outbound headers.
@@ -26,7 +31,8 @@ test('no token => web path unchanged: no Authorization header, no ?token on /ws'
   const req = await reqHeadersPromise;
   expect(req.headers()['authorization']).toBeUndefined();
 
-  // 2) WS: the live socket opened on load (or reconnect) carries no token param.
+  // 2) WS: the live socket opened on load (or reconnect) carries no token — not
+  // in the URL, and no auth frame is sent on the cookie path.
   const wsPromise = page.waitForEvent('websocket');
   await page.evaluate(async () => {
     const mod = await import('/src/index.ts');
@@ -39,7 +45,9 @@ test('no token => web path unchanged: no Authorization header, no ?token on /ws'
   expect(ws.url()).not.toContain('token=');
 });
 
-test('token present => Authorization: Bearer on HTTP and ?token on /ws', async ({ page }) => {
+test('token present => Authorization: Bearer on HTTP and auth frame on /ws (never in the URL)', async ({
+  page,
+}) => {
   // Write the token through the REAL accessor, then drive the REAL singletons.
   await page.evaluate(async (t) => {
     const mod = await import('/src/index.ts');
@@ -55,7 +63,8 @@ test('token present => Authorization: Bearer on HTTP and ?token on /ws', async (
   const req = await reqHeadersPromise;
   expect(req.headers()['authorization']).toBe(`Bearer ${TEST_TOKEN}`);
 
-  // 2) WS: a reconnect re-reads the token and appends ?token=<raw>.
+  // 2) WS: a reconnect opens a bare /ws (NO token in the URL) and sends the
+  // token as the first WS frame. Capture the first sent frame.
   const wsPromise = page.waitForEvent('websocket');
   await page.evaluate(async () => {
     const mod = await import('/src/index.ts');
@@ -65,7 +74,14 @@ test('token present => Authorization: Bearer on HTTP and ?token on /ws', async (
   });
   const ws = await wsPromise;
   expect(ws.url()).toContain('/ws');
-  expect(ws.url()).toContain(`token=${TEST_TOKEN}`);
+  expect(ws.url()).not.toContain('token=');
+  // The first client→server frame must be the auth handshake carrying the token.
+  const frame = await ws.waitForEvent('framesent', { timeout: 5_000 });
+  const payload =
+    typeof frame.data === 'string' ? frame.data : frame.data?.toString() ?? '';
+  const parsed = JSON.parse(payload) as { type?: string; token?: string };
+  expect(parsed.type).toBe('auth');
+  expect(parsed.token).toBe(TEST_TOKEN);
 
   // Cleanup so a later spec/run starts unpaired.
   await page.evaluate(async () => {

--- a/frontend/packages/shared/src/services/WebSocketService.ts
+++ b/frontend/packages/shared/src/services/WebSocketService.ts
@@ -147,9 +147,10 @@ export class WebSocketService {
     return host ? host.replace(/\/$/, '') : globalThis.location.origin;
   }
   private buildWsUrl(): string {
-    const token = this.getToken();
-    const query = token ? '?token=' + encodeURIComponent(token) : '';
-    return this.baseUrl().replace(/^http/, 'ws') + '/ws' + query;
+    // The bearer token is NOT carried in the URL — a query-string credential
+    // leaks into reverse-proxy/access logs, Referer, and history. The native
+    // client sends it as the first WS frame instead (see ``connect``).
+    return this.baseUrl().replace(/^http/, 'ws') + '/ws';
   }
   private buildHttpUrl(path: string): string {
     return this.baseUrl() + path;
@@ -197,6 +198,16 @@ export class WebSocketService {
       this.reconnectDelay = 1000;
       this.lastInboundAt = Date.now();
       this.startLivenessWatch();
+      // Native clients have no cookie, so they present the bearer token as the
+      // first WS frame — never in the URL. The web (cookie) path sends none.
+      const token = this.getToken();
+      if (token) {
+        try {
+          ws.send(JSON.stringify({ type: 'auth', token }));
+        } catch {
+          /* frame send failure surfaces as onclose → reconnect */
+        }
+      }
       try {
         this.connectHandler?.();
       } catch {


### PR DESCRIPTION
Closes #1901
Part of #1883 audit, raised by @rygel

## Problem

The native-client `/ws` handshake read the bearer token from the `?token=` query string (`backend/api/websocket.py:56`). Long-lived credentials in a URL leak into reverse-proxy/access logs, `Referer`, and browser history.

This path was dev-gated (`internal_dev_enabled()` — `CHALIE_INTERNAL_DEV == '1'`, which released images never set), so production was not exposed, but dev builds still carried the token in the URL.

## Fix

Move the bearer token out of the URL and into the **first WebSocket message** (`{"type":"auth","token":...}`), sent immediately on `onopen`.

- **Backend** (`backend/api/websocket.py`): the cookie session is still checked at handshake time (browser path, unchanged). When there is no cookie and the internal-dev gate is open, the handler waits for the first WS frame (10s timeout), expects `{"type":"auth","token":...}`, validates the bearer via the real `WrapperAuthService.validate_bearer`, and only then registers the connection with the broker. Any other first frame (missing, malformed, non-`auth`, garbage token) yields the existing `Unauthorized` error frame + close — unchanged behaviour for the reject path.
- **Frontend** (`WebSocketService`): `buildWsUrl` no longer appends `?token=`; the URL is a bare `/ws`. On `onopen`, if a token is configured (native client), the service sends the `auth` frame as the first client→server message. The web (cookie) path sends no auth frame.

The `/ws` URL now carries no secret, so it cannot leak into logs, `Referer`, or history — even in dev builds.

## Tests

- `backend/tests/test_websocket_bearer_handshake.py` — rewritten to the first-frame flow: a valid token in the first frame authenticates (broker ping delivered, no error/close); missing/garbage/non-auth/malformed first frames are rejected; a new case asserts the request URL carries no `token` query arg (the regression guard for this issue). The same-minted-token HTTP bearer test is unchanged.
- `frontend/apps/interface/tests/bearer-attach.spec.ts` — updated to assert the `/ws` URL carries no `token=` and the first sent frame is the `auth` handshake (Playwright, requires a live backend).

All 1401 backend unit tests pass (incl. the strict mypy gate).