### PR TITLE
fix(notifications): cap background notifications array (FIFO eviction)

### DIFF
--- a/frontend/apps/interface/src/stores/notifications.ts
+++ b/frontend/apps/interface/src/stores/notifications.ts
@@ -22,6 +22,7 @@ const CHIME_GAIN_END = 0.01;
 const NOTIFY_TITLE = 'Chalie';
 const NOTIFY_BODY_MAX = 200;
 const NOTIFY_TAG = 'chalie-message';
+const MAX_NOTIFICATIONS = 50;
 
 const LS_UPDATE_DISMISSED = 'chalie_update_dismissed';
 
@@ -124,6 +125,9 @@ export const useNotificationsStore = defineStore('notifications', {
       showOsNotification(text);
       playChime();
       this.notifications.push({ id: String(Date.now()), text });
+      if (this.notifications.length > MAX_NOTIFICATIONS) {
+        this.notifications.splice(0, this.notifications.length - MAX_NOTIFICATIONS);
+      }
     },
 
     /**


### PR DESCRIPTION
Closes #1902

Part of #1883 audit, raised by @rygel

---

## Summary

`pushBackground()` in `frontend/apps/interface/src/stores/notifications.ts` appended to `this.notifications` with no cap or trim. A static search confirms nothing reads, renders, slices, or clears the array anywhere in `apps/interface/src/` — only the chime + OS notification fire; the array entry is never consumed.

The leak only fires on blurred-tab messages with OS notification permission granted, and entries are tiny `{id, text}` reset on reload, so it is a slow latent leak with no functional symptom (per the issue's severity assessment: Medium / rare edge-case).

## Fix

Cap the array at `MAX_NOTIFICATIONS = 50` and FIFO-evict the oldest entries once the limit is exceeded. The array still serves no current consumer, so eviction is the correct behaviour — there is nothing to display that the trim would lose.

## Classification

Minor localized bugfix (no new cross-step behaviour); no new automated test added beyond existing coverage. Coding standards + CI gates apply.

## Verification

- `pnpm run lint` — clean (only pre-existing `v-html` warnings unrelated to this change).
- `pnpm run typecheck` — clean across `packages/shared`, `apps/interface`, `apps/brain`.

## Files changed

- `frontend/apps/interface/src/stores/notifications.ts` (+4)
