### PR TITLE
fix(db): close worker threads' SQLite connections on exit

### DIFF
--- a/backend/consumer.py
+++ b/backend/consumer.py
@@ -65,6 +65,16 @@ class WorkerManager:
                 worker_func()
             except Exception:
                 logging.exception(f"[Manager] Service {worker_id} crashed")
+            finally:
+                # Close this thread's SQLite connection so dead workers don't
+                # leak thread-local handles (issue #1903). SQLite objects may
+                # only be touched by their owning thread, which is still live
+                # here; closing now avoids a ResourceWarning / stale WAL handle.
+                try:
+                    from services.database_service import close_thread_connection
+                    close_thread_connection()
+                except Exception:
+                    pass
 
         t = threading.Thread(target=_run, daemon=True, name=worker_id)
         t.start()

--- a/backend/services/database_service.py
+++ b/backend/services/database_service.py
@@ -57,6 +57,29 @@ def get_shared_db_service() -> 'DatabaseService':
     return _shared_db_service
 
 
+def close_thread_connection() -> None:
+    """Close the *calling* thread's SQLite connection and clear its thread-local state.
+
+    Counterpart to :meth:`DatabaseService._get_connection` for worker teardown:
+    a thread that opened a connection (via ``get_shared_db_service()``) must
+    close it before exiting, otherwise the connection is abandoned for the GC
+    to reclaim — emitting a ``ResourceWarning`` and holding a transient WAL
+    handle (issue #1903). SQLite objects may only be touched by their owning
+    thread, so this must run *while the thread is still live*, e.g. in a
+    worker wrapper's ``finally`` block.
+
+    Safe to call from a thread that never opened a connection: it is a no-op.
+    """
+    conn = getattr(_local, 'conn', None)
+    if conn is not None:
+        try:
+            conn.close()
+        except Exception:
+            pass
+        _local.conn = None
+        _local.db_path = None
+
+
 class SessionProxy:
     """Lightweight shim that mimics SQLAlchemy session.execute(text("SQL"), params).
 
@@ -343,18 +366,9 @@ class DatabaseService:
     def close_pool(self) -> None:
         """Close the calling thread's SQLite connection and clear thread-local state.
 
-        Silently ignores errors from ``sqlite3.Connection.close()`` so that
-        worker teardown paths remain exception-safe.  After this call
-        ``_local.conn`` and ``_local.db_path`` are both reset to ``None``,
-        ensuring the next call to :meth:`_get_connection` opens a new
-        connection.
+        Thin wrapper around :func:`close_thread_connection` kept for the
+        instance-style API; see that function for behaviour and the rationale
+        for calling it from worker teardown paths.
         """
-        conn = getattr(_local, 'conn', None)
-        if conn:
-            try:
-                conn.close()
-            except Exception:
-                pass
-            _local.conn = None
-            _local.db_path = None
+        close_thread_connection()
 


### PR DESCRIPTION
Closes #1903

Part of #1883 audit, raised by @rygel

## Problem

Dead worker threads abandoned their thread-local SQLite connections (`backend/services/database_service.py:224-254`, `backend/consumer.py:88-91`). Connections stored in the module-level `threading.local()` were only closed inside `_get_connection` on the *same live* thread. `WorkerManager.check_health` respawned dead workers without closing the dead thread's connection — leaving it for GC (`ResourceWarning`, transient WAL handle).

## Why this is an edge case

Triggers only when a worker dies on an unhandled exception (rare for long-lived loops); GC eventually reclaims the connection and SQLite's WAL tolerates stale handles — hygiene, not correctness.

## Constraint

SQLite objects may only be touched by their owning thread (`sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread`). The manager thread **cannot** close a dead worker's connection — the dead thread's `threading.local()` slot is invisible to other threads, and cross-thread `close()` is forbidden by SQLite. So the only correct place to close the connection is on the owning thread, while it is still alive.

## Fix

Close the calling thread's connection **preventively**, in the worker wrapper's `finally` block — while the worker thread is still live (whether it exited cleanly or crashed on an unhandled exception).

- `backend/services/database_service.py`: extract the close-and-clear logic from `DatabaseService.close_pool` into a module-level `close_thread_connection()` that operates purely on the thread-local `_local` (no singleton instantiation). `close_pool` now delegates to it. Safe to call from a thread that never opened a connection (no-op).
- `backend/consumer.py`: `WorkerManager.spawn_service`'s `_run` wrapper gains a `finally` that calls `close_thread_connection()`. Since `run.py` registers all workers through this same `WorkerManager.spawn_service`, every supervised worker is covered.

By the time `check_health` detects a dead thread and respawns it, the dead thread's connection is already closed (in its own `finally`), so there is nothing left to leak.

## Verification

- `ruff check` clean on both edited files.
- `mypy --strict`: no new errors (only pre-existing third-party `import-untyped` noise).
- `cd backend && pytest -m unit -q` — **1400 passed, 134 deselected**.
- Behavioural check: a worker thread that opens a connection and then raises is confirmed (via post-close `conn.execute("SELECT 1")` → `ProgrammingError: Cannot operate on a closed database`) to have its connection closed by the `finally` on its own thread, with no cross-thread SQLite violation.