### PR TITLE
fix(session): invoke _busUnbinds on teardown, track focus listener, drop duplicate registration

### DIFF
--- a/frontend/apps/interface/src/App.vue
+++ b/frontend/apps/interface/src/App.vue
@@ -67,6 +67,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   _unbindRecall?.();
+  session.teardown();
   useHeartbeat().stop();
   useAmbientSensor().destroy();
 });

--- a/frontend/apps/interface/src/stores/session.ts
+++ b/frontend/apps/interface/src/stores/session.ts
@@ -96,8 +96,10 @@ export const useSessionStore = defineStore('session', {
         }
       });
 
-      // Tab-refocus liveness check.
-      globalThis.addEventListener('focus', () => ws.ensureAlive());
+      // Tab-refocus liveness check. Tracked for teardown (HMR / StrictMode).
+      const onFocus = () => ws.ensureAlive();
+      globalThis.addEventListener('focus', onFocus);
+      _busUnbinds.push(() => globalThis.removeEventListener('focus', onFocus));
 
       // chalie:action — deterministic skill invocations. Registered inside init()
       // so the WS single-owner rule holds (only one listener ever bound).
@@ -156,6 +158,12 @@ export const useSessionStore = defineStore('session', {
       );
 
       ws.connect();
+    },
+
+    /** Tear down everything init() bound (HMR / StrictMode). Idempotent. */
+    teardown(): void {
+      _busUnbinds.splice(0).forEach((unbind) => unbind());
+      _initialized = false;
     },
 
     /** Register an auth-failure callback (called by App bootstrap). */

--- a/frontend/packages/shared/src/composables/useWebSocket.ts
+++ b/frontend/packages/shared/src/composables/useWebSocket.ts
@@ -5,7 +5,6 @@ import { getHost, getToken } from '../config/host';
 import { useConnectionStore } from '../stores/connection';
 
 let service: WebSocketService | null = null;
-let focusBound = false;
 
 /** Process-wide singleton so every view shares one socket. */
 export function getWebSocket(): WebSocketService {
@@ -24,10 +23,6 @@ export function useWebSocket() {
     ws.onConnect(() => conn.setConnected(ws.isConnected));
     ws.connect();
     conn.setConnected(ws.isConnected);
-    if (!focusBound) {
-      focusBound = true;
-      globalThis.addEventListener('focus', () => ws.ensureAlive());
-    }
   });
 
   return { ws, connected };


### PR DESCRIPTION
Closes #1904

Part of #1883 audit, raised by @rygel

## Summary

Per #1904 — three small fixes in the session/WS layer:

- **`_busUnbinds` was push-only** (never invoked) → added `teardown()` that drains the array via `splice(0).forEach` and resets `_initialized`, and wired it into `App.vue` `onBeforeUnmount`. This makes `init()`/`teardown()` a balanced pair so HMR (and Vue StrictMode remounts) no longer leak bus listeners.
- **Focus listener was anonymous and untracked** → named it `onFocus`, registered its `removeEventListener` in `_busUnbinds` so `teardown()` cleans it up.
- **Duplicate focus→`ensureAlive` binding** in `useWebSocket.ts` (guarded by a module-level `focusBound`) → dropped entirely. `session.init()` already owns the focus-liveness contract (single-owner rule per the store's header comment), so the second registration was a redundant idempotent no-op. Removed the now-unused `focusBound` flag too.

## Why minor / no tests

This is a localized frontend cleanup of an HMR/StrictMode-only edge case. `_initialized` already prevents re-binding in a normal app lifetime, so the leak never manifests in production. No new user-facing behavior and no schema changes; no automated test added — the guarded re-binding cannot be exercised deterministically on the production hot path.
