### PR TITLE
fix(security): MCP server bind host configurable, inherits main --host

### DIFF
--- a/backend/api/mcp_settings.py
+++ b/backend/api/mcp_settings.py
@@ -39,6 +39,7 @@ def get_mcp_settings() -> "ResponseReturnValue":
 
     enabled = settings.get("mcp_server_enabled")
     port = settings.get("mcp_server_port") or "8462"
+    host = settings.get("mcp_server_host")
     wrapper_id = settings.get("mcp_server_token_wrapper_id")
 
     token_display = None
@@ -50,6 +51,7 @@ def get_mcp_settings() -> "ResponseReturnValue":
     return jsonify({
         "enabled": enabled is None or str(enabled).lower() not in ("false", "0", "no"),
         "port": int(port) if port and port.isdigit() else 8462,
+        "host": host or "0.0.0.0",
         "token": token_display,
         "wrapper_id": wrapper_id,
     })
@@ -74,6 +76,13 @@ def update_mcp_settings() -> "ResponseReturnValue":
                 return jsonify({"error": "Port must be between 1024 and 65535"}), 400
         except (ValueError, TypeError):
             return jsonify({"error": "Invalid port number"}), 400
+
+    if "host" in data:
+        host_val = str(data["host"]).strip()
+        if host_val:
+            settings.set("mcp_server_host", host_val)
+        else:
+            return jsonify({"error": "Host cannot be empty"}), 400
 
     return jsonify({"success": True})
 

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -179,7 +179,12 @@ def _build_app(mcp: FastMCP) -> Starlette:
 
 
 def run_mcp_server() -> None:
-    """Run the MCP server (blocking). Intended as a WorkerManager service."""
+    """Run the MCP server (blocking). Intended as a WorkerManager service.
+
+    The bind host inherits the main app's ``--host`` (via ``runtime_config``)
+    unless an explicit ``mcp_server_host`` setting overrides it, so locking the
+    REST API to loopback also keeps the MCP port off the LAN.
+    """
     from services.settings_service import SettingsService
     from services.database_service import get_shared_db_service
 
@@ -197,13 +202,20 @@ def run_mcp_server() -> None:
     except (ValueError, TypeError):
         port = _DEFAULT_PORT
 
+    host_setting = settings.get("mcp_server_host")
+    if host_setting and host_setting.strip():
+        host = host_setting.strip()
+    else:
+        import runtime_config
+        host = str(runtime_config.get("host", "0.0.0.0"))
+
     _ensure_mcp_token(db)
 
-    logger.info("[MCP] Starting MCP server on port %d", port)
-    mcp = create_mcp_server(host="0.0.0.0", port=port)
+    logger.info("[MCP] Starting MCP server on %s:%d", host, port)
+    mcp = create_mcp_server(host=host, port=port)
     app = _build_app(mcp)
 
-    uvicorn.run(app, host="0.0.0.0", port=port, log_level="info")
+    uvicorn.run(app, host=host, port=port, log_level="info")
 
 
 def _ensure_mcp_token(db: DatabaseService) -> None:

--- a/frontend/apps/brain/src/api/mcp.ts
+++ b/frontend/apps/brain/src/api/mcp.ts
@@ -18,6 +18,7 @@ import { api } from '@chalie/shared';
 export interface McpServerConfig {
   enabled?: boolean;
   port?: number;
+  host?: string;
   token?: string | null;
   [key: string]: unknown;
 }

--- a/frontend/apps/brain/src/views/McpView.vue
+++ b/frontend/apps/brain/src/views/McpView.vue
@@ -13,6 +13,7 @@ const { confirm } = useConfirm();
 
 const inConfig = ref<McpServerConfig>({});
 const inPort = ref<number>(8462);
+const inHost = ref<string>('0.0.0.0');
 const loadingInbound = ref(true);
 
 const outServers = ref<McpClient[]>([]);
@@ -34,6 +35,7 @@ async function loadInbound(): Promise<void> {
     const data = await mcp.getServerConfig();
     inConfig.value = data;
     inPort.value = (data.port as number) || 8462;
+    inHost.value = (data.host as string) || '0.0.0.0';
   } catch {
     showToast('Failed to load MCP inbound settings', 'error');
   } finally {
@@ -59,6 +61,13 @@ function onPortBlur(): void {
   const val = inPort.value;
   if (val >= 1024 && val <= 65535 && val !== inConfig.value.port) {
     saveInbound({ port: val });
+  }
+}
+
+function onHostBlur(): void {
+  const val = inHost.value.trim();
+  if (val && val !== inConfig.value.host) {
+    saveInbound({ host: val });
   }
 }
 
@@ -253,6 +262,24 @@ onMounted(async () => {
             @blur="onPortBlur"
           >
         </div>
+      </div>
+
+      <div class="form-group">
+        <label for="mcpHost">Bind Host</label>
+        <div class="input-group">
+          <span class="input-prefix">IP</span>
+          <input
+            id="mcpHost"
+            v-model="inHost"
+            type="text"
+            placeholder="0.0.0.0"
+            @blur="onHostBlur"
+          >
+        </div>
+        <p class="mcp-hint">
+          When empty, inherits the main app's <code>--host</code>. Set
+          <code>127.0.0.1</code> to keep the MCP port off the LAN.
+        </p>
       </div>
 
       <div class="mcp-token-section">


### PR DESCRIPTION
## Summary

The MCP server's bind host was hardcoded to `0.0.0.0` in `run_mcp_server()` — only the port was settings-configurable. As a result, a user who locked the main REST app to loopback (`--host=127.0.0.1`) still exposed the MCP port to the LAN, contradicting the loopback-lockdown posture.

## Fix

- `run_mcp_server()` now reads an `mcp_server_host` setting; when unset (the default), it **inherits the main app's `--host`** via `runtime_config`. So the MCP port now follows the REST API's bind posture by default.
- An explicit `mcp_server_host` setting still overrides it for users who want the MCP server on a different interface than the REST API.
- `GET/PUT /api/mcp-server` expose and accept a `host` field.
- The Brain → MCP panel gains a **Bind Host** input with a hint explaining the inheritance and the `127.0.0.1` lockdown option.

## Files

- `backend/mcp_server/server.py` — `run_mcp_server()` resolves host from setting → `runtime_config` → `0.0.0.0`.
- `backend/api/mcp_settings.py` — `host` in GET response + PUT handling.
- `frontend/apps/brain/src/api/mcp.ts` — `host` on `McpServerConfig`.
- `frontend/apps/brain/src/views/McpView.vue` — Bind Host field + `onHostBlur` save.

## Verification

- `ruff` clean on both changed backend files.
- `vulture` — no new findings (all pre-existing).
- Unit gate: `pytest -m unit -q` → 1400 passed / 0 failed / 134 deselected.
- Frontend `npm run typecheck` → clean.
- Existing e2e (`tests/e2e/test_mcp_server.py`) unaffected — it calls `create_mcp_server(host="127.0.0.1")` directly, bypassing `run_mcp_server()`.

Closes #1905

Part of #1883 audit, raised by @rygel