### PR TITLE
fix(ubiquiti): stop silent SSL downgrade when verify_ssl=True

### DIFF
--- a/backend/capabilities/ubiquiti_capability/unifi_rest_handler.py
+++ b/backend/capabilities/ubiquiti_capability/unifi_rest_handler.py
@@ -6,7 +6,6 @@ import threading
 from typing import TYPE_CHECKING, cast
 
 import requests
-from requests.exceptions import SSLError
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -40,12 +39,7 @@ def _get_session(url: str, username: str, password: str, verify_ssl: bool) -> tu
     login_url = f"{url.rstrip('/')}/api/auth/login"
     body: dict[str, str | bool] = {"username": username, "password": password, "rememberMe": True}
 
-    try:
-        resp = session.post(login_url, json=body, verify=verify_ssl, timeout=_TIMEOUT)
-    except SSLError:
-        logger.debug("SSL verification failed for %s, retrying without", url)
-        resp = session.post(login_url, json=body, verify=False, timeout=_TIMEOUT)
-
+    resp = session.post(login_url, json=body, verify=verify_ssl, timeout=_TIMEOUT)
     if not resp.ok:
         safe_body = resp.text[:300].replace("\n", " ").replace("\r", " ")
         logger.warning(
@@ -66,14 +60,6 @@ def _invalidate_session(url: str, username: str = "") -> None:
 # ── Core request helper ──────────────────────────────────────────────────────
 
 
-def _ssl_call(fn: "Callable[..., requests.Response]", *args: object, verify_ssl: bool, url: str, **kwargs: object) -> requests.Response:
-    try:
-        return fn(*args, verify=verify_ssl, **kwargs)
-    except SSLError:
-        logger.debug("SSL verification failed for %s, retrying without", url)
-        return fn(*args, verify=False, **kwargs)
-
-
 def _request(
     method: str,
     url: str,
@@ -91,7 +77,7 @@ def _request(
 
     if api_key:
         fn = cast("Callable[..., requests.Response]", getattr(requests, method))
-        resp = _ssl_call(fn, full_url, headers=_auth_headers(api_key), verify_ssl=verify_ssl, url=url, **kwargs)
+        resp = fn(full_url, headers=_auth_headers(api_key), verify=verify_ssl, **kwargs)
         resp.raise_for_status()
         return resp
 
@@ -103,7 +89,7 @@ def _request(
         headers: dict[str, str] = {"Content-Type": "application/json"}
         if needs_csrf:
             headers["X-CSRF-Token"] = tok
-        return _ssl_call(cast("Callable[..., requests.Response]", getattr(sess, method)), full_url, headers=headers, verify_ssl=verify_ssl, url=url, **kwargs)
+        return cast("Callable[..., requests.Response]", getattr(sess, method))(full_url, headers=headers, verify=verify_ssl, **kwargs)
 
     resp = _session_call(session, csrf)
 

--- a/backend/tests/.gitignore
+++ b/backend/tests/.gitignore
@@ -1,0 +1,1 @@
+_ssl_downgrade_certs/

--- a/backend/tests/test_ubiquiti_ssl_downgrade.py
+++ b/backend/tests/test_ubiquiti_ssl_downgrade.py
@@ -1,0 +1,117 @@
+# Copyright 2026 Chalie AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Feature test for the UniFi SSL-verification downgrade regression (#1906).
+
+Spins a real HTTPS server with a self-signed certificate (no mocks) and
+proves that when the user opts into ``verify_ssl=True``, an SSLError is
+raised to the caller instead of being silently swallowed by retrying the
+request with ``verify=False``. This is exactly the narrow MITM exposure the
+audit flagged: credentials/CSRF carried over an unverified connection that
+the user never asked for.
+
+The same server also proves the ``verify_ssl=False`` path still works, so the
+test is a two-sided contract: verify-True must fail loud, verify-False must
+connect.
+"""
+
+from __future__ import annotations
+
+import http.server
+import ssl
+import threading
+from pathlib import Path
+from typing import cast
+
+import pytest
+import requests.exceptions
+
+from capabilities.ubiquiti_capability import unifi_rest_handler as rest
+
+pytestmark = pytest.mark.unit
+
+# ── Self-signed cert fixture ────────────────────────────────────────────────
+
+_CERT_DIR = Path(__file__).parent / "_ssl_downgrade_certs"
+
+
+def _ensure_cert() -> tuple[Path, Path]:
+    key = _CERT_DIR / "key.pem"
+    cert = _CERT_DIR / "cert.pem"
+    if cert.exists() and key.exists():
+        return cert, key
+    _CERT_DIR.mkdir(parents=True, exist_ok=True)
+    import subprocess
+
+    subprocess.run(  # noqa: S603 — trusted args
+        [
+            "openssl", "req", "-x509", "-newkey", "rsa:2048",
+            "-keyout", str(key), "-out", str(cert),
+            "-days", "1", "-nodes", "-subj", "/CN=localhost",
+        ],
+        check=True, capture_output=True,
+    )
+    _key_perms = 0o600
+    key.chmod(_key_perms)
+    return cert, key
+
+
+@pytest.fixture(scope="module")
+def untrusted_https_server() -> object:
+    """A real HTTPS server presenting a self-signed cert, threaded in the background."""
+    cert, key = _ensure_cert()
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 — http.server contract
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"data": []}')
+
+        def log_message(self, *args: object) -> None:  # noqa: ARG002 — silence
+            return
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    server.socket = ssl.wrap_socket(  # noqa: S502 — self-signed by design
+        server.socket, certfile=str(cert), keyfile=str(key), server_side=True,
+    )
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    class _ServerHandle:
+        url = f"https://127.0.0.1:{port}"
+
+        def stop(self) -> None:
+            server.shutdown()
+            server.server_close()
+
+    handle = _ServerHandle()
+    try:
+        yield handle
+    finally:
+        handle.stop()
+
+
+# ── The regression contract ────────────────────────────────────────────────
+
+
+def test_verify_true_raises_on_untrusted_cert(untrusted_https_server: object) -> None:
+    """When the user opts into verify_ssl=True, an untrusted cert must raise — not silently downgrade."""
+    handle = cast("object", untrusted_https_server)
+    url = cast("str", getattr(handle, "url"))
+    with pytest.raises(requests.exceptions.SSLError):
+        rest.list_devices(url, "default", api_key="k", verify_ssl=True)
+
+
+def test_verify_false_still_connects(untrusted_https_server: object) -> None:
+    """The explicit opt-out path (verify_ssl=False) must still connect to the untrusted server."""
+    handle = cast("object", untrusted_https_server)
+    url = cast("str", getattr(handle, "url"))
+    result = rest.list_devices(url, "default", api_key="k", verify_ssl=False)
+    assert result["count"] == 0

--- a/backend/tests/test_ubiquiti_ssl_downgrade.py
+++ b/backend/tests/test_ubiquiti_ssl_downgrade.py
@@ -77,9 +77,9 @@ def untrusted_https_server() -> object:
             return
 
     server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
-    server.socket = ssl.wrap_socket(  # noqa: S502 — self-signed by design
-        server.socket, certfile=str(cert), keyfile=str(key), server_side=True,
-    )
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)  # ssl.wrap_socket removed in 3.12; SSLContext works 3.11+
+    ctx.load_cert_chain(certfile=str(cert), keyfile=str(key))
+    server.socket = ctx.wrap_socket(server.socket, server_side=True)
     port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()


### PR DESCRIPTION
Closes #1906

Part of #1883 audit, raised by @rygel

## Summary

Issue #1906 flagged a narrow MITM exposure in the UniFi REST handler: when a user explicitly configured `verify_ssl=True` but the controller presented an untrusted certificate, the code silently retried the request with `verify=False`. The unverified connection still carried credentials and the CSRF token — a silent downgrade the user never opted into.

## Fix

Removed the guarded `except SSLError: retry with verify=False` fallback in two places:

- `_get_session` (login POST)
- `_ssl_call` (core request helper — deleted entirely, its single real behaviour inlined at the two call sites)

Now when `verify_ssl=True` and an `SSLError` occurs, it propagates to the caller. The explicit `verify_ssl=False` opt-out path is unchanged and still works.

Net-negative on the production code (`unifi_rest_handler.py`): the helper, the redundant import, and the retry branches are all gone. The test file is additive.

## Test

Adds `backend/tests/test_ubiquiti_ssl_downgrade.py` — a feature test that spins a real HTTPS server with a self-signed certificate (no mocks) and asserts the two-sided contract:

- `test_verify_true_raises_on_untrusted_cert` — `verify_ssl=True` against the untrusted cert raises `SSLError` (regression captured; verified this test FAILS against the old code with `DID NOT RAISE`).
- `test_verify_false_still_connects` — the explicit `verify_ssl=False` opt-out still connects (contract preserved).

Run: `cd backend && pytest -m unit tests/test_ubiquiti_ssl_downgrade.py -q`