### PR TITLE
Fix MemoryStore.brpop 10Hz busy-poll on timeout=0

### DIFF
--- a/backend/services/memory_store.py
+++ b/backend/services/memory_store.py
@@ -39,6 +39,10 @@ class MemoryStore:
         # Locks per keyspace
         self._str_lock = threading.RLock()
         self._list_lock = threading.RLock()
+        # Condition over the list lock so brpop can block without busy-polling;
+        # rpush/lpush notify_all after appending. The underlying RLock is still
+        # usable directly by every other list operation.
+        self._list_cond = threading.Condition(self._list_lock)
         self._zset_lock = threading.RLock()
         self._set_lock = threading.RLock()
 
@@ -145,25 +149,29 @@ class MemoryStore:
         return lst
 
     def rpush(self, key: str, *values: object) -> int:
-        with self._list_lock:
+        with self._list_cond:
             lst = self._get_list(key)
             if lst is None:
                 lst = []
                 self._lists[key] = (lst, None)
             for v in values:
                 lst.append(str(v))
-            return len(lst)
+            length = len(lst)
+            self._list_cond.notify_all()
+            return length
 
     def lpush(self, key: str, *values: object) -> int:
         """Values are inserted one at a time in argument order, so the last argument ends up at index 0."""
-        with self._list_lock:
+        with self._list_cond:
             lst = self._get_list(key)
             if lst is None:
                 lst = []
                 self._lists[key] = (lst, None)
             for v in values:
                 lst.insert(0, str(v))
-            return len(lst)
+            length = len(lst)
+            self._list_cond.notify_all()
+            return length
 
     def ltrim(self, key: str, start: int, stop: int) -> bool:
         """Supports negative indices (Redis-compatible semantics). Returns ``False`` if the key does not exist."""
@@ -204,17 +212,25 @@ class MemoryStore:
             return lst.pop(0)
 
     def brpop(self, key: str, timeout: int = 0) -> Optional[Tuple[str, str]]:
-        """Blocking right-pop. Polls with sleep for simplicity."""
-        deadline = time.time() + timeout if timeout > 0 else None
-        while True:
-            with self._list_lock:
+        """Blocking right-pop. Waits on a condition variable (no busy-poll).
+
+        ``timeout=0`` blocks indefinitely (Redis semantics); any positive value
+        caps the wait in seconds. Returns ``(key, value)`` on success or
+        ``None`` on timeout.
+        """
+        with self._list_cond:
+            deadline = time.monotonic() + timeout if timeout > 0 else None
+            while True:
                 lst = self._get_list(key)
                 if lst:
-                    val = lst.pop()
-                    return (key, val)
-            if deadline and time.time() >= deadline:
-                return None
-            time.sleep(0.1)
+                    return (key, lst.pop())
+                if deadline is None:
+                    self._list_cond.wait()
+                else:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        return None
+                    self._list_cond.wait(timeout=remaining)
 
     # ── SORTED SET operations ──────────────────────────────────
 


### PR DESCRIPTION
Closes #1907
Part of #1883 audit, raised by @rygel

## Problem
`MemoryStore.brpop` busy-polled `time.sleep(0.1)` (10Hz) forever when called with the default `timeout=0` (block-forever, Redis semantics). The `deadline` was `None`, so the loop's exit condition never tripped and the thread spun in a poll-sleep loop on an empty key. Severity Low — latent, as there are currently zero callers of `.brpop(` in the repo.

## Fix
Replace the poll-sleep loop with a `threading.Condition` over the existing list lock:
- `brpop` waits on the condition (indefinitely for `timeout=0`, or with a `time.monotonic()` deadline for positive timeouts) — zero CPU while idle.
- `rpush`/`lpush` now `notify_all` after appending, waking any blocked `brpop`.
- All other list operations keep using `self._list_lock` directly (the Condition wraps that same RLock, so locking semantics are unchanged).

## Verification
- `ruff check` clean, no new vulture findings.
- Unit suite (memory/list/store-filtered): 173 passed.
- Manual smoke: block-forever is woken by a delayed `rpush` (~0.3s), `timeout=1` returns `None` in ~1.0s, immediate pop when an element is present, and `lpush` also wakes the waiter.

## Scope
Localized bugfix — no new behavior, no callers, no UI surface.
