### PR TITLE
fix(embedding): guard get_embedding_service singleton with double-checked locking

### DIFF
--- a/backend/services/embedding_service.py
+++ b/backend/services/embedding_service.py
@@ -292,12 +292,15 @@ def _submit_for_inference(texts: List[str], mp: object = None) -> np.ndarray:
 
 # Singleton EmbeddingService instance
 _embedding_service_instance = None
+_embedding_service_lock = threading.Lock()
 
 
 def get_embedding_service() -> 'EmbeddingService':
     global _embedding_service_instance
     if _embedding_service_instance is None:
-        _embedding_service_instance = EmbeddingService()
+        with _embedding_service_lock:
+            if _embedding_service_instance is None:
+                _embedding_service_instance = EmbeddingService()
     return _embedding_service_instance
 
 


### PR DESCRIPTION
## Summary

`get_embedding_service()` performed an unlocked check-then-set on the module-level singleton, inconsistent with the two other double-checked-locking patterns in this module (`_get_session_and_tokenizer` under `_model_lock`, `_ensure_worker_started` under `_embedding_worker_started`).

Wrapped the accessor in the same DCL pattern using a dedicated `_embedding_service_lock` so the singleton construction is thread-safe and consistent with the rest of the module.

The race was low-severity: `EmbeddingService.__init__` only stores a config dict (no I/O, no model load), so a race at worst constructed a duplicate stateless wrapper that was harmlessly discarded — the heavy ONNX session/tokenizer/worker singletons it delegates to are independently locked. Fixed for consistency and to close the window.

Closes #1908

Part of #1883 audit, raised by @rygel