### PR TITLE
fix(docker): pin installer fetch to the build's TAG/BRANCH ref

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,14 @@ FROM python:3.12-slim
 ARG BRANCH=
 ARG TAG=
 
-RUN apt-get update \
+# Fetch the installer at the same pinned ref as the app tarball so tagged
+# builds don't silently drift from main's installer. Falls back to main only
+# when neither --tag nor --branch is given (the API-resolved latest case).
+RUN installer_ref="${TAG:-${BRANCH:-main}}" \
+ && apt-get update \
  && apt-get install -y --no-install-recommends curl ca-certificates bash tar \
  && rm -rf /var/lib/apt/lists/* \
- && curl -fsSL https://raw.githubusercontent.com/chalie-ai/chalie/main/installer/install.sh -o /tmp/install.sh \
+ && curl -fsSL "https://raw.githubusercontent.com/chalie-ai/chalie/${installer_ref}/installer/install.sh" -o /tmp/install.sh \
  && bash /tmp/install.sh ${BRANCH:+--branch="$BRANCH"} ${TAG:+--tag="$TAG"} \
  && rm /tmp/install.sh
 


### PR DESCRIPTION
Closes #1909

Part of #1883 audit, raised by @rygel

---

The Dockerfile always fetched `install.sh` from `main`, even when building a tagged release. The `--build-arg TAG`/`BRANCH` flags were only forwarded to `install.sh` itself, which uses them solely to pick the app *tarball* ref — the installer script came from `…/chalie/main/installer/install.sh` unconditionally (`Dockerfile:21`).

This is a reproducibility/supply-chain hygiene issue: a tagged build could silently use an installer that drifted from the one that shipped with that tag. There is no checksum/signature on the fetch, and it is HTTPS (TLS-trusted), so impact is hygiene, not an active exploit.

**Fix:** derive the installer fetch ref from the same pinned `TAG` (preferred) or `BRANCH`, falling back to `main` only when neither is given (the API-resolved latest case — preserves current default behavior).

```diff
-RUN apt-get update \
- && curl -fsSL https://raw.githubusercontent.com/chalie-ai/chalie/main/installer/install.sh -o /tmp/install.sh \
+RUN installer_ref="${TAG:-${BRANCH:-main}}" \
+ && apt-get update \
+ && curl -fsSL "https://raw.githubusercontent.com/chalie-ai/chalie/${installer_ref}/installer/install.sh" -o /tmp/install.sh \
```

No code outside the Dockerfile changes; `install.sh` itself is untouched.