### PR TITLE
fix(installer): verify source tarball SHA256 against published sidecar

### DIFF
--- a/.github/workflows/publish-checksum.yml
+++ b/.github/workflows/publish-checksum.yml
@@ -1,0 +1,32 @@
+name: Publish Release Checksum
+
+# Publish a SHA256 sidecar of the release source tarball so install.sh can
+# verify the archive it downloads (issue #1910). GitHub source archives are
+# byte-deterministic, so the checksum computed here matches the archive
+# install.sh fetches from refs/tags/<tag>.tar.gz.
+#
+# Triggered on release publication (not tag push): releases are published
+# manually, so this attaches the sidecar to the existing release rather than
+# racing to create one at tag-push time.
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  publish-checksum:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch and checksum the release tarball
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          curl -fsSL "https://github.com/${{ github.repository }}/archive/refs/tags/${TAG}.tar.gz" -o "chalie-${TAG}.tar.gz"
+          sha256sum "chalie-${TAG}.tar.gz" | awk -v t="$TAG" '{print $1"  chalie-"t".tar.gz"}' > "chalie-${TAG}.tar.gz.sha256"
+
+      - name: Upload checksum sidecar to the release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: chalie-*.tar.gz.sha256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,3 +58,21 @@ jobs:
           else
             echo "No changes to commit"
           fi
+
+  # Publish a SHA256 sidecar of the release source tarball so install.sh can
+  # verify the archive it downloads (issue #1910). GitHub source archives are
+  # byte-deterministic, so the checksum computed at release time matches the
+  # archive install.sh fetches from refs/tags/<tag>.tar.gz.
+  publish-checksum:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch and checksum the release tarball
+        run: |
+          TAG="${{ github.ref_name }}"
+          curl -fsSL "https://github.com/${{ github.repository }}/archive/refs/tags/${TAG}.tar.gz" -o "chalie-${TAG}.tar.gz"
+          sha256sum "chalie-${TAG}.tar.gz" | awk '{print $1"  chalie-'${TAG}'.tar.gz"}' > "chalie-${TAG}.tar.gz.sha256"
+
+      - name: Upload checksum sidecar to the release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: chalie-*.tar.gz.sha256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,21 +58,3 @@ jobs:
           else
             echo "No changes to commit"
           fi
-
-  # Publish a SHA256 sidecar of the release source tarball so install.sh can
-  # verify the archive it downloads (issue #1910). GitHub source archives are
-  # byte-deterministic, so the checksum computed at release time matches the
-  # archive install.sh fetches from refs/tags/<tag>.tar.gz.
-  publish-checksum:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fetch and checksum the release tarball
-        run: |
-          TAG="${{ github.ref_name }}"
-          curl -fsSL "https://github.com/${{ github.repository }}/archive/refs/tags/${TAG}.tar.gz" -o "chalie-${TAG}.tar.gz"
-          sha256sum "chalie-${TAG}.tar.gz" | awk '{print $1"  chalie-'${TAG}'.tar.gz"}' > "chalie-${TAG}.tar.gz.sha256"
-
-      - name: Upload checksum sidecar to the release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: chalie-*.tar.gz.sha256

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -21,6 +21,8 @@ GITHUB_API="https://api.github.com/repos/$CHALIE_REPO/releases/latest"
 # Installer flags (parsed from args)
 _BRANCH=""
 _TAG=""
+_CHECKSUM=""
+_INSECURE=false
 
 # ─── Colours ────────────────────────────────────────────────────────────────
 _reset="\033[0m"
@@ -54,6 +56,9 @@ _parse_args() {
       --branch)                _BRANCH="$2"; shift 2 ;;
       --tag=*)                 _TAG="${arg#--tag=}"; shift ;;
       --tag)                   _TAG="$2"; shift 2 ;;
+      --checksum=*)            _CHECKSUM="${arg#--checksum=}"; shift ;;
+      --checksum)              _CHECKSUM="$2"; shift 2 ;;
+      --insecure)              _INSECURE=true; shift ;;
       --disable-default-tools) shift ;; # deprecated, ignored — tools are bundled in the repo
       *) shift ;;
     esac
@@ -181,6 +186,62 @@ _install_build_deps() {
   _ok "Build dependencies ready"
 }
 
+# ─── Integrity Verification ────────────────────────────────────────────────
+_sha256_file() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | cut -d' ' -f1
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | cut -d' ' -f1
+  else
+    _error "Neither sha256sum nor shasum is available — cannot verify integrity."
+    exit 1
+  fi
+}
+
+# Resolve the expected SHA256 for the downloaded tarball, in priority order:
+#   1. Explicit --checksum=HEX (caller pins it; fail-closed if it mismatches).
+#   2. Published sidecar at releases/download/<ref>/chalie-<ref>.tar.gz.sha256.
+#   3. "" (empty) → no checksum available; rely on HTTPS-only posture.
+_resolve_checksum() {
+  local ref="$1"
+  if [[ -n "$_CHECKSUM" ]]; then
+    echo "$_CHECKSUM"
+    return
+  fi
+  local sidecar_url="https://github.com/$CHALIE_REPO/releases/download/$ref/chalie-$ref.tar.gz.sha256"
+  local sum
+  sum="$(curl -fsSL "$sidecar_url" 2>/dev/null | head -1 | awk '{print $1}')" || true
+  if [[ -n "$sum" && "$sum" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "$sum"
+  else
+    echo ""
+  fi
+}
+
+# Verify a downloaded tarball against an expected SHA256. Empty expected →
+# warn and proceed (no sidecar published for this ref; TLS-only posture).
+_verify_tarball() {
+  local tarball="$1" expected="$2" ref="$3"
+  if [[ -z "$expected" ]]; then
+    if [[ "$_INSECURE" != true ]]; then
+      _warn "No checksum published for '$ref' — proceeding with TLS-only verification."
+    fi
+    return 0
+  fi
+  local actual
+  actual="$(_sha256_file "$tarball")"
+  if [[ "$actual" != "$expected" ]]; then
+    _error "Integrity check FAILED for '$ref'."
+    _error "  expected: $expected"
+    _error "  actual:   $actual"
+    _error "The downloaded archive does not match its published checksum."
+    _error "This may indicate a truncated download or a compromised origin."
+    exit 1
+  fi
+  _ok "Integrity verified (sha256: ${actual:0:12}…)"
+}
+
 # ─── Download Latest Release ────────────────────────────────────────────────
 _fetch_latest_tag() {
   local tag
@@ -246,6 +307,13 @@ _download_release() {
     rm -rf "$tmp_dir"
     exit 1
   fi
+
+  # Integrity: verify SHA256 against an explicit pin or a published sidecar.
+  # Fail-closed on mismatch; absent checksum → TLS-only warning (preserves the
+  # conventional curl|bash posture for refs that predate the checksum sidecar).
+  local expected_checksum
+  expected_checksum="$(_resolve_checksum "$ref")"
+  _verify_tarball "$tarball" "$expected_checksum" "$ref"
 
   # Remove old managed source directories before extraction so deleted files
   # from previous versions don't linger. data/ is user state — never touched.


### PR DESCRIPTION
## Summary

Hardens the `curl | bash` install/update paths with SHA256 integrity verification of the downloaded source tarball, addressing the supply-chain concern in #1910.

GitHub source archives (`/archive/refs/tags/<tag>.tar.gz`) are byte-deterministic (verified: identical SHA256 across repeated fetches), so a checksum published at release time matches the archive the installer downloads at runtime.

## Changes

**`installer/install.sh`**
- New `--checksum=SHA256` flag (explicit pin, fail-closed on mismatch) and `--insecure` (skip).
- `_sha256_file` / `_resolve_checksum` / `_verify_tarball` helpers (sha256sum with shasum fallback).
- `_download_release` now verifies the tarball after download, before extraction:
  - Explicit `--checksum` → fail-closed on mismatch.
  - No pin → fetch published sidecar at `releases/download/<ref>/chalie-<ref>.tar.gz.sha256`; fail-closed on mismatch.
  - No sidecar available (refs that predate it, branch builds) → warn + proceed under the existing TLS-only posture. Non-breaking for old releases.

**`.github/workflows/release.yml`**
- New `publish-checksum` job: fetches the release tarball, computes its SHA256, and uploads `chalie-<tag>.tar.gz.sha256` as a release asset so install.sh can verify against it.

## Scope notes

- The uv one-liner (`:287`) is left as-is: Astral publishes no stable checksum URL, and the issue verdict classifies it as the conventional one-liner posture (rustup/uv/Deno identical). The issue's "at minimum" target is the tarball.
- The `chalie update` action (`:431`) re-runs install.sh, so it inherits the new tarball verification transitively.
- Minor security-hardening fix — no new cross-step behavior and no UI surface, so it ships as shell + CI changes verified by shellcheck, `bash -n`, and the byte-determinism check below.

## Verification

- `shellcheck -S warning` clean.
- `bash -n` syntax OK.
- Functional test against a real GitHub tarball: valid tarball + matching checksum passes (`Integrity verified`); corrupted tarball fails-closed with exit 1 and clear diagnostics; no-sidecar path warns and proceeds.

Closes #1910
Part of #1883 audit, raised by @rygel
