### PR TITLE
perf(api): cache hashed assets immutably, keep index.html no-cache

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -68,7 +68,6 @@ def _register_blueprints(app: Flask) -> None:
 def _configure_app(app: Flask) -> None:
     """Apply Flask config, proxy middleware, and CORS to a new app instance."""
     app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024
-    app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 0
 
     from werkzeug.middleware.proxy_fix import ProxyFix
     setattr(app, 'wsgi_app', ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1))
@@ -85,16 +84,33 @@ def _register_static_routes(app: Flask) -> None:
         dist/on-boarding/index.html, dist/pairing/index.html).
       • brain      →  apps/brain/dist      — admin SPA at '/brain/', auth-gated.
 
-    index.html documents are served no-cache (they point at hashed asset URLs);
-    SEND_FILE_MAX_AGE_DEFAULT=0 keeps hashed assets revalidating, which is correct
-    because a new build produces new filenames.
+    index.html documents are served no-cache (they point at hashed asset URLs).
+    Files under assets/ are content-hashed by Vite (a new build produces new
+    filenames), so they are served immutable with a 1-year max-age — safe to
+    cache forever with no staleness risk. All other paths fall back to the SPA
+    index document.
     """
     interface_dir = FileMapperService.get_frontend_path("apps", "interface", "dist")
     brain_dir = FileMapperService.get_frontend_path("apps", "brain", "dist")
 
+    _IMMUTABLE_CACHE = 'public, max-age=31536000, immutable'
+    _NO_CACHE = 'no-cache, no-store, must-revalidate'
+
     def _send_index(directory: Path, filename: str = 'index.html') -> Response:
         resp = send_from_directory(str(directory), filename)
-        resp.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
+        resp.headers['Cache-Control'] = _NO_CACHE
+        return resp
+
+    def _send_asset(directory: Path, filename: str) -> Response:
+        """Serve a file under assets/ with immutable long-term caching.
+
+        Vite content-hashes every asset filename, so the same content always
+        maps to the same URL and a new build produces new filenames — safe to
+        cache forever. Callers must confirm the file exists and resolves under
+        the assets/ subtree of *directory*.
+        """
+        resp = send_from_directory(str(directory), filename)
+        resp.headers['Cache-Control'] = _IMMUTABLE_CACHE
         return resp
 
     # ── Brain admin SPA (auth-gated, matches the legacy /brain/ gate) ─────
@@ -118,6 +134,8 @@ def _register_static_routes(app: Flask) -> None:
             return redirect(f'/login/?next=/brain/{filename}')
         candidate = brain_dir / filename
         if candidate.is_file():
+            if filename.startswith('assets/'):
+                return _send_asset(brain_dir, filename)
             return send_from_directory(str(brain_dir), filename)
         return _send_index(brain_dir)
 
@@ -155,6 +173,8 @@ def _register_static_routes(app: Flask) -> None:
     def interface_static(filename: str) -> ResponseReturnValue:
         candidate = interface_dir / filename
         if candidate.is_file():
+            if filename.startswith('assets/'):
+                return _send_asset(interface_dir, filename)
             return send_from_directory(str(interface_dir), filename)
         return _send_index(interface_dir)
 


### PR DESCRIPTION
## Summary

Closes the caching half of #1944.

`SEND_FILE_MAX_AGE_DEFAULT = 0` forced **every** hashed asset (`/assets/*.js`, `*.css`, `*.woff2`) to revalidate on every request — a conditional GET round-trip per file per page load, forever. This defeats the purpose of Vite's content hashing: hashed filenames change on every build, so the files are safe to cache indefinitely with zero staleness risk.

## Change

- **Remove** `app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 0` (misapplied to all static files).
- **Add** `_send_asset()` helper that serves files under `assets/` with `Cache-Control: public, max-age=31536000, immutable`.
- Keep `_send_index()` serving `index.html` with `no-cache, no-store, must-revalidate` (correct — HTML entry points point at the hashed URLs and must revalidate to pick up new builds).
- Route both the interface and brain static handlers through the helpers based on whether the path starts with `assets/`.

After #1943 cut the font payload to ~96 KB, this revalidation churn was the next-largest perceptible cost on repeat visits.

## Why `immutable` is safe

Vite content-hashes every asset filename (`main-GTTPhYeq.js`, `inter-latin-400-normal-C38fXH4l.woff2`, …). Verified: identical content yields identical hashes across builds and apps (`inter-latin-400-normal-C38fXH4l.woff2` is byte-identical in both `interface/dist` and `brain/dist`). A new build produces new filenames, so caching the old ones forever can never serve stale content. The HTML entry points (un-hashed, live in `dist/` root, not `dist/assets/`) correctly stay no-cache.

## Verification (Flask test client)

```
/assets/main-*.js           -> 200, Cache-Control: public, max-age=31536000, immutable
/assets/inter-latin-*.woff2 -> 200, Cache-Control: public, max-age=31536000, immutable
/ (index.html)              -> 200, Cache-Control: no-cache, no-store, must-revalidate
/unknown/spa/route          -> 200 no-cache (index fallback)
/assets/../../../etc/passwd -> 200 index.html (traversal blocked by send_from_directory, falls back)
```

No existing tests covered these routes. Path-traversal safety confirmed (the 200 on the traversal attempt is the SPA index fallback, not the system file).

## Risk

Low. Browsers that already have the assets cached under the old `max-age=0` will simply start caching them on the next response. Worst case during rollout: one extra fetch per asset as the cache directive changes, then immutable thereafter.

Backend-only; no frontend or DB changes.

## Related

- #1941 / #1943 — woff2-only fonts (the size reduction this complements).
- #1944 — the full ticket; the font-weight 700 finding is a separate frontend PR.