### PR TITLE
Show message timestamps and time-to-answer in the chat interface

### DIFF
--- a/frontend/apps/interface/src/components/conversation/ChalieBubble.vue
+++ b/frontend/apps/interface/src/components/conversation/ChalieBubble.vue
@@ -24,6 +24,13 @@ const MODE_LABELS: Record<string, string> = {
 
 const modeBadgeLabel = computed(() => MODE_LABELS[props.form.meta.mode ?? ''] ?? '');
 
+// Turn latency in seconds, shown beside the timestamp so response cost is visible.
+const latencyLabel = computed(() =>
+  props.form.meta.duration_ms && props.form.meta.duration_ms >= 1000
+    ? `${(props.form.meta.duration_ms / 1000).toFixed(1)}s`
+    : '',
+);
+
 const speakText = computed(() => chalieFormPlaintext(props.form));
 
 // Remember/speak controls live only on the turn's LAST Chalie row — a turn may
@@ -67,6 +74,7 @@ function onSpeak(): void {
     <div v-if="isLastInTurn" class="speech-form__meta">
       <span class="sender-glyph" aria-hidden="true"></span>
       <span class="speech-form__timestamp">{{ form.meta.ts ?? '' }}</span>
+      <span v-if="latencyLabel" class="speech-form__timestamp">· {{ latencyLabel }}</span>
 
       <span v-if="modeBadgeLabel" class="meta-mode-badge">{{ modeBadgeLabel }}</span>
 

--- a/frontend/apps/interface/src/components/conversation/UserBubble.vue
+++ b/frontend/apps/interface/src/components/conversation/UserBubble.vue
@@ -41,6 +41,8 @@ function open(att: AttachmentPreview): void {
   >
     <div v-if="showText" class="speech-form speech-form--user">{{ form.text }}</div>
 
+    <div v-if="form.ts" class="user-message__ts">{{ form.ts }}</div>
+
     <!-- Attachments live OUTSIDE the bubble, below it: a condensed, right-aligned
          list in the act-trail idiom. Click an image to preview, a doc to download. -->
     <ul v-if="form.attachments && form.attachments.length" class="user-attachments">

--- a/frontend/apps/interface/src/stores/conversation.ts
+++ b/frontend/apps/interface/src/stores/conversation.ts
@@ -7,6 +7,7 @@
 import { defineStore } from 'pinia';
 import type { ConversationAttachment, ConversationMessage, ConversationSegment } from '../api/conversation';
 import { extractText } from '../composables/useMarkup';
+import { chatTimestamp } from '../utils/time';
 
 export interface AttachmentPreview {
   filename: string;
@@ -51,6 +52,8 @@ export interface UserForm extends TurnTagged {
   attachments?: AttachmentPreview[];
   /** Whether the turn is within working memory (faded if false). */
   inWorkingMemory?: boolean;
+  /** Display-formatted send time ("%d %b %H:%M"); history rows carry the server string. */
+  ts?: string;
 }
 
 export interface ChalieForm extends TurnTagged {
@@ -160,7 +163,7 @@ export const useConversationStore = defineStore('conversation', {
     appendUser(
       text: string,
       attachments?: AttachmentPreview[],
-      opts?: { inWorkingMemory?: boolean; turnId?: number | null },
+      opts?: { inWorkingMemory?: boolean; turnId?: number | null; ts?: string },
     ): number {
       const id = nextId();
       const form: UserForm = {
@@ -170,6 +173,7 @@ export const useConversationStore = defineStore('conversation', {
         attachments: attachments ?? [],
         inWorkingMemory: opts?.inWorkingMemory ?? true,
         turnId: opts?.turnId,
+        ts: opts?.ts ?? chatTimestamp(),
       };
       this.forms.push(form);
       return id;
@@ -398,7 +402,7 @@ export const useConversationStore = defineStore('conversation', {
     _appendMessage(msg: ConversationMessage, inWorkingMemory: boolean): void {
       if (msg.role === 'user') {
         const attachments = this._attachmentsFor(msg);
-        this.appendUser(msg.content, attachments, { inWorkingMemory, turnId: msg.turn_id });
+        this.appendUser(msg.content, attachments, { inWorkingMemory, turnId: msg.turn_id, ts: msg.timestamp });
         return;
       }
       for (const form of this._assistantForms(msg, inWorkingMemory)) {
@@ -417,6 +421,7 @@ export const useConversationStore = defineStore('conversation', {
           attachments,
           inWorkingMemory,
           turnId: msg.turn_id,
+          ts: msg.timestamp,
         });
         return;
       }

--- a/frontend/apps/interface/src/styles/conversation.scss
+++ b/frontend/apps/interface/src/styles/conversation.scss
@@ -231,6 +231,11 @@
   letter-spacing: 0.04em;
 }
 
+.user-message__ts {
+  @extend .speech-form__timestamp;
+  align-self: flex-end;
+}
+
 .speech-form__remember-btn {
   background: none;
   border: none;

--- a/frontend/apps/interface/src/utils/time.ts
+++ b/frontend/apps/interface/src/utils/time.ts
@@ -1,3 +1,19 @@
+/**
+ * Chat-bubble timestamp in the same "%d %b %H:%M" shape the backend emits
+ * (locale_service.CHAT_TIMESTAMP_FMT). History rows already carry that string;
+ * this formatter covers live-sent messages, which have no backend echo yet, so
+ * the browser's local zone stands in for the server-configured one until the
+ * next history reload. "" on parse error.
+ */
+export function chatTimestamp(iso?: string): string {
+  const d = iso ? new Date(iso) : new Date();
+  if (Number.isNaN(d.getTime())) return '';
+  const day = String(d.getDate()).padStart(2, '0');
+  const month = d.toLocaleString('en', { month: 'short' });
+  const time = d.toLocaleString('en', { hour: '2-digit', minute: '2-digit', hour12: false });
+  return `${day} ${month} ${time}`;
+}
+
 // Short relative-time label for scheduler UI ("now", "in 5m", "tomorrow",
 // "overdue", "" on parse error).
 export function relativeTime(isoStr: string): string {


### PR DESCRIPTION
Closes #1954.

## What & why
It is not visible in the chat interface how long it takes for Chalie to answer a user message, nor when a user sent a message. This makes response cost and send time visible at a glance.

## Changes
- **User message timestamp:** `UserBubble.vue` now renders the send time (`03 Jul 17:45` format). `UserForm` gains an optional `ts` field, threaded through `appendUser` and both history paths (`_appendMessage` / `_prependMessage`). History rows reuse the server-formatted `msg.timestamp`; live-sent rows are formatted client-side by a new `chatTimestamp()` helper that matches the backend `CHAT_TIMESTAMP_FMT` shape.
- **Time-to-answer:** `ChalieBubble.vue` renders the turn latency (`· 2.3s`) beside the existing timestamp. The `duration_ms` field was already plumbed end-to-end (backend WS `done` event → `session.ts` → `form.meta.duration_ms`) but unused — this surfaces it.

## Scope
Minor / frontend-only. No backend, data-shape, or DB change. No new tests (localized display, no new cross-step behavior).

## Verification
- `vue-tsc --noEmit` clean.
- `eslint .` — no new warnings (only pre-existing `vue/no-v-html` on untouched files).
