### PR TITLE
fix(interface): add missing chalie-markup class to SegmentRenderer v-html divs

### DIFF
--- a/frontend/apps/interface/src/components/conversation/SegmentRenderer.vue
+++ b/frontend/apps/interface/src/components/conversation/SegmentRenderer.vue
@@ -21,7 +21,7 @@ const resolved = computed<{ seg: ConversationSegment; richEntry: RichCardEntry |
   <template v-for="(item, idx) in resolved" :key="idx">
     <div
       v-if="item.seg.type === 'text'"
-      class="speech-form__text"
+      class="speech-form__text chalie-markup"
       v-html="renderMarkup(item.seg.content ?? '')"
     />
 
@@ -38,7 +38,7 @@ const resolved = computed<{ seg: ConversationSegment; richEntry: RichCardEntry |
       <!-- Unknown-tag fallback: render synthesis or content as markup. -->
       <div
         v-else
-        class="speech-form__text"
+        class="speech-form__text chalie-markup"
         v-html="renderMarkup(item.seg.synthesis ?? item.seg.content ?? '')"
       />
     </template>


### PR DESCRIPTION
Fixes #1956

Tables rendered through the segment path in \SegmentRenderer.vue\ lacked all table styling because the \-html\ wrapper div was missing the \chalie-markup\ CSS class. All table CSS (descendant selectors on \.chalie-markup table\, \.chalie-markup th\, etc.) requires that ancestor class.

Affects both:
- The text-segment div (line 21)
- The unknown-tag rich-segment fallback div (line 31)