### PR TITLE
fix(markup): allow colspan/rowspan/scope/headers attributes on td/th

### DIFF
--- a/backend/services/markup.py
+++ b/backend/services/markup.py
@@ -41,6 +41,8 @@ _ATTRIBUTES = {
     "img": {"src", "alt"},
     "action": {"label", "value", "execute", "collect", "target", "open-url", "payload", "style"},
     "span": {"id"},
+    "td": {"colspan", "rowspan", "headers"},
+    "th": {"colspan", "rowspan", "scope", "headers"},
 }
 
 # Image src URLs are restricted to http(s). ``data:`` and ``javascript:`` are

--- a/backend/tests/test_markup.py
+++ b/backend/tests/test_markup.py
@@ -60,13 +60,13 @@ class TestSanitize:
         out = sanitize(html)
         assert "<tfoot>" in out
 
-    def test_strips_table_attributes(self) -> None:
-        html = '<table class="fancy" style="width:100%"><tr><td colspan="2">x</td></tr></table>'
+    def test_preserves_table_cell_attrs_strips_unsafe(self) -> None:
+        html = '<table class="fancy" style="width:100%"><tr><td colspan="2" style="color:red">x</td></tr></table>'
         out = sanitize(html)
         assert "<table>" in out
         assert "class=" not in out
-        assert "style=" not in out
-        assert "colspan=" not in out
+        assert "style=" not in out  # stripped from table and td alike
+        assert 'colspan="2"' in out  # structural attr preserved
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Fixes #1957

The nh3 sanitizer was stripping all attributes from \	d\ and \	h\ because \_ATTRIBUTES\ had no entries for table-cell elements. This broke any table where the LLM uses \colspan\ or \owspan\.

Added:
- \	d\: \colspan\, \owspan\, \headers\
- \	h\: \colspan\, \owspan\, \scope\, \headers\

These are purely structural HTML attributes — no XSS vector (no URLs, no event handlers, no style injection). \scope\ and \headers\ are included for accessibility screen-reader support.