### PR TITLE
feat(interface): add Enter-to-send toggle in chat input

### DIFF
--- a/frontend/apps/interface/src/components/layout/InputDock.vue
+++ b/frontend/apps/interface/src/components/layout/InputDock.vue
@@ -54,6 +54,10 @@ const hasVisionProvider = ref(true);
 const thinkingMenuOpen = ref(false);
 const thinkingWrapRef = ref<HTMLDivElement | null>(null);
 
+const ENTER_SENDS_KEY = 'chalie:enterSends';
+const enterSends = ref(lsGet(ENTER_SENDS_KEY) === 'true');
+watch(enterSends, (v) => lsSet(ENTER_SENDS_KEY, String(v)));
+
 /** True when there is something to send: non-empty text OR ≥1 attachment.
  *  Mirrors the handleSend guard — both gate on getFiles(). */
 const canSend = computed(
@@ -98,9 +102,15 @@ async function handleSend(): Promise<void> {
   textareaRef.value?.focus();
 }
 
-// Multi-line textarea: Enter inserts a newline and ONLY the send button submits,
-// so there is no keydown handler. Cancelling an in-flight turn is the act-trail's
-// stop/undo button, not the dock.
+/** When enterSends is enabled, Enter submits the message; Shift+Enter always
+ *  inserts a newline. Cancelling an in-flight turn is the act-trail's stop/undo
+ *  button, not the dock. */
+function onTextareaKeydown(e: KeyboardEvent): void {
+  if (e.key === 'Enter' && !e.shiftKey && enterSends.value) {
+    e.preventDefault();
+    void handleSend();
+  }
+}
 
 function chooseDocument(): void {
   attachMenuOpen.value = false;
@@ -291,6 +301,7 @@ onBeforeUnmount(() => {
           placeholder="Talk to Chalie..."
           rows="1"
           @input="grow"
+          @keydown="onTextareaKeydown"
         ></textarea>
 
         <button
@@ -341,6 +352,10 @@ onBeforeUnmount(() => {
         <span class="context-display__caption">Context</span>
         <span class="context-indicator" title="Last request size / context window">{{ usageDisplay }}</span>
       </div>
+      <label class="enter-sends-toggle" :class="{ active: enterSends }" title="Enter sends message">
+        <input v-model="enterSends" type="checkbox" class="enter-sends-toggle__input" />
+        <span class="enter-sends-toggle__label">Enter ↵ sends</span>
+      </label>
     </div>
 
     <!-- No capture attr: lets mobile show the standard OS picker (library +

--- a/frontend/apps/interface/src/styles/interface.scss
+++ b/frontend/apps/interface/src/styles/interface.scss
@@ -675,6 +675,32 @@ body.speaker-user #ambientBloom {
   font-variant-numeric: tabular-nums;
 }
 
+.enter-sends-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 4px;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  color: var(--text-tertiary);
+  user-select: none;
+}
+
+.enter-sends-toggle.active {
+  color: var(--accent-primary);
+}
+
+.enter-sends-toggle__input {
+  width: 12px;
+  height: 12px;
+  accent-color: var(--accent-primary);
+  cursor: pointer;
+}
+
+.enter-sends-toggle__label {
+  line-height: 1;
+}
+
 .voice-rec-btn {
   flex-shrink: 0;
   position: relative;


### PR DESCRIPTION
Fixes #1962

Adds a checkbox toggle in the dock-controls area (next to the Thinking selector and Context display) that lets users switch between Enter-to-send and the default behavior (Enter = newline, button sends).

## Changes

### InputDock.vue
- Added \nterSends\ ref persisted to localStorage (key: \chalie:enterSends\)
- Added \onTextareaKeydown\ handler: Enter without Shift calls \handleSend()\ when toggle is active, Shift+Enter always inserts newline
- Added checkbox \<label>\ in the dock-controls row

### interface.scss
- Added \.enter-sends-toggle\, \.enter-sends-toggle.active\, \.enter-sends-toggle__input\, \.enter-sends-toggle__label\ styles

## Behavior

| Toggle | Enter | Shift+Enter |
|--------|-------|-------------|
| Off (default) | newline | newline |
| On | sends message | newline |