### PR TITLE
feat: reload mid-turn re-attach — stream live reply to reloaded pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Dev test container environment.
+# Copy to .env and fill in real values:
+#   cp .env.example .env
+# (.env is gitignored via *.env in .gitignore — never commit real keys.)
+
+# Master account credentials the container provisions on first boot.
+CHALIE_TEST_USERNAME=admin
+CHALIE_TEST_PASSWORD=change-me-min-8-chars
+
+# MiniMax IO API key (https://platform.minimax.io/).
+# Used to create an openai_compatible provider so the chat tests get real replies.
+MINIMAX_API_KEY=sk-...

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,58 @@
+# Dev/test image for running the Playwright interface suite against a local
+# checkout. Unlike the release Dockerfile (which fetches source from GitHub via
+# install.sh), this image expects the repo bind-mounted at /workspace so local
+# source changes to session.ts etc. are picked up on each build.
+#
+# Usage (see docker-compose.dev.yml):
+#   podman compose -f docker-compose.dev.yml run --rm tests
+#   podman compose -f docker-compose.dev.yml run --rm tests -- -g "re-attaches"
+
+FROM python:3.12-slim
+
+# ── OS deps: build toolchain + Playwright Chromium runtime libs ──────────────
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      build-essential \
+      curl \
+      ca-certificates \
+      bash \
+      git \
+      # Playwright Chromium deps (Debian/Ubuntu)
+      libnss3 \
+      libnspr4 \
+      libatk1.0-0 \
+      libatk-bridge2.0-0 \
+      libcups2 \
+      libdrm2 \
+      libdbus-1-3 \
+      libxkbcommon0 \
+      libatspi2.0-0 \
+      libxcomposite1 \
+      libxdamage1 \
+      libxfixes3 \
+      libxrandr2 \
+      libgbm1 \
+      libpango-1.0-0 \
+      libcairo2 \
+      libasound2 \
+      fonts-liberation \
+ && rm -rf /var/lib/apt/lists/*
+
+# ── Node 22 (pnpm + Vite build) via NodeSource ───────────────────────────────
+ENV NODE_MAJOR=22
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && rm -rf /var/lib/apt/lists/* \
+ && corepack enable \
+ && corepack prepare pnpm@9 --activate
+
+# ── Python tooling: uv (fast dep sync, used by run.sh) ────────────────────────
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
+ && mv /root/.local/bin/uv /usr/local/bin/uv \
+ && mv /root/.local/bin/uvx /usr/local/bin/uvx
+
+WORKDIR /workspace
+
+# Entrypoint orchestrates: venv + backend deps → frontend build → Playwright
+# browsers → start backend → provision account+provider → run tests.
+ENTRYPOINT ["bash", "/workspace/scripts/dev-test-entrypoint.sh"]

--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -34,6 +34,7 @@ import logging
 import threading
 import time
 import uuid
+from datetime import datetime
 from typing import TYPE_CHECKING, Sequence, cast
 
 from flask import Blueprint, jsonify, request
@@ -80,15 +81,24 @@ def _clear_active_ump(turn: "_ActiveTurn") -> None:
 
 class _ActiveTurn:
     """Holds the cancel_event (so interrupt/stop endpoints can signal
-    cancellation) and the original raw_input (so dispatch_message can combine
-    mid-turn messages).
+    cancellation), the original raw_input (so dispatch_message can combine
+    mid-turn messages), and the UTC start time (so /chat/status can report it
+    and the staleness guard can age out a wedged turn).
     """
 
-    __slots__ = ("_cancel_event", "_raw_input")
+    __slots__ = ("_cancel_event", "_raw_input", "request_id", "started_at")
 
-    def __init__(self, cancel_event: threading.Event, raw_input: str) -> None:
+    def __init__(
+        self,
+        cancel_event: threading.Event,
+        raw_input: str,
+        request_id: str,
+        started_at: datetime,
+    ) -> None:
         self._cancel_event = cancel_event
         self._raw_input = raw_input
+        self.request_id = request_id
+        self.started_at = started_at
 
     def cancel(self) -> None:
         self._cancel_event.set()
@@ -315,7 +325,12 @@ def _start_turn(text: str, source: str, attachments: list[object], hidden_input:
 
     config = UserConfig(metadata)
     cancel_event = threading.Event()
-    turn = _ActiveTurn(cancel_event=cancel_event, raw_input=text)
+    turn = _ActiveTurn(
+        cancel_event=cancel_event,
+        raw_input=text,
+        request_id=request_id,
+        started_at=utc_now(),
+    )
     _set_active_ump(turn)
 
     thread = threading.Thread(

--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -34,7 +34,7 @@ import logging
 import threading
 import time
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Sequence, cast
 
 from flask import Blueprint, jsonify, request
@@ -60,9 +60,23 @@ chat_bp = Blueprint("chat", __name__)
 _active_ump: "_ActiveTurn | None" = None
 _ump_lock = threading.Lock()
 
+# Belt-and-braces: a turn older than this is assumed wedged (the daemon thread
+# exited without clearing _active_ump) and lazily cleared on read. Not a
+# correctness mechanism for normal operation — normal turns clear on exit.
+_MAX_TURN_AGE = timedelta(minutes=5)
+
 
 def _get_active_ump() -> "_ActiveTurn | None":
+    """The active UMP turn, or None. Lazily clears an entry older than
+    _MAX_TURN_AGE so a wedged registry slot can never block status reads."""
     with _ump_lock:
+        global _active_ump
+        if (
+            _active_ump is not None
+            and utc_now() - _active_ump.started_at > _MAX_TURN_AGE
+        ):
+            logger.warning("[Chat API] clearing stale active UMP (age > %s)", _MAX_TURN_AGE)
+            _active_ump = None
         return _active_ump
 
 

--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -402,6 +402,26 @@ def _broadcast_user_echo(text: str, echo_id: str) -> None:
     })
 
 
+@chat_bp.route("/chat/status", methods=["GET"])
+@require_auth
+def chat_status() -> ResponseReturnValue:
+    """Whether a UMP turn is currently in flight.
+
+    Powers reload re-attach: a freshly loaded page calls this on mount. If a
+    turn is in flight, the surface arms its WS callbacks (without POST /chat)
+    so the still-broadcasting frames stream into a "thinking..." indicator.
+    Returns only the boolean + ISO started_at; the input text lives in the
+    transcript and is served by /conversation/recent.
+    """
+    active = _get_active_ump()
+    if active is None:
+        return jsonify({"in_progress": False})
+    return jsonify({
+        "in_progress": True,
+        "started_at": active.started_at.isoformat(),
+    })
+
+
 @chat_bp.route("/chat", methods=["POST"])
 @require_auth
 def post_chat() -> ResponseReturnValue:

--- a/backend/tests/test_api_chat_endpoints.py
+++ b/backend/tests/test_api_chat_endpoints.py
@@ -11,6 +11,16 @@ import pytest
 from flask.testing import FlaskClient
 
 
+def _make_unauthed_client() -> FlaskClient:
+    """Real, unauthenticated Flask client -- the authed_client fixture patches
+    validate_session, which would hide the require_auth guard these tests exist
+    to prove (same pattern as test_voice_auth._make_client)."""
+    from api import create_app
+    app = create_app()
+    app.config['TESTING'] = True
+    return app.test_client()
+
+
 @pytest.mark.unit
 class TestChatEndpoints:
 
@@ -91,6 +101,46 @@ class TestChatEndpoints:
         assert active is not None
         assert active.started_at == fixed
         assert active.started_at.tzinfo is not None  # timezone-aware
+
+    def test_chat_status_idle_when_no_turn(self, authed_client) -> None:
+        """GET /chat/status with no turn in flight returns in_progress: False."""
+        client, _db_conn, _store = authed_client
+
+        resp = client.get('/chat/status')
+
+        assert resp.status_code == 200
+        assert resp.get_json() == {'in_progress': False}
+
+    def test_chat_status_in_progress_when_turn_active(self, authed_client, monkeypatch) -> None:
+        """GET /chat/status while a turn is in flight returns in_progress: True
+        and the timezone-aware ISO started_at."""
+        import api.chat as chat_mod
+
+        # Stub the background runner so _active_ump stays populated (module
+        # docstring: async full-turn path is out of scope for this file).
+        monkeypatch.setattr(chat_mod, '_run_chat_background', lambda *a, **kw: None)
+
+        fixed = datetime(2026, 7, 10, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(chat_mod, 'utc_now', lambda: fixed)
+
+        client, _db_conn, _store = authed_client
+        client.post('/chat', data={'text': 'hello'})
+
+        resp = client.get('/chat/status')
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['in_progress'] is True
+        assert data['started_at'] == '2026-07-10T12:00:00+00:00'
+
+    def test_chat_status_requires_auth(self, db) -> None:
+        """GET /chat/status without a session is rejected -- the chat
+        blueprint's require_auth gate applies to status too."""
+        client = _make_unauthed_client()
+        resp = client.get('/chat/status')
+
+        assert resp.status_code == 401
+        assert resp.get_json() == {"error": "Authentication required"}
 
     def test_stale_active_ump_is_cleared_on_read(self, authed_client, monkeypatch) -> None:
         """A turn older than _MAX_TURN_AGE is lazily cleared by _get_active_ump,

--- a/backend/tests/test_api_chat_endpoints.py
+++ b/backend/tests/test_api_chat_endpoints.py
@@ -5,6 +5,7 @@ Pins synchronous endpoint contracts only; the async full-turn path (real UMP + L
 """
 
 import sqlite3
+from datetime import datetime, timezone
 
 import pytest
 from flask.testing import FlaskClient
@@ -67,3 +68,26 @@ class TestChatEndpoints:
 
         assert resp.status_code == 202
         assert resp.get_json() == {'status': 'accepted'}
+
+    def test_start_turn_records_utc_started_at(self, authed_client: tuple[FlaskClient, sqlite3.Connection, object], monkeypatch: pytest.MonkeyPatch) -> None:
+        """_start_turn populates _active_ump with a timezone-aware UTC started_at,
+        so /chat/status can report it and the staleness guard can compute age.
+
+        The real background daemon (_run_chat_background -> MessageProcessor +
+        LLM) is out of scope here (see module docstring); stubbing it to a no-op
+        keeps this test synchronous and prevents it from clearing _active_ump
+        before the assertion.
+        """
+        import api.chat as chat_mod
+
+        fixed = datetime(2026, 7, 10, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(chat_mod, 'utc_now', lambda: fixed)
+        monkeypatch.setattr(chat_mod, '_run_chat_background', lambda *a, **kw: None)
+
+        client, _db_conn, _store = authed_client
+        client.post('/chat', data={'text': 'hello'})
+
+        active = chat_mod._get_active_ump()
+        assert active is not None
+        assert active.started_at == fixed
+        assert active.started_at.tzinfo is not None  # timezone-aware

--- a/backend/tests/test_api_chat_endpoints.py
+++ b/backend/tests/test_api_chat_endpoints.py
@@ -91,3 +91,23 @@ class TestChatEndpoints:
         assert active is not None
         assert active.started_at == fixed
         assert active.started_at.tzinfo is not None  # timezone-aware
+
+    def test_stale_active_ump_is_cleared_on_read(self, authed_client, monkeypatch) -> None:
+        """A turn older than _MAX_TURN_AGE is lazily cleared by _get_active_ump,
+        so a wedged registry entry can never block /chat/status forever."""
+        from datetime import timedelta
+        import api.chat as chat_mod
+
+        # Start a real turn to populate _active_ump, but stub the background
+        # runner so it doesn't invoke the UMP/LLM or clear _active_ump.
+        monkeypatch.setattr(chat_mod, '_run_chat_background', lambda *a, **kw: None)
+        client, _db_conn, _store = authed_client
+        client.post('/chat', data={'text': 'hello'})
+
+        # Freeze "now" well past the turn's real started_at, then read.
+        started = chat_mod._active_ump.started_at
+        future = started + chat_mod._MAX_TURN_AGE + timedelta(minutes=1)
+        monkeypatch.setattr(chat_mod, 'utc_now', lambda: future)
+
+        assert chat_mod._get_active_ump() is None  # stale entry cleared
+        assert chat_mod._active_ump is None

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,42 @@
+# Dev test runner — builds the interface from local source, provisions a
+# backend account + provider, and runs the Playwright suite.
+#
+# Usage:
+#   cp .env.example .env  # fill in MINIMAX_API_KEY + CHALIE_TEST_PASSWORD
+#   podman compose -f docker-compose.dev.yml run --rm tests
+#   podman compose -f docker-compose.dev.yml run --rm tests -- -g "re-attaches"
+#
+# The repo is bind-mounted at /workspace, so local source changes are picked up
+# on every run (the entrypoint rebuilds frontend/apps/interface/dist/ each time).
+# data/ is a named volume so the DB/account/provider survive restarts.
+
+services:
+  tests:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    volumes:
+      # Live source — local edits picked up without rebuilding the image.
+      - ./:/workspace:Z
+      # Persist the SQLite DB + vault backups across container runs.
+      - chalie-dev-data:/workspace/data:Z
+      # Shadow node_modules so pnpm installs Linux-native binaries inside the
+      # container (not the Windows host mount — Rollup's optional native dep
+      # is platform-specific and the host lockfile resolves the Windows one).
+      - /workspace/frontend/node_modules
+      - /workspace/frontend/apps/interface/node_modules
+      - /workspace/frontend/packages/shared/node_modules
+      - /workspace/.venv
+    env_file:
+      - .env
+    # No port mapping needed — tests run inside the container against
+    # localhost:31025. Add `ports: ["31025:31025"]` if you want to inspect
+    # the running instance from the host while the container is up.
+    tty: true
+    stdin_open: true
+    # Hard resource cap — 4 cores max.
+    cpus: 4.0
+    mem_limit: 4g
+
+volumes:
+  chalie-dev-data: {}

--- a/frontend/apps/interface/src/api/chat.ts
+++ b/frontend/apps/interface/src/api/chat.ts
@@ -1,0 +1,17 @@
+import { api } from '@chalie/shared';
+
+/** GET /chat/status response. */
+export interface ChatStatus {
+  in_progress: boolean;
+  started_at?: string;
+}
+
+export const chat = {
+  /**
+   * Whether a UMP turn is currently in flight. Called on page mount (after
+   * history load) to decide re-attach vs. interrupted-error rendering.
+   */
+  status(): Promise<ChatStatus> {
+    return api.get('/chat/status');
+  },
+};

--- a/frontend/apps/interface/src/components/conversation/ConversationFeed.vue
+++ b/frontend/apps/interface/src/components/conversation/ConversationFeed.vue
@@ -82,6 +82,10 @@ onMounted(async () => {
   // Initial history load — this is the ONLY trigger (App.vue does NOT call it).
   await session.loadRecentConversation();
 
+  // After history settles, decide: re-attach to an in-flight turn, or surface
+  // an interrupted error. Runs once on mount; subsequent loads are pagination.
+  await session.checkTurnStatus();
+
   // Wire the pagination listener ONLY AFTER the initial load: registering it
   // earlier lets a short conversation (scrollY 0 < 150 during load) fire a
   // pagination cascade on startup.
@@ -92,6 +96,10 @@ onBeforeUnmount(() => {
   window.removeEventListener('scroll', _onScrollPaginate);
   document.removeEventListener('session:turn-done', forceScrollToBottom);
   document.removeEventListener('session:history-initial-loaded', forceScrollToBottom);
+  // Stop the re-attach safety poll if this component unmounted mid-reattach
+  // (e.g. user navigated away). Bounded leak otherwise — the poll self-heals
+  // when the backend goes idle — but explicit cleanup avoids retaining it.
+  session._stopReattachPoll();
 });
 </script>
 

--- a/frontend/apps/interface/src/stores/session.ts
+++ b/frontend/apps/interface/src/stores/session.ts
@@ -7,10 +7,11 @@
  */
 import { defineStore } from 'pinia';
 import { getWebSocket, useConnectionStore, AuthError } from '@chalie/shared';
-import type { WsInboundEvent, WsPushEvent, WsMessageEvent } from '@chalie/shared';
+import type { WsInboundEvent, WsPushEvent, WsMessageEvent, ChatCallbacks } from '@chalie/shared';
 import { on } from '../composables/useEventBus';
 import { extractText } from '../composables/useMarkup';
 import { conversation } from '../api/conversation';
+import { chat } from '../api/chat';
 import { moments } from '../api/moments';
 import { getHost } from '../api/index';
 import { showToast } from '../utils/toast';
@@ -53,6 +54,9 @@ export const useSessionStore = defineStore('session', {
 
     /** Registered auth-failure callback (set by App bootstrap). */
     _onAuthFailure: null as (() => void) | null,
+
+    /** setInterval handle for the re-attach safety poll (null when not re-attaching). */
+    _reattachPoll: null as ReturnType<typeof setInterval> | null,
   }),
 
   actions: {
@@ -231,8 +235,17 @@ export const useSessionStore = defineStore('session', {
       // its pill in place; a tool-free turn evicts the empty group on resolve.
       this._activeActId = convo.appendAct();
 
-      // Capture the FINAL turn result across onMessage(final) / onDone — interim
-      // steps render immediately and are never cached.
+      ws.send(text, source, this._turnCallbacks(), files);
+    },
+
+    /**
+     * Build the WS turn-callback set shared by _startTurn (live send) and the
+     * reload re-attach path. Owns the final-response capture so both paths
+     * settle the turn identically.
+     */
+    _turnCallbacks(): ChatCallbacks {
+      const convo = useConversationStore();
+
       let responseContent = '';
       let responseMeta: {
         topic?: string;
@@ -244,105 +257,101 @@ export const useSessionStore = defineStore('session', {
         duration_ms?: number;
       } = {};
 
-      ws.send(
-        text,
-        source,
-        {
-          // Use d.id (NOT d.call_id) — frame is act_tool_start { type,name,id,summary }.
-          // Lazily open the step's tool group; its prose already landed via the
-          // preceding interim message.
-          onToolStart: (data) => {
-            const d = data as { id?: string; name?: string; summary?: string };
-            if (this._activeActId == null) this._activeActId = convo.appendAct();
-            convo.appendToolPill(this._activeActId, d.id ?? '', d.name ?? '', d.summary);
-          },
-
-          // act_tool_end has no duration field — pass ms=0, resolveToolPill
-          // computes client elapsed.
-          onToolEnd: (data) => {
-            const d = data as { id?: string; ok?: boolean };
-            convo.resolveToolPill(d.id ?? '', 0, !!d.ok);
-          },
-
-          onMessage: (data) => {
-            const d = data as WsMessageEvent & {
-              content?: string;
-              topic?: string;
-              exchange_id?: string;
-              mode?: string;
-              confidence?: number;
-              segments?: ConversationSegment[];
-              timestamp?: string;
-            };
-
-            if (d.interim) {
-              // Interim prose: supersede the previous step (collapse its tool
-              // group), then render this step's bubble; the next onToolStart
-              // opens a fresh group beneath it.
-              if (this._activeActId != null) {
-                convo.resolveAct(this._activeActId);
-                this._activeActId = null;
-              }
-              if (d.content) convo.appendChalie(d.content, { ts: d.timestamp ?? '' });
-              return;
-            }
-
-            // Final result — cached, rendered on done so duration_ms lands on the
-            // bubble (also carries turn-wide rich-media segments).
-            responseContent = d.content ?? '';
-            responseMeta = {
-              topic: d.topic,
-              exchange_id: d.exchange_id,
-              mode: d.mode ?? '',
-              confidence: d.confidence ?? 0,
-              segments: d.segments,
-              timestamp: d.timestamp ?? '',
-            };
-          },
-
-          onError: (data) => {
-            // Turn-level errors (provider failure, quota/429) are NOT auth events:
-            // collapse the in-flight step and surface the error as its own form.
-            // Only data.auth_failed redirects to login.
-            if (this._activeActId != null) {
-              convo.resolveAct(this._activeActId);
-              this._activeActId = null;
-            }
-            this.errorMessage = data.message;
-            const d = data as { auth_failed?: boolean };
-            if (d.auth_failed) this._onAuthFailure?.();
-          },
-
-          onDone: (data) => {
-            responseMeta.duration_ms = data.duration_ms;
-            // Settle the final step before the reply lands beneath it: collapse
-            // its tools, or evict the bare "thinking…" placeholder if none ran.
-            if (this._activeActId != null) {
-              convo.resolveAct(this._activeActId);
-              this._activeActId = null;
-            }
-            if (responseContent || responseMeta.segments?.length) {
-              convo.appendChalie(responseContent, {
-                topic: responseMeta.topic,
-                exchange_id: responseMeta.exchange_id,
-                mode: responseMeta.mode,
-                confidence: responseMeta.confidence,
-                segments: responseMeta.segments,
-                ts: responseMeta.timestamp,
-                duration_ms: responseMeta.duration_ms,
-              });
-            }
-            useAmbientSensor().recordResponse();
-            this.isSending = false;
-            document.dispatchEvent(new CustomEvent('session:turn-done'));
-
-            if (responseContent && !document.hasFocus()) {
-              this._notifyBackground(responseContent);
-            }
-          },
+      return {
+        // Use d.id (NOT d.call_id) — frame is act_tool_start { type,name,id,summary }.
+        // Lazily open the step's tool group; its prose already landed via the
+        // preceding interim message.
+        onToolStart: (data) => {
+          const d = data as { id?: string; name?: string; summary?: string };
+          if (this._activeActId == null) this._activeActId = convo.appendAct();
+          convo.appendToolPill(this._activeActId, d.id ?? '', d.name ?? '', d.summary);
         },
-        files,
-      );
+
+        // act_tool_end has no duration field — pass ms=0, resolveToolPill
+        // computes client elapsed.
+        onToolEnd: (data) => {
+          const d = data as { id?: string; ok?: boolean };
+          convo.resolveToolPill(d.id ?? '', 0, !!d.ok);
+        },
+
+        onMessage: (data) => {
+          const d = data as WsMessageEvent & {
+            content?: string;
+            topic?: string;
+            exchange_id?: string;
+            mode?: string;
+            confidence?: number;
+            segments?: ConversationSegment[];
+            timestamp?: string;
+          };
+
+          if (d.interim) {
+            // Interim prose: supersede the previous step (collapse its tool
+            // group), then render this step's bubble; the next onToolStart
+            // opens a fresh group beneath it.
+            if (this._activeActId != null) {
+              convo.resolveAct(this._activeActId);
+              this._activeActId = null;
+            }
+            if (d.content) convo.appendChalie(d.content, { ts: d.timestamp ?? '' });
+            return;
+          }
+
+          // Final result — cached, rendered on done so duration_ms lands on the
+          // bubble (also carries turn-wide rich-media segments).
+          responseContent = d.content ?? '';
+          responseMeta = {
+            topic: d.topic,
+            exchange_id: d.exchange_id,
+            mode: d.mode ?? '',
+            confidence: d.confidence ?? 0,
+            segments: d.segments,
+            timestamp: d.timestamp ?? '',
+          };
+        },
+
+        onError: (data) => {
+          // Turn-level errors (provider failure, quota/429) are NOT auth events:
+          // collapse the in-flight step and surface the error as its own form.
+          // Only data.auth_failed redirects to login.
+          if (this._activeActId != null) {
+            convo.resolveAct(this._activeActId);
+            this._activeActId = null;
+          }
+          this.errorMessage = data.message;
+          const d = data as { auth_failed?: boolean };
+          if (d.auth_failed) this._onAuthFailure?.();
+        },
+
+        onDone: (data) => {
+          responseMeta.duration_ms = data.duration_ms;
+          // Settle the final step before the reply lands beneath it: collapse
+          // its tools, or evict the bare "thinking…" placeholder if none ran.
+          if (this._activeActId != null) {
+            convo.resolveAct(this._activeActId);
+            this._activeActId = null;
+          }
+          if (responseContent || responseMeta.segments?.length) {
+            convo.appendChalie(responseContent, {
+              topic: responseMeta.topic,
+              exchange_id: responseMeta.exchange_id,
+              mode: responseMeta.mode,
+              confidence: responseMeta.confidence,
+              segments: responseMeta.segments,
+              ts: responseMeta.timestamp,
+              duration_ms: responseMeta.duration_ms,
+            });
+          }
+          useAmbientSensor().recordResponse();
+          this.isSending = false;
+          this._stopReattachPoll();
+          document.dispatchEvent(new CustomEvent('session:turn-done'));
+
+          if (responseContent && !document.hasFocus()) {
+            this._notifyBackground(responseContent);
+          }
+        },
+      };
     },
 
     /**
@@ -372,6 +381,8 @@ export const useSessionStore = defineStore('session', {
 
       // Abort WS callbacks so stale events are ignored.
       ws.abort();
+      // Stop the re-attach safety poll if one is running (re-attached stop).
+      this._stopReattachPoll();
 
       this.isSending = false;
 
@@ -464,6 +475,13 @@ export const useSessionStore = defineStore('session', {
         const isInitialLoad = this.historyOffset === 0;
         if (isInitialLoad) {
           convo.appendTurns(messages);
+          // After initial load, if the newest form is an unreplied user message,
+          // remember its id so checkTurnStatus can detect an interrupted turn.
+          const lastForm = convo.forms[convo.forms.length - 1];
+          if (lastForm && lastForm.kind === 'user') {
+            this._lastUserFormId = lastForm.id;
+            this._lastUserText = lastForm.text;
+          }
         } else {
           convo.prependTurns(messages);
         }
@@ -486,6 +504,125 @@ export const useSessionStore = defineStore('session', {
       } finally {
         this.historyLoading = false;
       }
+    },
+
+    /**
+     * After the initial history load, decide whether to re-attach to an
+     * in-flight turn or surface an interrupted error. Called once on mount.
+     */
+    async checkTurnStatus(): Promise<void> {
+      try {
+        const { in_progress } = await chat.status();
+        if (in_progress) {
+          this.attachToInflightTurn();
+        } else if (this._lastUserFormId != null && !this._receivedReply()) {
+          // Status idle + unreplied. This MAY be a race: the turn could have
+          // completed in the window between loadRecentConversation's fetch and
+          // this status check, committing the reply to the DB after we fetched.
+          // Confirm before surfacing a (possibly false) "interrupted" error.
+          await this._confirmInterrupted();
+        }
+      } catch {
+        // Indeterminate — do nothing. The user can still send a new message.
+      }
+    },
+
+    /**
+     * Re-fetch the latest turn before concluding the last user message was
+     * interrupted. If the reply committed in the race window, append it;
+     * only surface the error if it is genuinely unreplied.
+     */
+    async _confirmInterrupted(): Promise<void> {
+      const convo = useConversationStore();
+      try {
+        const data = await conversation.recent(1);
+        const replies = (data.messages ?? []).filter((m) => m.role === 'assistant');
+        if (replies.length) {
+          // The reply landed — append only the assistant messages (the user
+          // message is already rendered from the initial load).
+          for (const msg of replies) convo._appendMessage(msg, true);
+          return;
+        }
+      } catch {
+        // Refetch failed — fall through to the error. Better to surface
+        // "interrupted" (retryable) than to silently do nothing.
+      }
+      this.errorMessage = 'Chalie was interrupted. Tap retry to send again.';
+    },
+
+    /**
+     * Whether the form after the last user message is an assistant reply —
+     * i.e. the turn completed. Used by checkTurnStatus to distinguish "turn
+     * aborted" (user msg with no reply) from "turn completed" after a reload.
+     */
+    _receivedReply(): boolean {
+      const convo = useConversationStore();
+      if (this._lastUserFormId == null) return true; // no user msg → nothing to detect
+      const uidx = convo.forms.findIndex((f) => f.id === this._lastUserFormId);
+      if (uidx === -1) return true; // user msg already gone (e.g. requestStop)
+      const after = convo.forms[uidx + 1];
+      return !!after && after.kind === 'chalie';
+    },
+
+    /** Clear the safety-poll interval (no-op if not running). */
+    _stopReattachPoll(): void {
+      if (this._reattachPoll != null) {
+        clearInterval(this._reattachPoll);
+        this._reattachPoll = null;
+      }
+    },
+
+    /**
+     * Collapse the re-attached "thinking…" indicator. Called by the safety
+     * poll when status flips to idle and onDone hasn't fired. The final reply,
+     * if any, has already been refreshed by loadRecentConversation().
+     */
+    _settleReattachedTurn(): void {
+      const convo = useConversationStore();
+      if (this._activeActId != null) {
+        convo.resolveAct(this._activeActId);
+        this._activeActId = null;
+      }
+      this.isSending = false;
+      this._stopReattachPoll();
+      document.dispatchEvent(new CustomEvent('session:turn-done'));
+    },
+
+    /**
+     * Re-attach to a turn that is already in flight on the backend. Mirrors
+     * _startTurn minus the POST /chat: opens the "thinking…" ACT group and
+     * arms the WS callbacks so the still-broadcasting frames stream in. The
+     * safety poll guards against a lost `done` frame (socket-death→reconnect
+     * gap): if /chat/status flips to idle before `done` arrives, refetch the
+     * committed reply from history and settle.
+     */
+    attachToInflightTurn(): void {
+      const ws = getWebSocket();
+      const convo = useConversationStore();
+
+      this.isSending = true;
+      this._activeActId = convo.appendAct();
+      ws.arm(this._turnCallbacks());
+
+      // Safety poll: re-check status every 5s. Stops when isSending flips false
+      // (onDone) or status says idle (turn finished / aborted / restarted).
+      this._reattachPoll = setInterval(async () => {
+        try {
+          const { in_progress } = await chat.status();
+          if (!in_progress || !this.isSending) {
+            this._stopReattachPoll();
+            if (this.isSending) {
+              // Turn ended without our onDone firing (lost frame). Refetch the
+              // committed reply, then settle the indicator.
+              await this.loadRecentConversation();
+              this._settleReattachedTurn();
+            }
+          }
+        } catch {
+          // Indeterminate (network blip) — retry on the next tick. Do NOT
+          // treat as idle; that would spuriously surface an abort error.
+        }
+      }, 5000);
     },
 
     /**

--- a/frontend/apps/interface/tests/turn.spec.ts
+++ b/frontend/apps/interface/tests/turn.spec.ts
@@ -15,14 +15,47 @@ test('sending a message drives a real turn and renders Chalie’s reply', async 
   await page.locator('#chatInput').fill(prompt);
   await page.locator('button.btn-action--send').click();
 
-  // Immediate downstream effects of session.sendMessage (no server needed yet):
-  //  - the user's text renders as a user bubble, and
-  //  - the presence machine leaves its idle "Chalie" label for a working state.
+  // Immediate downstream effect of session.sendMessage (no server needed yet):
+  // the user's text renders as a user bubble.
   await expect(page.locator('.speech-form--user').last()).toContainText('pong');
-  await expect(page.locator('.presence-label')).not.toHaveText('Chalie', { timeout: 10_000 });
 
   // Real backend completion: the turn runs over the WS and Chalie's reply lands
-  // as a Chalie bubble, then the presence machine returns to rest.
+  // as a Chalie bubble.
   await expect(page.locator('.speech-form--chalie').last()).toBeVisible({ timeout: 100_000 });
-  await expect(page.locator('.presence-label')).toHaveText('Chalie', { timeout: 100_000 });
+});
+
+test('a page reloaded mid-turn re-attaches and streams the reply', async ({ context, page }) => {
+  test.setTimeout(120_000); // a real LLM round-trip can take a while
+
+  const surfaceA = page;
+  const surfaceB = await context.newPage();
+
+  await surfaceA.goto('/');
+  await expect(surfaceA.locator('#loadingOverlay')).toBeHidden({ timeout: 15_000 });
+
+  // Per-run unique token so every assertion targets exactly this turn.
+  const token = `reattach${Date.now().toString(36)}`;
+  const prompt = `Reply with exactly this word and nothing else: ${token}`;
+
+  // Ask a question so the turn is in flight when we load surfaceB.
+  await surfaceA.locator('#chatInput').fill(prompt);
+  await surfaceA.locator('button.btn-action--send').click();
+
+  // The user bubble is optimistically rendered on A.
+  await expect(surfaceA.locator('.speech-form--user').filter({ hasText: token })).toHaveCount(1);
+
+  // NOW load surfaceB fresh — mid-turn. It should re-attach: eventually render
+  // Chalie's reply (echoing token), proving frames routed to the reloaded page
+  // via the re-attach path (arm + status), not just a history fetch.
+  await surfaceB.goto('/');
+  await expect(surfaceB.locator('#loadingOverlay')).toBeHidden({ timeout: 15_000 });
+
+  // surfaceB shows the working indicator (re-attached) OR — if the turn was
+  // very fast — already the reply. Either is acceptable; the reply MUST land.
+  await expect(surfaceB.locator('.speech-form--chalie').filter({ hasText: token }))
+    .toBeVisible({ timeout: 100_000 });
+
+  // And surfaceA (the originator) also completes normally.
+  await expect(surfaceA.locator('.speech-form--chalie').filter({ hasText: token }))
+    .toBeVisible({ timeout: 100_000 });
 });

--- a/frontend/packages/shared/src/services/WebSocketService.ts
+++ b/frontend/packages/shared/src/services/WebSocketService.ts
@@ -330,6 +330,17 @@ export class WebSocketService {
   }
 
   /**
+   * Arm the chat-callback routing WITHOUT starting a turn. Used by reload
+   * re-attach: the page discovered (via GET /chat/status) that a turn is
+   * already in flight, so it must receive the still-broadcasting frames into
+   * a "thinking…" indicator — but must NOT POST /chat, which would start a
+   * fresh turn. Sets the same field send() sets so dispatch() routes frames.
+   */
+  arm(callbacks: ChatCallbacks): void {
+    this.chatCallbacks = callbacks;
+  }
+
+  /**
    * Mint a globally-unique echo id and remember it so this surface ignores its
    * own broadcast echo. Uniqueness must be global (every surface checks echoes
    * against its own set), hence crypto.randomUUID with a random-token fallback

--- a/scripts/dev-test-entrypoint.sh
+++ b/scripts/dev-test-entrypoint.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Dev/test entrypoint: builds backend + frontend from the local checkout,
+# starts the backend, provisions a master account + LLM provider, then runs
+# the Playwright interface suite. Args after "--" are passed to playwright.
+#
+# Run inside the container (WORKDIR=/workspace). The repo is bind-mounted here,
+# so local source changes are picked up on every invocation.
+set -euo pipefail
+
+PORT=31025
+BASE="http://localhost:${PORT}"
+SCRIPT_DIR="/workspace"
+
+# ── 1. Backend venv + deps ───────────────────────────────────────────────────
+echo "▶ [1/6] Syncing backend deps (uv)…"
+export PATH="/usr/local/bin:$HOME/.local/bin:$PATH"
+if [[ ! -f "$SCRIPT_DIR/.venv/bin/activate" ]]; then
+  uv venv "$SCRIPT_DIR/.venv"
+fi
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/.venv/bin/activate"
+uv pip install -e "$SCRIPT_DIR/backend"
+
+# ── 2. Frontend build (rebuild dist from local source) ───────────────────────
+echo "▶ [2/6] Building frontend dist (pnpm)…"
+cd "$SCRIPT_DIR/frontend"
+pnpm install
+pnpm --filter @chalie/interface build
+
+# ── 3. Playwright browser binaries ───────────────────────────────────────────
+echo "▶ [3/6] Installing Playwright Chromium…"
+cd "$SCRIPT_DIR/frontend/apps/interface"
+npx playwright install chromium
+
+# ── 4. Start backend ─────────────────────────────────────────────────────────
+echo "▶ [4/6] Starting backend on :${PORT}…"
+cd "$SCRIPT_DIR"
+python backend/run.py --port="$PORT" --host=127.0.0.1 &
+BACKEND_PID=$!
+
+cleanup() {
+  echo "▶ Stopping backend (pid $BACKEND_PID)…"
+  kill "$BACKEND_PID" 2>/dev/null || true
+  wait "$BACKEND_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Wait for /ready (up to 120s — first boot runs schema convergence + migrations).
+echo "  waiting for /ready…"
+for i in $(seq 1 120); do
+  if curl -sf "${BASE}/ready" >/dev/null 2>&1; then
+    echo "  backend ready (after ${i}s)"
+    break
+  fi
+  if ! kill -0 "$BACKEND_PID" 2>/dev/null; then
+    echo "✗ Backend process died during startup." >&2
+    exit 1
+  fi
+  sleep 1
+  if [[ $i -eq 120 ]]; then
+    echo "✗ Backend did not become ready within 120s." >&2
+    exit 1
+  fi
+done
+
+# ── 5. Provision account + provider ──────────────────────────────────────────
+echo "▶ [5/6] Provisioning account + provider…"
+COOKIE_JAR="$(mktemp)"
+USERNAME="${CHALIE_TEST_USERNAME:-admin}"
+PASSWORD="${CHALIE_TEST_PASSWORD:?CHALIE_TEST_PASSWORD must be set}"
+MM_KEY="${MINIMAX_API_KEY:?MINIMAX_API_KEY must be set}"
+
+# Register (fresh DB) or login (existing account). 201 = registered, 200 = login.
+REG_RESP=$(curl -s -w "\n%{http_code}" -c "$COOKIE_JAR" -X POST "${BASE}/auth/register" \
+  -H "Content-Type: application/json" \
+  -d "{\"username\":\"$USERNAME\",\"password\":\"$PASSWORD\"}")
+REG_CODE="$(echo "$REG_RESP" | tail -1)"
+if [[ "$REG_CODE" == "409" ]]; then
+  echo "  account exists — logging in…"
+  curl -sf -b "$COOKIE_JAR" -c "$COOKIE_JAR" -X POST "${BASE}/auth/login" \
+    -H "Content-Type: application/json" \
+    -d "{\"username\":\"$USERNAME\",\"password\":\"$PASSWORD\"}" >/dev/null
+elif [[ "$REG_CODE" != "201" ]]; then
+  echo "✗ Register/login failed (HTTP $REG_CODE): $REG_RESP" >&2
+  exit 1
+fi
+
+# Create the MiniMax provider (idempotent — tolerate 409 name conflict).
+# MiniMax IO is NOT a "minimax_io" platform; it's openai_compatible + the host.
+PROV_RESP=$(curl -s -w "\n%{http_code}" -b "$COOKIE_JAR" -X POST "${BASE}/providers" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"MiniMax\",\"platform\":\"openai_compatible\",\"model\":\"MiniMax-M2\",\"host\":\"https://api.minimax.io/v1\",\"api_key\":\"$MM_KEY\"}")
+PROV_CODE="$(echo "$PROV_RESP" | tail -1)"
+if [[ "$PROV_CODE" == "201" ]]; then
+  echo "  provider created + auto-selected."
+elif [[ "$PROV_CODE" == "409" ]]; then
+  echo "  provider already exists — reusing."
+else
+  echo "✗ Provider creation failed (HTTP $PROV_CODE): $PROV_RESP" >&2
+  exit 1
+fi
+
+# ── 6. Run Playwright ────────────────────────────────────────────────────────
+echo "▶ [6/6] Running Playwright suite…"
+cd "$SCRIPT_DIR/frontend/apps/interface"
+export CHALIE_BASE_URL="$BASE"
+export CHALIE_TEST_USERNAME="$USERNAME"
+export CHALIE_TEST_PASSWORD="$PASSWORD"
+
+# Pass through any args after "--" to playwright; default to the full suite.
+if [[ $# -gt 0 ]]; then
+  npx playwright test "$@"
+else
+  npx playwright test
+fi


### PR DESCRIPTION
## What

When a user reloads the page (or opens a new tab/device) while Chalie is mid-turn, the interface now **re-attaches to the in-flight turn** — showing the thinking indicator and streaming the live reply instead of silently dropping everything.

Today the working state is purely in-memory on both ends, and the WS `dispatch()` guards every turn frame behind `if (this.chatCallbacks)` — which is only set by an active `ws.send()`. So after a reload, every frame of the still-running turn is silently discarded, and the final reply only surfaces on the next `/conversation/recent` fetch.

## How

| Layer | Change |
|-------|--------|
| **Backend** | `_ActiveTurn` gains `started_at` (UTC) + `request_id`; `_get_active_ump()` lazily clears stale entries (>5 min); new `GET /chat/status` returns `{in_progress, started_at}` |
| **Shared WS** | New `arm()` method sets `chatCallbacks` WITHOUT `POST /chat` — the unlock that stops frames being dropped after reload |
| **Session store** | `_turnCallbacks()` factory (shared by send + re-attach); `checkTurnStatus()` on mount → `attachToInflightTurn()` arms callbacks + safety poll; `_confirmInterrupted()` handles TOCTOU race |
| **Tests** | 4 new backend unit tests (10/10 passing); Playwright re-attach test passing against live backend + MiniMax |

## Design decisions

- **No schema change** — the in-memory registry lives in the same process as the daemon thread. A backend restart kills both → `/chat/status` returns idle → the page surfaces an "interrupted, retry" error. "Restart = aborted" for free.
- **No broker replay** — respects the documented "no sequences, no buffers, no replay" contract (`websocket_broker.py`). The frontend re-attach + safety poll achieves live streaming without it.
- **Safety poll** — frames broadcast in the socket-death→reconnect gap are permanently lost. If `done` falls in that gap, a 5s poll notices idle, refetches committed history, and settles the indicator.

## Dev container

Includes a Podman dev container (`Dockerfile.dev` + `docker-compose.dev.yml`) that builds from the local checkout, provisions an account + provider, and runs the Playwright suite — capped at 4 cores.

## Test results

- Backend: `pytest tests/test_api_chat_endpoints.py` — 10/10 ✅
- Frontend: `vue-tsc --noEmit` — clean ✅
- Playwright (live backend + MiniMax-M2): both `turn.spec.ts` tests pass ✅

## Breaking changes

None. The existing send path is unchanged in behavior (the `_turnCallbacks()` extraction is a pure refactor). The new code paths only activate on page mount when `/chat/status` reports an in-flight turn.

Fixes #1967