### PR TITLE
fix(scheduler): run scheduled work loop under CHAT policy, not SUBCONSCIOUS

### DIFF
--- a/backend/configs/channels/scheduled.py
+++ b/backend/configs/channels/scheduled.py
@@ -44,7 +44,13 @@ class ScheduledConfig(ProcessorConfig):
         super().__init__(
             channel=Channel.SCHEDULE.value,
             role="user",
-            policy_channel=PolicyChannel.SUBCONSCIOUS,
+            # CHAT, not SUBCONSCIOUS: a fired schedule is work the user queued on
+            # their own behalf, so it runs under the user's own policy rows —
+            # where web_search/web_browse are seeded allow — exactly as the
+            # tool-surface note above and the system prompt already promise.
+            # SUBCONSCIOUS is the silent-housekeeping family that seeds the web
+            # delegates deny; borrowing it here hard-blocked scheduled web work.
+            policy_channel=PolicyChannel.CHAT,
             always_available=list(DEFAULT_ALWAYS_AVAILABLE),
             skip_transcript=False,
             skip_input_row=False,


### PR DESCRIPTION
## What

Fixes #1968 — `web_search` (and `web_browse`) were hard-blocked when triggered by an alarm/scheduled prompt.

A fired scheduled prompt is work the **user queued on their own behalf** ("search for X at 9am"), but the scheduled work loop ran under `PolicyChannel.SUBCONSCIOUS` — the channel family reserved for silent housekeeping loops (episode encoding, pattern/fact extraction). The static policy seed denies web access on that channel:

`backend/abilities/assets/policy_defaults.json`
```json
{"channel": "subconscious", "permission": "web_browse", "setting": "deny"},
{"channel": "subconscious", "permission": "web_search", "setting": "deny"}
```

So a fired scheduled task calling `web_search` resolved `(subconscious, web_search)` → `deny` and got `"The web_search action is not allowed. Do NOT retry."` — the model gave up and the user's scheduled task failed.

## Fix

`ScheduledConfig` now declares its policy channel as `CHAT` — where `web_search`/`web_browse` are seeded `allow`:

`backend/configs/channels/scheduled.py`
```diff
-            policy_channel=PolicyChannel.SUBCONSCIOUS,
+            policy_channel=PolicyChannel.CHAT,
```

The policy channel is owned by the **config**, not injected by the service — the config is the single authority for its own contract. This matches what the scheduled channel already assumes in two places on this branch:
1. Its source comment: *"every DISCOVERABLE tool (including the web delegates) is reachable, exactly like UserConfig."*
2. Its system prompt tells the model to *"use your tools to gather whatever you need (search, read, …)."*

The rejected alternative — adding an `allow` row for `(subconscious, web_search)` — would also unblock the genuine housekeeping loops, which must never touch the web via the gated delegates.

> **Note:** retargeted to `feat/thread-system` and rebuilt onto that branch — the scheduler was refactored there so the policy channel is now owned by `ScheduledConfig` rather than passed in by `scheduler_service.py`, which is where this fix belongs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Fixes #1968
