### PR TITLE
fix(scheduler): defer prompt items when vault is locked instead of dropping them

### DIFF
--- a/backend/services/scheduler_service.py
+++ b/backend/services/scheduler_service.py
@@ -175,8 +175,12 @@ def _poll_and_fire() -> None:
 
                     if skip:
                         logger.debug(f"{LOG_PREFIX} Skipping {item['id']} — quiet hours / weekend")
-                    else:
-                        _fire_item(item)
+                    elif not _fire_item(item):
+                        # Deferred (e.g. vault locked on a prompt): leave the row
+                        # 'pending' and do NOT generate its next occurrence, or the
+                        # schedule would duplicate every poll until it fires. It is
+                        # retried in place on the next cycle — see _fire_item.
+                        continue
                     cursor.execute(
                         "UPDATE scheduled_items SET status='fired', last_fired_at=? WHERE id=?",
                         (now_iso, item["id"])
@@ -305,8 +309,14 @@ def _build_departure_advisory(item: dict[str, object]) -> str | None:
     return None
 
 
-def _fire_item(item: dict[str, object]) -> None:
-    """Fire a due item — directly or via LLM pipeline depending on item_type."""
+def _fire_item(item: dict[str, object]) -> bool:
+    """Fire a due item — directly or via LLM pipeline depending on item_type.
+
+    Returns ``True`` if the item ran (or was dispatched), ``False`` if it was
+    deferred and should stay ``pending`` for the next poll cycle. A prompt is
+    deferred when the vault is locked: its daemon thread cannot resolve the
+    provider API key and would crash silently after the item is stamped fired.
+    """
     advisory = _build_departure_advisory(item)
     message = cast(str, item.get("message", ""))
     if advisory:
@@ -326,13 +336,26 @@ def _fire_item(item: dict[str, object]) -> None:
                 logger.error(f"{LOG_PREFIX} System handler '{handler_key}' failed: {exc}")
         else:
             logger.warning(f"{LOG_PREFIX} No system handler for topic '{handler_key}'")
-        return
+        return True
 
     if is_prompt:
-        # Guard: empty/whitespace prompts are not actionable
+        # Guard: empty/whitespace prompts are a permanent data defect (not a
+        # transient condition like a locked vault). Stamp fired and move on —
+        # returning False would retry them every 60s forever.
         if not message or not message.strip():
             logger.warning(f"{LOG_PREFIX} Skipping prompt item '{item.get('id', '?')}' — empty message")
-            return
+            return True
+        # Defer when the vault is locked: the work loop calls build_client(),
+        # which calls _unseal_api_key() → returns None when the DEK is not in
+        # memory → ValueError "provider requires 'api_key'", killing the daemon
+        # thread after the item was already stamped fired. Staying 'pending'
+        # lets the next 60s poll retry once the vault is unlocked.
+        from services.vault_service import get_vault_service
+        if not get_vault_service().is_unlocked():
+            logger.warning(
+                f"{LOG_PREFIX} Vault locked — deferring prompt item '{item.get('id', '?')}'"
+            )
+            return False
         # Fire asynchronously: the two-stage work runs the full LLM ACT loop and
         # must NOT execute on the scheduler poll thread, which is mid-transaction
         # claiming/marking items. A nested write commit on the shared thread-local
@@ -355,6 +378,7 @@ def _fire_item(item: dict[str, object]) -> None:
             'content': sanitize(message),
         })
         logger.info(f"{LOG_PREFIX} Fired {source} (direct) '{item.get('id')}': {message[:80]}")
+    return True
 
 
 def _run_scheduled_work_loop(message: str) -> str:

--- a/backend/tests/test_tkt926_per_source_profiles.py
+++ b/backend/tests/test_tkt926_per_source_profiles.py
@@ -66,6 +66,23 @@ def _inject_fake_client(send_fn: Callable[[ProviderApiRequest], ProviderApiRespo
         setattr(Providers, '_resolve', original)
 
 
+@contextlib.contextmanager
+def _vault_unlocked() -> Generator[None, None, None]:
+    """Set the vault to the unlocked state for the duration of the block.
+
+    ``_fire_item`` defers prompt items when ``is_unlocked()`` is False (DEK not
+    in memory). Tests that drive the scheduled poll happy path must hold the
+    vault open so the prompt is not deferred to the next cycle.
+    """
+    from services.vault_service import _vault_state
+    held_dek = _vault_state.dek
+    _vault_state.dek = b"test-dek-not-None"
+    try:
+        yield
+    finally:
+        _vault_state.dek = held_dek
+
+
 def _text_response(text: str) -> ProviderApiResponse:
     return ProviderApiResponse(
         text=text, model="test-model", provider="mock", tool_calls=None,
@@ -493,6 +510,18 @@ def _join_threads(prefix: str, timeout: float = 15.0) -> None:
             t.join(timeout)
 
 
+def _assert_no_thread(name: str) -> None:
+    """Assert no live background thread named exactly ``name`` exists.
+
+    The complement of _join_threads: proves a deferred item never spawned its
+    daemon thread in the first place (the deferral happens before start()).
+    """
+    alive = [t.name for t in threading.enumerate() if t.name == name]
+    assert not alive, (
+        f"no thread named {name!r} should exist; found {alive!r}"
+    )
+
+
 def _transcript_rows(db: sqlite3.Connection, channel: str, role: str | None = None) -> list[str]:
     sql = "SELECT content FROM transcript WHERE channel=?"
     params: list[str] = [channel]
@@ -551,7 +580,10 @@ def test_scheduled_poll_claims_item_then_surfaces_two_stage_on_user(db: sqlite3.
         # scheduled result the Stage-2 user turn relays; Stage-2 echoes it back.
         return _text_response(result_text)
 
-    with _inject_fake_client(_send):
+    # This test covers the happy path: the vault is unlocked, so the prompt is
+    # not deferred. _fire_item checks is_unlocked() before spawning the work
+    # thread; without a DEK in memory it would defer (stay 'pending').
+    with _inject_fake_client(_send), _vault_unlocked():
         scheduler_service._poll_and_fire()
         # Stage 1 (work loop + dispatch) runs on scheduled-work-<id>; it spawns
         # the Stage-2 chat-<id> thread synchronously before returning, so join it
@@ -598,4 +630,65 @@ def test_scheduled_poll_claims_item_then_surfaces_two_stage_on_user(db: sqlite3.
         "the return hop must not write a synthetic user input row "
         "(hidden_input=True) — the scheduled result is the model's reply, not a "
         "faked user message"
+    )
+
+
+def test_scheduled_poll_defers_prompt_when_vault_locked(db: sqlite3.Connection, store: object) -> None:
+    """When the vault is locked at fire time, a due prompt must defer, not drop.
+
+    Regression for #1949: _fire_item previously returned None and the caller
+    stamped status='fired' unconditionally, so a prompt whose daemon thread
+    crashed (no API key) was silently lost. Now _fire_item returns False when
+    the vault is locked, the row stays 'pending' for the next poll, and —
+    critically — no next-occurrence row is generated (or a recurring schedule
+    would duplicate every cycle until it fires).
+
+    Drives the real _poll_and_fire() entry point with the vault held locked.
+    The deferral happens before any thread is spawned, so no LLM seam is
+    reached; _assert_no_thread is the guard that proves no work thread ran.
+    """
+    from services import scheduler_service
+    from services.time_utils import utc_now
+
+    item_id = "sched-defer-1"
+    instruction = "morning briefing"
+    due_at = (utc_now() - timedelta(minutes=1)).isoformat()
+    db.execute(
+        "INSERT INTO scheduled_items (id, item_type, message, due_at, status, is_prompt, recurrence) "
+        "VALUES (?, 'prompt', ?, ?, 'pending', 1, 'daily')",
+        (item_id, instruction, due_at),
+    )
+    db.commit()
+
+    def _explode(_dto: ProviderApiRequest) -> ProviderApiResponse:
+        # If the deferral is bypassed, the daemon thread's work loop reaches
+        # this client. Its assertion fires on that daemon thread (logged, not
+        # raised to pytest) — _assert_no_thread below is the real guard. The
+        # client is here so a bypass is noisy in logs, not silent.
+        raise AssertionError("work loop ran despite vault locked — deferral bypassed")
+
+    # Vault held LOCKED: _vault_state.dek is None (the default test state).
+    with _inject_fake_client(_explode):
+        scheduler_service._poll_and_fire()
+        # No daemon thread should have been spawned for this item.
+        _assert_no_thread(f"scheduled-work-{item_id}")
+
+    # The row stays 'pending' — the deferral the bug dropped silently.
+    status = db.execute(
+        "SELECT status FROM scheduled_items WHERE id=?", (item_id,)
+    ).fetchone()[0]
+    assert status == "pending", (
+        f"a deferred prompt must stay 'pending' for the next poll; got {status!r}"
+    )
+
+    # No duplicate next-occurrence row was generated — the schedule does not
+    # fork on every poll while waiting for the vault. The original row is the
+    # only one carrying this instruction.
+    count = db.execute(
+        "SELECT COUNT(*) FROM scheduled_items WHERE message=?",
+        (instruction,),
+    ).fetchone()[0]
+    assert count == 1, (
+        f"deferred item must not generate a next-occurrence row (would duplicate "
+        f"every cycle); found {count} rows with its instruction"
     )


### PR DESCRIPTION
## What

Fixes #1949 — scheduled prompt items were silently dropped when the vault was locked at fire time. The item was marked `fired` in the DB, the daemon thread crashed (no API key), and no retry or notification occurred.

## Root cause

In `_poll_and_fire()`, the flow for each due item was:

1. `_fire_item(item)` — for prompts, spawns a daemon thread and returns immediately
2. The item is **immediately** stamped `status='fired'` in the DB — regardless of whether `_fire_item` actually did anything (`scheduler_service.py:180-183`)
3. Next occurrence row inserted

`_fire_item` was typed `-> None`, so the caller had no signal to distinguish "fired" from "deferred". When the vault was locked, the daemon thread's work loop hit:

```
build_client() → _unseal_api_key() → None (DEK not in memory)
→ ValueError: openai_compatible provider requires 'api_key' field
```

The thread crashed, but the item was already `fired` — silently lost, never retried.

## Fix

**`_fire_item` now returns `bool`** — `False` when a prompt is deferred (vault locked), `True` when it ran or was handled.

**The caller `continue`s on deferral** — skipping both the `status='fired'` stamp AND the next-occurrence generation. A deferred item stays `pending` and is retried on the next 60s poll cycle. Skipping the next-occurrence generation is critical: without it, a recurring schedule would fork a duplicate row every cycle while waiting for the vault.

```python
# scheduler_service.py — _poll_and_fire
if skip:
    logger.debug(...)                          # quiet hours: stamps fired below
elif not _fire_item(item):
    continue                                   # deferred: stays pending, no next row
cursor.execute("UPDATE scheduled_items SET status='fired', ...")
# next-occurrence generation runs only for skip / fired items
```

```python
# scheduler_service.py — _fire_item (prompt branch)
if not get_vault_service().is_unlocked():
    logger.warning(f"... Vault locked — deferring prompt item '{id}'")
    return False   # stays 'pending', retried next cycle
```

### Empty-prompt guard

The empty-message guard now returns `True` (handled — stamp `fired`), not `False`. An empty prompt is a permanent data defect, not a transient condition like a locked vault — returning `False` would retry it every 60s forever.

## Why this differs from the ticket's suggested fix

The ticket proposed checking `is_unlocked()` inside `_fire_item` and returning early. But `_fire_item` was `-> None`, so the caller would still have stamped `status='fired'` right after — the item would still be lost. The fix requires `_fire_item` to signal deferral back to the caller, and the caller must skip both the stamp and the next-occurrence generation. Commented on #1949.

## Review

This change went through an independent critic subagent pass (per the branch-and-ship Major workflow). The critic caught two regressions in the first iteration:
1. The next-occurrence block ran unconditionally for deferred items → duplicate rows every poll. Fixed with the `continue`.
2. The empty-prompt guard returned `False` → infinite retry. Fixed to return `True`.

Both were verified empirically; the regression test was confirmed to fail without the fix.

## Verification

- `ruff check` — clean
- `mypy --strict` — no issues
- `pytest -m unit -q` — 371 passed (1 pre-existing failure in `test_browser_screenshot_ingest`, unrelated — `Pillow` not installed in this env)
- **Done-gate #4**: `test_scheduled_poll_defers_prompt_when_vault_locked` drives the real `_poll_and_fire` with the vault locked; asserts item stays `pending`, no work thread spawned, no duplicate next-occurrence row. **Verified to fail without the fix** (`status='fired'`, thread spawned).
- Updated the existing happy-path test (`test_scheduled_poll_claims_item_then_surfaces_two_stage_on_user`) to hold the vault unlocked via a `_vault_unlocked()` context manager.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change

Fixes #1949