### PR TITLE
fix(run.sh): auto-restart on crash with exponential backoff (#1878 pt.3)

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -62,16 +62,54 @@ fi
 _install -e "$SCRIPT_DIR/backend"
 
 # ─── Launch ──────────────────────────────────────────────────────────────────
-# Loop: Python exits with code 42 to request a restart (e.g. after in-place update).
-# Any other exit code passes through normally.
+# Supervised restart loop. Exit codes:
+#   42  → intentional restart (restart_service.py: snapshot import, in-place
+#         update) → re-sync deps and relaunch immediately. Resets the crash
+#         counter — a clean restart is never penalised.
+#   0   → clean shutdown → exit 0, do not loop.
+#   *   → crash / OOM / uncaught exception → relaunch with exponential backoff.
+#         After MAX_CRASHES consecutive crashes without a clean run, give up and
+#         surface the last exit code (a deterministically-fatal startup loops
+#         forever otherwise — log flooding, CPU churn). A run that stays up
+#         longer than RUN_HEALTHY_SECS resets the crash counter.
+MAX_CRASHES=5
+RUN_HEALTHY_SECS=30
+_crashes=0
+_backoff=1
+
 while true; do
   # set -e would kill the script on run.py's non-zero exit before we could
   # read it, defeating the restart loop. Capture via `||` (exempt from errexit).
+  _start=$SECONDS
   _EXIT=0
   "$PYTHON" "$SCRIPT_DIR/backend/run.py" --port="$_PORT" --host="$_HOST" || _EXIT=$?
-  if [[ "$_EXIT" -ne 42 ]]; then
-    exit $_EXIT
+
+  # Intentional restart: re-sync deps, relaunch immediately, reset crash state.
+  if [[ "$_EXIT" -eq 42 ]]; then
+    echo "→ Restart requested (exit 42). Re-syncing deps and relaunching..."
+    _install -e "$SCRIPT_DIR/backend"
+    _crashes=0
+    _backoff=1
+    continue
   fi
-  echo "→ Restart requested (exit 42). Re-syncing deps and relaunching..."
-  _install -e "$SCRIPT_DIR/backend"
+
+  # Clean shutdown: exit without looping.
+  if [[ "$_EXIT" -eq 0 ]]; then
+    exit 0
+  fi
+
+  # Crash: back off and retry, up to the cap. A run that stayed up long enough
+  # to be healthy resets the counter — only rapid repeated crashes escalate.
+  if (( SECONDS - _start >= RUN_HEALTHY_SECS )); then
+    _crashes=0
+    _backoff=1
+  fi
+  _crashes=$((_crashes + 1))
+  if [[ "$_crashes" -gt "$MAX_CRASHES" ]]; then
+    echo "→ Process crashed ($MAX_CRASHES consecutive times). Giving up (exit $_EXIT)." >&2
+    exit "$_EXIT"
+  fi
+  echo "→ Process crashed (exit $_EXIT). Retry $_crashes/$MAX_CRASHES in ${_backoff}s..." >&2
+  sleep "$_backoff"
+  _backoff=$((_backoff * 2))
 done


### PR DESCRIPTION
## What

Part 3 of #1878 — auto-recovery from crashes instead of a full lockout.

`run.sh`'s restart loop only relaunched on exit code 42 (intentional self-restart via `restart_service.py`). Any other non-zero exit — a crash, OOM, or uncaught exception — passed straight through to `exit`, terminating the process with no recovery. Every crash became a full lockout until a human re-ran the launcher.

## The fix

Extend the loop to supervise crashes with three explicit exit-code paths:

| Exit code | Meaning | Behavior |
|---|---|---|
| **42** | Intentional restart (`restart_service.py`) | Re-sync deps + relaunch immediately (unchanged). Now also resets the crash counter. |
| **0** | Clean shutdown | `exit 0` — don't loop (now explicit). |
| **other** | Crash / OOM / uncaught exception | Relaunch with exponential backoff (1s, 2s, 4s, 8s, 16s). After `MAX_CRASHES` (5) consecutive rapid crashes, give up and surface the real exit code. |

The **healthy-run reset** is load-bearing: a run that stays up ≥ `RUN_HEALTHY_SECS` (30s) resets the crash counter, so an occasionally-crashing long-running process isn't permanently killed — only rapid repeated crashes (a deterministically-fatal startup) escalate to give-up. Without this, the cap would eventually kill any process that crashes infrequently after long uptime.

## Verification

- ✅ `bash -n run.sh` — syntax valid
- ✅ `shellcheck run.sh` — clean (0 findings)
- ✅ Manual trace of all exit-code paths (42/0/crash/healthy-reset/intermittent)
- ✅ Self-review 8-point gate passed
- ℹ️ No bash test harness exists in the repo (no bats/shellcheck CI); verification is static analysis + logic tracing. The loop is simple enough that exhaustive manual tracing is reliable.

## Scope

Part 3 only. Part 1 (#1972 — send-path 401 detection) and Part 2 (#1973 — vault re-seal overlay) ship separately. Together, the three PRs close #1878.

## Self-review (8-point)

All pass. Key points:
- **Evidence:** old `run.sh:72-73` dies on any non-42 exit (verified); exit 42 originates from `restart_service.py:33` (verified).
- **Minimum dose:** ~30 lines replace ~6; the healthy-reset is necessary for correctness, not optional.
- **Zero residue:** the exit-42 echo was moved into the branch, not duplicated.
- **Consent:** adds resilience; the give-up cap surfaces the real exit code + logs to stderr — failures stay visible.