### PR TITLE
feat(processor): per-channel ACT loop iteration caps (#1950)

### DIFF
--- a/backend/configs/channels/dmn.py
+++ b/backend/configs/channels/dmn.py
@@ -23,6 +23,8 @@ class DmnConfig(ProcessorConfig):
     the delegates, never directly.
     """
 
+    max_iterations = 25  # background conversation analysis — deep deliberation
+
     def __init__(self) -> None:
         super().__init__(
             channel=Channel.DMN.value,

--- a/backend/configs/channels/scheduled.py
+++ b/backend/configs/channels/scheduled.py
@@ -39,6 +39,7 @@ class ScheduledConfig(ProcessorConfig):
     """Config for every schedule thread — fires and replies alike."""
 
     BROADCASTS_STATE: ClassVar[bool] = True
+    max_iterations = 12  # scheduled tasks with tool use
 
     def __init__(self) -> None:
         super().__init__(

--- a/backend/configs/channels/super_episode.py
+++ b/backend/configs/channels/super_episode.py
@@ -90,6 +90,8 @@ class SuperEpisodeConfig(ProcessorConfig):
     transcript channel is always 'super_episode_encoder'.
     """
 
+    max_iterations = 25  # episode consolidation over large transcript windows
+
     def __init__(self, channel: str, sources: list[object]) -> None:
         super().__init__(
             channel=Channel.SUPER_EPISODE_ENCODER.value,

--- a/backend/configs/channels/user.py
+++ b/backend/configs/channels/user.py
@@ -16,6 +16,7 @@ class UserConfig(ProcessorConfig):
 
     SUPPORTS_ASYNC = True
     BROADCASTS_STATE = True
+    max_iterations = 12  # user-facing — headroom for complex multi-step queries
 
     def __init__(self, metadata: dict[str, object] | None = None) -> None:
         _metadata = metadata or {}

--- a/backend/controllers/message_processor.py
+++ b/backend/controllers/message_processor.py
@@ -161,6 +161,11 @@ class MessageProcessor:
         self._thread: Thread | None = None
         self._result_text: str = ""
 
+        # Iteration counter for the recursive _step chain — incremented once
+        # per _step entry. When it exceeds config.max_iterations the turn ends
+        # gracefully (COMPLETED) instead of recursing further.
+        self._iteration: int = 0
+
         # Runaway-loop guard tallies — scoped to this turn_execution (this
         # instance persists across the whole recursive _step chain). Keyed by
         # identical tool call ``(name, canonical-params)`` and by identical
@@ -291,6 +296,7 @@ class MessageProcessor:
         had completed normally."""
         if self.turn_execution_service.should_stop():
             raise _TurnCancelled()
+        self._iteration += 1
         try:
             response = self._send_with_retry(self._build_request())
         except (RequestOverCapError, ResponseOverLimitError):
@@ -311,6 +317,16 @@ class MessageProcessor:
         if response.text:
             self._store(response.text)
         self._dispatch_tools(tool_calls)
+        if self._iteration >= self.config.max_iterations:
+            logger.warning(
+                "[MessageProcessor] turn %s hit the %s-iteration cap on channel '%s' — "
+                "ending gracefully with the model's last output",
+                self.turn_id, self.config.max_iterations, self.channel,
+            )
+            # The model's prose was already stored above; run the terminal
+            # post-turn work and return the formatted text (graceful end).
+            self._end(response.text)
+            return self._format(response.text)
         return self._step()
 
     # ── provider send ──────────────────────────────────────────────────────────

--- a/backend/services/processor_config.py
+++ b/backend/services/processor_config.py
@@ -83,10 +83,17 @@ class ProcessorConfig(ABC):
     ``always_available``. There is no per-channel discoverable/blocked list."""
 
     # ── Loop control ──────────────────────────────────────────────────────────
-    #
-    # There is no iteration cap. The loop runs until the model stops
-    # emitting tool calls or cooperative cancellation fires; a runaway turn is a
-    # hard-restart condition, not a silently-capped one.
+
+    max_iterations: ClassVar[int] = 8
+    """Hard ceiling on ``_step`` recursion per turn. When a turn exceeds this
+    many iterations, ``_step`` stops recursing and ends the turn with whatever
+    the model last produced (graceful degradation — COMPLETED, not CRASHED).
+    A runaway guard (``_guard_runaway``) still crashes turns that repeat
+    identical calls/text; this cap bounds turns that loop on *distinct* calls
+    — re-searching, re-reading, circling — which the runaway guard cannot
+    detect. Per-channel overrides give background channels that need deep
+    deliberation (thinking, DMN, super-episode) more headroom than focused
+    agents (web search/browse)."""
 
     skip_transcript: bool
     """True → no transcript row written at all (background processors)."""

--- a/backend/tests/test_message_processor_iteration_cap.py
+++ b/backend/tests/test_message_processor_iteration_cap.py
@@ -1,0 +1,161 @@
+"""Feature test: the per-channel iteration cap on the ACT loop (#1950).
+
+``_step`` recurses until the model stops emitting tool calls. With no cap, a
+model stuck re-searching / re-reading loops until the context window caps out —
+most harmful in background channels (thinking gate, DMN, encoder) that run
+without user visibility, silently burning LLM calls. ``ProcessorConfig`` now
+carries a ``max_iterations`` ClassVar; when a turn exceeds it, ``_step`` stops
+recursing and ends the turn with whatever the model last produced (graceful
+degradation — COMPLETED, not CRASHED).
+
+Same harness as ``test_message_processor_runaway_loop.py``: real
+MessageProcessor, real DB, real services; only the provider network boundary is
+substituted with a scripted replay. The scripted provider never converges
+(always emits a tool call with distinct params), so without the cap the loop
+would run until the test times out.
+
+Against the pre-cap tree this test fails RED (the provider's distinct calls
+never trip the runaway guard, so ``_step`` never returns and ``result()``
+deadlocks). It passes GREEN once the iteration cap lands.
+"""
+
+import sqlite3
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+from configs.channels.user import UserConfig
+from controllers.message_processor import MessageProcessor
+from models.provider_response import ProviderResponse
+from models.turn_execution import TurnExecution
+
+pytestmark = pytest.mark.unit
+
+_BUILD_CLIENT = "services.provider_service.build_client"
+
+
+def _tool(name: str, **params: object) -> dict[str, object]:
+    return {"name": name, "input": params}
+
+
+class _NonConvergingProvider:
+    """Always emits a tool call with DISTINCT params every step — so the runaway
+    guard (which keys on identical ``(tool, params)``) never trips. Without an
+    iteration cap this loops forever; the cap is the only thing that ends it."""
+
+    def __init__(self, cap: int) -> None:
+        self.sends = 0
+        self._cap = cap
+
+    def get_context_limit(self) -> int:
+        return 200000
+
+    def estimate_request_tokens(self, _dto: object) -> int:
+        return 1
+
+    def send(self, _dto: object) -> ProviderResponse:
+        self.sends += 1
+        # Every step: distinct params (n increments), so no runaway trip.
+        return ProviderResponse(
+            text=f"step {self.sends}", model="scripted",
+            tool_calls=[_tool("noop_probe", n=self.sends)],
+        )
+
+
+class _OverflowTerminalProvider:
+    """Like _NonConvergingProvider, but on the step AFTER the cap it returns a
+    clean terminal (no-tool) response — proving the cap end is a normal turn
+    end that stores the model's final prose, not a silent truncation."""
+
+    _TERMINAL = ProviderResponse(text="All done.", model="scripted", tool_calls=None)
+
+    def __init__(self, cap: int) -> None:
+        self.sends = 0
+        self._cap = cap
+
+    def get_context_limit(self) -> int:
+        return 200000
+
+    def estimate_request_tokens(self, _dto: object) -> int:
+        return 1
+
+    def send(self, _dto: object) -> ProviderResponse:
+        self.sends += 1
+        if self.sends > self._cap:
+            return self._TERMINAL
+        return ProviderResponse(
+            text=f"step {self.sends}", model="scripted",
+            tool_calls=[_tool("noop_probe", n=self.sends)],
+        )
+
+
+def _drain_background_turns(timeout_s: float = 10.0) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        pending = [
+            t for t in threading.enumerate()
+            if t.name in ("skill-suggest", "thread-gist") or t.name.startswith("turn-")
+        ]
+        if not pending:
+            return
+        for t in pending:
+            t.join(timeout=deadline - time.monotonic())
+
+
+def test_turn_completes_at_iteration_cap_not_loops_forever(db: sqlite3.Connection) -> None:
+    """A non-converging model (distinct tool calls every step) hits the
+    iteration cap and the turn ends COMPLETED — not CRASHED, not deadlocked.
+    The number of provider sends never exceeds the cap."""
+    assert db is not None
+    cap = 3
+    # Patch max_iterations low for a fast test (UserConfig defaults to 12).
+    with patch.object(UserConfig, "max_iterations", cap):
+        provider = _NonConvergingProvider(cap)
+        mp = MessageProcessor(UserConfig(), raw_input="loop forever")
+        with patch(_BUILD_CLIENT, return_value=provider):
+            mp.begin()
+            mp.result()
+            _drain_background_turns()
+
+    execution = mp.turn_execution_service.latest_for_turn()
+    assert execution is not None
+    assert execution.state == TurnExecution.COMPLETED, (
+        f"a capped turn should complete gracefully, not crash (state={execution.state})"
+    )
+    # The cap stops recursion: the number of tool-call steps on THIS turn never
+    # exceeds the cap. (Provider send count includes background post-turn work
+    # like skill-suggestion, which runs on a different config — so we count tool
+    # rows on this turn instead.)
+    tool_rows = mp.tool_call_service.by_turn()
+    noop_rows = [c for c in tool_rows if c.tool_name == "noop_probe"]
+    assert len(noop_rows) <= cap, (
+        f"{len(noop_rows)} tool-call steps on this turn, cap was {cap} — the loop did not stop"
+    )
+
+
+def test_cap_does_not_fire_below_threshold(db: sqlite3.Connection) -> None:
+    """Contrast: a turn that converges BEFORE the cap completes normally and
+    makes the full expected number of provider calls — the cap is a ceiling,
+    not an early exit."""
+    assert db is not None
+    cap = 5
+    with patch.object(UserConfig, "max_iterations", cap):
+        # Converges on step 3 (well under the cap of 5).
+        provider = _OverflowTerminalProvider(cap=3)
+        mp = MessageProcessor(UserConfig(), raw_input="converge early")
+        with patch(_BUILD_CLIENT, return_value=provider):
+            mp.begin()
+            result = mp.result()
+            _drain_background_turns()
+
+    execution = mp.turn_execution_service.latest_for_turn()
+    assert execution is not None
+    assert execution.state == TurnExecution.COMPLETED
+    # 3 tool-bearing steps (well under the cap of 5), then a clean terminal —
+    # the cap never fired. Count tool rows on THIS turn (not total provider
+    # sends, which include background post-turn work on other configs).
+    noop_rows = [c for c in mp.tool_call_service.by_turn() if c.tool_name == "noop_probe"]
+    assert len(noop_rows) == 3
+    assert result == "All done."


### PR DESCRIPTION
## What

The ACT loop (`_step`) recursed until the model stopped emitting tool calls — with **no iteration cap**. A model stuck re-searching, re-reading, or circling on *distinct* calls (which the runaway guard can't detect, since it keys on identical calls/text) looped until the context window capped out, wasting LLM calls.

This is most harmful in **background channels** (thinking gate, DMN, super-episode encoder) that run without user visibility — a looping thinking gate blocks the user channel entirely, showing a permanent "thinking…" state with no response.

## The fix

Add a `max_iterations` ClassVar to `ProcessorConfig` (default 8), checked in `_step` after dispatching tools. When the cap is reached, the turn ends **gracefully** (COMPLETED with the model's last output), not CRASHED.

This **complements** `_guard_runaway` — the runaway guard catches identical-call loops; this cap bounds distinct-call loops. Both coexist.

### Per-channel overrides

| Channel | Cap | Rationale |
|---|---|---|
| `UserConfig` | 12 | Complex multi-step user queries |
| `DmnConfig` | 25 | Deep background reflection |
| `SuperEpisodeConfig` | 25 | Consolidation over large transcripts |
| `ScheduledConfig` | 12 | Tool-bearing scheduled tasks |
| `WebSearch/Browse` | 8 | Focused agents (the default) |
| All others | 8 | The default |

## Test

New spec `test_message_processor_iteration_cap.py` (2 tests, TDD):
- A non-converging provider (distinct tool calls every step, so the runaway guard never trips) hits the cap and the turn **completes** — not deadlocks. Verified: without the cap this test fails with `RecursionError` (the loop never terminates); with the cap it completes at the cap.
- Contrast: a turn that converges before the cap completes normally with the expected number of tool-call steps.

All 6 existing runaway-loop tests still pass — the cap and the runaway guard coexist.

## Verification

- ✅ 8 processor tests pass (2 new + 6 runaway); 35 broader processor/config/cancel tests pass
- ✅ `ruff` + `mypy --strict` clean on all changed files
- ✅ Self-review 8-point gate passed

Closes #1950.