### PR TITLE
fix(mail): email.policy import + dead scheduled_items cleanup (TKT-1544)

### DIFF
--- a/backend/capabilities/mail_capability/capability.py
+++ b/backend/capabilities/mail_capability/capability.py
@@ -14,7 +14,6 @@ from capabilities.mail_capability.carddav_handler import CarddavHandler
 from capabilities.mail_capability.imap_handler import ImapHandler, SmtpCreds
 from capabilities.mail_capability.providers import UnifiedProvider, build_custom_provider, \
     discover_provider
-from services.database import Database
 from services.file_mapper_service import FileMapperService
 from utils.data_utils import parse_json_column
 
@@ -340,16 +339,6 @@ class MailCapability(AbstractCapability):
         self._carddav_ok = False
         self._connected = False
         self._cycle_count = 0
-
-        try:
-            with Database.transaction() as conn:
-                conn.execute(
-                    "UPDATE scheduled_items SET status='cancelled' "
-                    "WHERE source='mail' AND status='pending'"
-                )
-            logger.info("[mail] Scheduled items cancelled.")
-        except Exception as exc:
-            logger.warning("[mail] disconnect cleanup: %s", exc)
 
         self.delete_credentials()
         logger.info("[mail] Disconnected and credentials removed.")

--- a/backend/capabilities/mail_capability/imap_handler.py
+++ b/backend/capabilities/mail_capability/imap_handler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import email as _email_mod
+import email.policy
 import logging
 from dataclasses import dataclass
 from datetime import timedelta


### PR DESCRIPTION
## Problem

Every IMAP search crashes with `AttributeError: module 'email' has no attribute 'policy'` — `imap_handler.py` does `import email as _email_mod` but uses `_email_mod.policy.default`, and `email.policy` is a stdlib submodule that `import email` never binds. Confirmed systematic across every nightly run (34 hits in one run alone) and both model families.

Secondary defect in the same module: `disconnect()` runs `UPDATE scheduled_items SET status='cancelled' WHERE source='mail' AND status='pending'` — `scheduled_items` has neither a `status` nor a `source` column (schema.sql:192-205), so every disconnect logs `[mail] disconnect cleanup: no such column: status`. The block is dead legacy from the removed scheduled_items mirror; nothing in the mail capability writes to that table.

## Fix

- Add `import email.policy` (binds the submodule; existing `_email_mod.policy.default` usages resolve unchanged).
- Delete the dead cleanup block and the now-unused `Database` import.

## Verification

- Fresh interpreter, pre-fix semantics: `import email as m; m.policy` → AttributeError (the exact logged error). Post-fix semantics: resolves to `EmailPolicy()`.
- `capabilities.mail_capability.imap_handler` imports cleanly and `policy.default` resolves.
- `backend/tests/test_mail_providers.py`: 9 passed.
- `grep Database backend/capabilities/mail_capability/capability.py` → no remaining references after import removal.

Nightly evidence: run 20260718T022145Z → test_inbox_triage (evidence.json / chalie.log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)