### PR TITLE
fix(calendar): zero-width list_events window for same-day queries (TKT-1545)

### DIFF
--- a/backend/capabilities/mail_capability/caldav_handler.py
+++ b/backend/capabilities/mail_capability/caldav_handler.py
@@ -554,10 +554,35 @@ class CaldavHandler:
         if raw_to:
             end = parse_utc(raw_to)
             # A date-only upper bound should cover the WHOLE day, else events later
-            # that day are missed. CalendarAbility resolves both bare dates and day
-            # names ('sunday') to midnight before dispatch, so a midnight end with no
-            # time-of-day is the date-only signal; an explicit time is preserved.
+            # that day are missed. CalendarAbility resolves bare dates (e.g. '2026-07-19')
+            # to LOCAL midnight in the user's timezone and converts to UTC — so for a
+            # +02:00 user '2026-07-19' becomes 2026-07-18T22:00:00Z, which is NOT
+            # midnight UTC but IS midnight locally. Detect the date-only signal by
+            # checking both UTC midnight AND local-midnight (the latter being the
+            # canonical "bare date" signal). An explicit local time (e.g. 08:30) must
+            # stay as-is.
+            _extended = False
             if end.hour == 0 and end.minute == 0 and end.second == 0:
+                _extended = True
+            else:
+                # Try the local-timezone check; fall back silently on any failure so
+                # locale lookups can never break window resolution.
+                try:
+                    from zoneinfo import ZoneInfo  # stdlib
+
+                    from services.locale_service import get_timezone_name
+
+                    tz = ZoneInfo(get_timezone_name())
+                    local_end = end.astimezone(tz)
+                    if (
+                        local_end.hour == 0
+                        and local_end.minute == 0
+                        and local_end.second == 0
+                    ):
+                        _extended = True
+                except Exception:
+                    pass
+            if _extended:
                 end = end + timedelta(days=1)
         elif raw_from:
             end = start + timedelta(days=_LIST_DEFAULT_FUTURE_DAYS)

--- a/backend/tests/test_caldav_handler.py
+++ b/backend/tests/test_caldav_handler.py
@@ -246,6 +246,28 @@ class TestResolveWindow:
         assert start == _NOW
         assert end == _NOW + datetime.timedelta(days=7)
 
+    def test_non_utc_user_same_day_window_extended(self) -> None:
+        # Non-UTC user: bare date '2026-07-19' in Europe/Malta (+02:00) parses to
+        # 2026-07-18T22:00:00Z. Local-midnight must still trigger the extension so
+        # the window covers the whole local day.
+        with patch(
+            "services.locale_service.get_timezone_name", return_value="Europe/Malta"
+        ):
+            _start, end = self._window(
+                {"date_from": "2026-07-18T22:00:00+00:00", "date_to": "2026-07-18T22:00:00+00:00"},
+            )
+        # '2026-07-18T22:00:00Z' is 2026-07-19 00:00 in Europe/Malta → extended by 1 day
+        expected_end = _dt(2026, 7, 19, 22, 0)
+        assert end == expected_end
+
+    def test_non_utc_non_midnight_not_extended(self) -> None:
+        # Non-midnight explicit time (08:30 UTC) must NOT be extended, even for a
+        # non-UTC user — the user explicitly set a time of day.
+        with patch(
+            "services.locale_service.get_timezone_name", return_value="Europe/Malta"
+        ):
+            _start, end = self._window({"date_to": "2026-07-19T08:30:00+00:00"})
+        assert end == _dt(2026, 7, 19, 8, 30)
 
 # ---------------------------------------------------------------------------
 # _representative_per_uid — recurrence occurrences collapse to one occurrence


### PR DESCRIPTION
## Problem

`calendar list_events` with `date_from == date_to` (the natural encoding of "what do I have tomorrow?") returns 0 events for any non-UTC user, even when events exist that day. Nightly evidence (run 20260718T022145Z, test_calendar): tool result `{"events":[],"count":0,"window":{"start":"2026-07-18T22:00:00+00:00","end":"2026-07-18T22:00:00+00:00"}}` while independent CalDAV reads proved 3 events on that day.

## Root cause

`CalendarAbility._parse_dt` resolves bare dates to **local** midnight (Europe/Malta → 22:00 UTC), but `CaldavHandler._resolve_window`'s whole-day extension detects date-only bounds as midnight on the **UTC** representation — so the +1-day extension never fires off-UTC and the window collapses to zero width. This also explains why calendar scores bounced 0.79–1.0 across nightly runs: the bug only fires when the model encodes a same-day range naturally.

## Fix

Treat the upper bound as date-only when it is midnight in the user's timezone **or** midnight UTC (preserves existing behavior for UTC users and direct ISO callers). Locale lookup is lazy (matching `_parse_dt` precedent) and failure-proof — any exception falls back to the UTC-only check.

## Verification

- `backend/tests/test_caldav_handler.py`: 17 passed (15 baseline + 2 new: Malta local-midnight extension, Malta explicit-time preservation).
- Exact nightly repro (Malta user, `date_from == date_to == 2026-07-18T22:00:00Z`): window now `22:00 → 22:00 +1d`, width exactly 1 day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)