### PR TITLE
fix(async): suppress delegate delivery when the originating turn crashed

### DIFF
--- a/backend/services/async_delegate_runner.py
+++ b/backend/services/async_delegate_runner.py
@@ -44,6 +44,7 @@ from typing import TYPE_CHECKING, cast
 from uuid import uuid4
 
 from controllers.message_processor import MessageProcessor
+from models.turn_execution import TurnExecution
 from models.ws_message import WsMessage
 from services.time_utils import utc_now
 from services.websocket import Websocket
@@ -174,6 +175,19 @@ class AsyncDelegateRunner:
         switches itself to FORK view internally (no external flag). The input row
         is suppressed (``with_hidden_input``) and attachments dropped — both were
         already ingested on the originating turn and must not repeat here.
+
+        **Crash guard:** if the originating turn was already stamped ``CRASHED``
+        (the RunAwayLoop guard killed a looping tool) before this background
+        result arrived, the delivery is suppressed — respawning it would resume
+        the exact doomed work the guard just killed, which nightly run 1006
+        evidence showed as a cascade of six [MessageProcessor] turn-crashed
+        cycles at 20-40s spacing after the scenario ended, keeping the channel
+        busy for minutes while no user message could get through. A probe
+        ``MessageProcessor`` (inert, I2) reads ``latest_for_turn()`` on the
+        originating (channel, turn_id); only when no row exists, or the row is
+        not ``CRASHED`` (``WORKING``, ``COMPLETED``, ``CANCELLED``) does the
+        delivery proceed unchanged — the cancelled-DELEGATE notice path in
+        ``_run``'s ``cancel_event`` branch is untouched and must keep delivering.
         """
         config = getattr(origin_mp, "config", None)
         if config is None:
@@ -185,6 +199,21 @@ class AsyncDelegateRunner:
         metadata["hidden_input"] = True
         metadata["attachments"] = []
         turn_id = getattr(origin_mp, "turn_id", None)
+
+        # Crash guard: suppress delivery when the originating turn was already
+        # killed by the RunAwayLoop guard (state == CRASHED). A crashed origin
+        # means looping work was stopped; feeding the late result back would
+        # respawn the identical loop — nightly run 1006 evidence.
+        if turn_id is not None and turn_id >= 0:
+            probe = MessageProcessor(config, turn_id)  # inert (I2)
+            latest = probe.turn_execution_service.latest_for_turn()
+            if latest is not None and latest.state == TurnExecution.CRASHED:
+                logger.warning(
+                    "[AsyncDelegateRunner] async delivery suppressed: originating turn %s crashed (%s) — not respawning its work",
+                    turn_id, latest.stop_reason,
+                )
+                return
+
         # Full UserConfig turn: its lifecycle signals come from MessageProcessor
         # itself. Fire-and-forget — nothing consumes the final text, so the drive
         # thread is never joined.

--- a/backend/services/async_delegate_runner.py
+++ b/backend/services/async_delegate_runner.py
@@ -179,10 +179,10 @@ class AsyncDelegateRunner:
         **Crash guard:** if the originating turn was already stamped ``CRASHED``
         (the RunAwayLoop guard killed a looping tool) before this background
         result arrived, the delivery is suppressed — respawning it would resume
-        the exact doomed work the guard just killed, which nightly run 1006
-        evidence showed as a cascade of six [MessageProcessor] turn-crashed
-        cycles at 20-40s spacing after the scenario ended, keeping the channel
-        busy for minutes while no user message could get through. A probe
+        the exact doomed work the guard just killed, observed live as a cascade
+        of [MessageProcessor] turn-crashed cycles at 20-40s spacing after the
+        originating turn died, keeping the channel busy for minutes while no
+        user message could get through. A probe
         ``MessageProcessor`` (inert, I2) reads ``latest_for_turn()`` on the
         originating (channel, turn_id); only when no row exists, or the row is
         not ``CRASHED`` (``WORKING``, ``COMPLETED``, ``CANCELLED``) does the
@@ -203,7 +203,7 @@ class AsyncDelegateRunner:
         # Crash guard: suppress delivery when the originating turn was already
         # killed by the RunAwayLoop guard (state == CRASHED). A crashed origin
         # means looping work was stopped; feeding the late result back would
-        # respawn the identical loop — nightly run 1006 evidence.
+        # respawn the identical loop.
         if turn_id is not None and turn_id >= 0:
             probe = MessageProcessor(config, turn_id)  # inert (I2)
             latest = probe.turn_execution_service.latest_for_turn()

--- a/backend/tests/test_async_delegate_crash_guard.py
+++ b/backend/tests/test_async_delegate_crash_guard.py
@@ -1,0 +1,251 @@
+"""Feature test: an async delegate finishing after its originating turn
+crashed must not respawn the doomed work.
+
+Nightly run 1006 evidence: RunAwayLoop killed a browser-looping turn, then six
+[MessageProcessor] turn-crashed cycles at ~20-40s spacing as each surviving
+async browser delegate delivered and respawned the loop; work still running
+3 minutes after the scenario ended; the next five scenarios' sends never
+opened a turn.
+
+The fix lives in ``AsyncDelegateRunner._deliver``: before calling
+``MessageProcessor.process`` (which forks a new synthesis turn onto the
+originating (channel, turn_id)), we probe the originating turn's latest
+``turn_executions`` row via an inert ``MessageProcessor``. If the row exists
+and its state is ``CRASHED``, we suppress the delivery with a loud warning —
+respawning it would resume the exact doomed work the guard just killed.
+
+This test drives that guard against the real SQLite database (via the
+``db`` fixture from ``conftest.py``) with the real ``TurnExecutionService``
+and ``TranscriptService`` doing every read/write. The only substitution is
+``MessageProcessor.process`` itself — we patch it to a ``MagicMock`` to
+verify the guard suppresses or allows delivery as expected.
+"""
+
+import sqlite3
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from configs.channels.user import UserConfig
+from controllers.message_processor import MessageProcessor
+from models.turn_execution import TurnExecution
+
+pytestmark = pytest.mark.unit
+
+# The fully-qualified path ``_deliver`` ultimately calls — patch this, not the
+# instance method on the imported module, to verify the guard's decision point.
+_PROCESS = "controllers.message_processor.MessageProcessor.process"
+
+
+def _seed_turn_execution(
+    db: sqlite3.Connection,
+    channel: str,
+    turn_id: int,
+    state: str,
+    stop_reason: str | None = None,
+    started_at: datetime | None = None,
+    ended_at: datetime | None = None,
+) -> TurnExecution:
+    """Insert one ``turn_executions`` row directly into the test DB.
+
+    Mirrors what ``TurnExecutionService.open()`` / ``finish()`` do — the
+    guard reads via the real ``TurnExecutionService.latest_for_turn()``, so
+    the row must be a real DB row, not an in-memory fake.
+    """
+    now = started_at or datetime.utcnow()
+    if ended_at is None:
+        ended_at = now + timedelta(seconds=30)
+    if stop_reason is None:
+        stop_reason = "test_stop" if state == TurnExecution.CRASHED else None
+
+    row = TurnExecution(
+        channel=channel,
+        type="user",
+        turn_id=turn_id,
+        started_at=now.isoformat(),
+        ended_at=ended_at.isoformat(),
+        cancel_requested=False,
+        state=state,
+        stop_reason=stop_reason,
+    )
+    row.save()
+    return row
+
+
+def test_crashed_origin_turn_suppresses_delivery(db: sqlite3.Connection) -> None:
+    """A delegate finishing after its originating turn was killed by the
+    RunAwayLoop guard must not respawn the doomed work — ``process()`` must
+    NOT be called.
+
+    Seeds a CRASHED ``turn_executions`` row for the user channel + a chosen
+    turn_id, then calls ``_deliver`` with an inert origin mp. The guard
+    probes the row via an inert ``MessageProcessor``, sees ``CRASHED``, and
+    returns without calling ``process()``.
+    """
+    assert db is not None  # fixture is taken for its binding side effect (real DB gateway)
+    config = UserConfig()
+    channel = config.channel
+    turn_id = 9001
+
+    # Seed a CRASHED turn (mimics what RunAwayLoop left behind).
+    _seed_turn_execution(
+        db,
+        channel,
+        turn_id,
+        state=TurnExecution.CRASHED,
+        stop_reason="browser_loop_detected",
+        started_at=datetime.utcnow() - timedelta(minutes=2),
+        ended_at=datetime.utcnow() - timedelta(minutes=1),
+    )
+
+    # Build an inert origin mp (I2: no begin(), no DB/WS side effects).
+    origin_mp = MessageProcessor(config, turn_id)
+
+    with patch(_PROCESS, new_callable=MagicMock) as mock_process:
+        from services.async_delegate_runner import async_delegate_runner
+        async_delegate_runner._deliver(origin_mp, "late browser result")
+
+        # The guard must suppress delivery — process() was NOT called.
+        mock_process.assert_not_called()
+
+
+def test_completed_origin_turn_allows_delivery(db: sqlite3.Connection) -> None:
+    """A delegate finishing after its originating turn completed normally must
+    deliver the result — ``process()`` must be called exactly once, with the
+    originating turn_id.
+
+    Seeds a COMPLETED ``turn_executions`` row, then calls ``_deliver``. The
+    guard probes the row, sees ``COMPLETED`` (not ``CRASHED``), and allows
+    delivery to proceed.
+    """
+    assert db is not None  # fixture is taken for its binding side effect (real DB gateway)
+    config = UserConfig()
+    channel = config.channel
+    turn_id = 9002
+
+    # Seed a COMPLETED turn.
+    _seed_turn_execution(
+        db,
+        channel,
+        turn_id,
+        state=TurnExecution.COMPLETED,
+        started_at=datetime.utcnow() - timedelta(minutes=5),
+        ended_at=datetime.utcnow() - timedelta(minutes=4),
+    )
+
+    origin_mp = MessageProcessor(config, turn_id)
+
+    with patch(_PROCESS, new_callable=MagicMock) as mock_process:
+        from services.async_delegate_runner import async_delegate_runner
+        async_delegate_runner._deliver(origin_mp, "late result")
+
+        # The guard must allow delivery — process() was called exactly once.
+        mock_process.assert_called_once()
+        # The turn_id argument passed to process() must equal the originating turn_id.
+        _call_args = mock_process.call_args
+        called_turn_id = _call_args[0][3]  # 4th positional argument
+        assert called_turn_id == turn_id
+
+
+def test_no_execution_row_allows_delivery(db: sqlite3.Connection) -> None:
+    """A delegate finishing when no ``turn_executions`` row exists for the
+    originating turn must deliver the result — fail-open: absence of evidence
+    never suppresses delivery.
+
+    Seeds no row at all for the turn, then calls ``_deliver``. The guard
+    probes the row, sees ``None`` (no row), and allows delivery to proceed.
+    """
+    assert db is not None  # fixture is taken for its binding side effect (real DB gateway)
+    config = UserConfig()
+    channel = config.channel
+    turn_id = 9003
+
+    # No row seeded — the turn has no execution record at all.
+
+    origin_mp = MessageProcessor(config, turn_id)
+
+    with patch(_PROCESS, new_callable=MagicMock) as mock_process:
+        from services.async_delegate_runner import async_delegate_runner
+        async_delegate_runner._deliver(origin_mp, "late result")
+
+        # The guard must allow delivery — process() was called.
+        mock_process.assert_called_once()
+        _call_args = mock_process.call_args
+        called_turn_id = _call_args[0][3]  # 4th positional argument
+        assert called_turn_id == turn_id
+
+
+def test_cancelled_origin_turn_allows_delivery(db: sqlite3.Connection) -> None:
+    """A delegate finishing after its originating turn was cancelled normally
+    must deliver the result — ``process()`` must be called.
+
+    Seeds a CANCELLED ``turn_executions`` row, then calls ``_deliver``. The
+    guard probes the row, sees ``CANCELLED`` (not ``CRASHED``), and allows
+    delivery to proceed. This is important: the cancelled-DELEGATE notice path
+    in ``_run``'s ``cancel_event`` branch must keep delivering.
+    """
+    assert db is not None  # fixture is taken for its binding side effect (real DB gateway)
+    config = UserConfig()
+    channel = config.channel
+    turn_id = 9004
+
+    # Seed a CANCELLED turn.
+    _seed_turn_execution(
+        db,
+        channel,
+        turn_id,
+        state=TurnExecution.CANCELLED,
+        started_at=datetime.utcnow() - timedelta(minutes=3),
+        ended_at=datetime.utcnow() - timedelta(minutes=2),
+    )
+
+    origin_mp = MessageProcessor(config, turn_id)
+
+    with patch(_PROCESS, new_callable=MagicMock) as mock_process:
+        from services.async_delegate_runner import async_delegate_runner
+        async_delegate_runner._deliver(origin_mp, "late result")
+
+        # The guard must allow delivery — process() was called.
+        mock_process.assert_called_once()
+        _call_args = mock_process.call_args
+        called_turn_id = _call_args[0][3]  # 4th positional argument
+        assert called_turn_id == turn_id
+
+
+def test_working_origin_turn_allows_delivery(db: sqlite3.Connection) -> None:
+    """A delegate finishing while its originating turn is still WORKING must
+    deliver the result — ``process()`` must be called.
+
+    Seeds a WORKING ``turn_executions`` row (no ``ended_at``), then calls
+    ``_deliver``. The guard probes the row, sees ``WORKING`` (not ``CRASHED``),
+    and allows delivery to proceed. This handles the edge case where a
+    backgrounded tool finishes before the foreground turn completes — the
+    synthesis reply must still land.
+    """
+    assert db is not None  # fixture is taken for its binding side effect (real DB gateway)
+    config = UserConfig()
+    channel = config.channel
+    turn_id = 9005
+
+    # Seed a WORKING turn (no ended_at).
+    _seed_turn_execution(
+        db,
+        channel,
+        turn_id,
+        state=TurnExecution.WORKING,
+        started_at=datetime.utcnow(),
+        ended_at=None,
+    )
+
+    origin_mp = MessageProcessor(config, turn_id)
+
+    with patch(_PROCESS, new_callable=MagicMock) as mock_process:
+        from services.async_delegate_runner import async_delegate_runner
+        async_delegate_runner._deliver(origin_mp, "late result")
+
+        # The guard must allow delivery — process() was called.
+        mock_process.assert_called_once()
+        _call_args = mock_process.call_args
+        called_turn_id = _call_args[0][3]  # 4th positional argument
+        assert called_turn_id == turn_id

--- a/backend/tests/test_async_delegate_crash_guard.py
+++ b/backend/tests/test_async_delegate_crash_guard.py
@@ -1,24 +1,22 @@
 """Feature test: an async delegate finishing after its originating turn
 crashed must not respawn the doomed work.
 
-Nightly run 1006 evidence: RunAwayLoop killed a browser-looping turn, then six
-[MessageProcessor] turn-crashed cycles at ~20-40s spacing as each surviving
-async browser delegate delivered and respawned the loop; work still running
-3 minutes after the scenario ended; the next five scenarios' sends never
-opened a turn.
+Observed live: RunAwayLoop killed a browser-looping turn, then each surviving
+async delegate delivered its late result and respawned the identical loop — a
+cascade of [MessageProcessor] turn-crashed cycles at ~20-40s spacing that kept
+the channel busy for minutes while no user message could open a turn.
 
 The fix lives in ``AsyncDelegateRunner._deliver``: before calling
 ``MessageProcessor.process`` (which forks a new synthesis turn onto the
-originating (channel, turn_id)), we probe the originating turn's latest
-``turn_executions`` row via an inert ``MessageProcessor``. If the row exists
-and its state is ``CRASHED``, we suppress the delivery with a loud warning —
-respawning it would resume the exact doomed work the guard just killed.
+originating (channel, turn_id)), it probes the originating turn's latest
+``turn_executions`` row via an inert ``MessageProcessor``. A ``CRASHED`` row
+suppresses the delivery with a loud warning; any other state — or no row at
+all — delivers exactly as before (fail-open).
 
-This test drives that guard against the real SQLite database (via the
-``db`` fixture from ``conftest.py``) with the real ``TurnExecutionService``
-and ``TranscriptService`` doing every read/write. The only substitution is
-``MessageProcessor.process`` itself — we patch it to a ``MagicMock`` to
-verify the guard suppresses or allows delivery as expected.
+Drives the guard against the real SQLite database (``db`` fixture) with the
+real ``TurnExecutionService`` doing every read. The only substitution is
+``MessageProcessor.process`` itself, patched to a ``MagicMock`` to observe the
+guard's decision.
 """
 
 import sqlite3
@@ -30,6 +28,7 @@ import pytest
 from configs.channels.user import UserConfig
 from controllers.message_processor import MessageProcessor
 from models.turn_execution import TurnExecution
+from services.async_delegate_runner import async_delegate_runner
 
 pytestmark = pytest.mark.unit
 
@@ -37,215 +36,61 @@ pytestmark = pytest.mark.unit
 # instance method on the imported module, to verify the guard's decision point.
 _PROCESS = "controllers.message_processor.MessageProcessor.process"
 
+_TURN_ID = 9001
 
-def _seed_turn_execution(
-    db: sqlite3.Connection,
-    channel: str,
-    turn_id: int,
-    state: str,
-    stop_reason: str | None = None,
-    started_at: datetime | None = None,
-    ended_at: datetime | None = None,
-) -> TurnExecution:
-    """Insert one ``turn_executions`` row directly into the test DB.
 
-    Mirrors what ``TurnExecutionService.open()`` / ``finish()`` do — the
-    guard reads via the real ``TurnExecutionService.latest_for_turn()``, so
-    the row must be a real DB row, not an in-memory fake.
-    """
-    now = started_at or datetime.utcnow()
-    if ended_at is None:
-        ended_at = now + timedelta(seconds=30)
-    if stop_reason is None:
-        stop_reason = "test_stop" if state == TurnExecution.CRASHED else None
-
-    row = TurnExecution(
+def _seed_turn_execution(channel: str, turn_id: int, state: str) -> None:
+    """Insert one real ``turn_executions`` row — the guard reads it via the
+    real ``TurnExecutionService.latest_for_turn()``. A ``WORKING`` row has no
+    ``ended_at`` (the turn is still running); every settled state does."""
+    now = datetime.utcnow()
+    TurnExecution(
         channel=channel,
         type="user",
         turn_id=turn_id,
         started_at=now.isoformat(),
-        ended_at=ended_at.isoformat(),
+        ended_at=None if state == TurnExecution.WORKING else (now + timedelta(seconds=30)).isoformat(),
         cancel_requested=False,
         state=state,
-        stop_reason=stop_reason,
-    )
-    row.save()
-    return row
+        stop_reason="browser_loop_detected" if state == TurnExecution.CRASHED else None,
+    ).save()
 
 
 def test_crashed_origin_turn_suppresses_delivery(db: sqlite3.Connection) -> None:
     """A delegate finishing after its originating turn was killed by the
-    RunAwayLoop guard must not respawn the doomed work — ``process()`` must
-    NOT be called.
-
-    Seeds a CRASHED ``turn_executions`` row for the user channel + a chosen
-    turn_id, then calls ``_deliver`` with an inert origin mp. The guard
-    probes the row via an inert ``MessageProcessor``, sees ``CRASHED``, and
-    returns without calling ``process()``.
-    """
+    RunAwayLoop guard must not respawn the doomed work — ``process()`` is
+    never called."""
     assert db is not None  # fixture is taken for its binding side effect (real DB gateway)
     config = UserConfig()
-    channel = config.channel
-    turn_id = 9001
-
-    # Seed a CRASHED turn (mimics what RunAwayLoop left behind).
-    _seed_turn_execution(
-        db,
-        channel,
-        turn_id,
-        state=TurnExecution.CRASHED,
-        stop_reason="browser_loop_detected",
-        started_at=datetime.utcnow() - timedelta(minutes=2),
-        ended_at=datetime.utcnow() - timedelta(minutes=1),
-    )
-
-    # Build an inert origin mp (I2: no begin(), no DB/WS side effects).
-    origin_mp = MessageProcessor(config, turn_id)
+    _seed_turn_execution(config.channel, _TURN_ID, TurnExecution.CRASHED)
+    origin_mp = MessageProcessor(config, _TURN_ID)  # inert (I2)
 
     with patch(_PROCESS, new_callable=MagicMock) as mock_process:
-        from services.async_delegate_runner import async_delegate_runner
         async_delegate_runner._deliver(origin_mp, "late browser result")
 
-        # The guard must suppress delivery — process() was NOT called.
-        mock_process.assert_not_called()
+    mock_process.assert_not_called()
 
 
-def test_completed_origin_turn_allows_delivery(db: sqlite3.Connection) -> None:
-    """A delegate finishing after its originating turn completed normally must
-    deliver the result — ``process()`` must be called exactly once, with the
-    originating turn_id.
-
-    Seeds a COMPLETED ``turn_executions`` row, then calls ``_deliver``. The
-    guard probes the row, sees ``COMPLETED`` (not ``CRASHED``), and allows
-    delivery to proceed.
-    """
+@pytest.mark.parametrize(
+    "state",
+    [None, TurnExecution.COMPLETED, TurnExecution.CANCELLED, TurnExecution.WORKING],
+    ids=["no-row", "completed", "cancelled", "working"],
+)
+def test_non_crashed_origin_allows_delivery(db: sqlite3.Connection, state: str | None) -> None:
+    """Every non-crashed origin delivers exactly as before — COMPLETED and
+    CANCELLED settled turns (the cancelled-DELEGATE notice path must keep
+    delivering), a still-WORKING turn (a backgrounded tool may finish before
+    the foreground turn ends), and no execution row at all (fail-open:
+    absence of evidence never suppresses delivery). ``process()`` is called
+    exactly once with the originating turn_id."""
     assert db is not None  # fixture is taken for its binding side effect (real DB gateway)
     config = UserConfig()
-    channel = config.channel
-    turn_id = 9002
-
-    # Seed a COMPLETED turn.
-    _seed_turn_execution(
-        db,
-        channel,
-        turn_id,
-        state=TurnExecution.COMPLETED,
-        started_at=datetime.utcnow() - timedelta(minutes=5),
-        ended_at=datetime.utcnow() - timedelta(minutes=4),
-    )
-
-    origin_mp = MessageProcessor(config, turn_id)
+    if state is not None:
+        _seed_turn_execution(config.channel, _TURN_ID, state)
+    origin_mp = MessageProcessor(config, _TURN_ID)  # inert (I2)
 
     with patch(_PROCESS, new_callable=MagicMock) as mock_process:
-        from services.async_delegate_runner import async_delegate_runner
         async_delegate_runner._deliver(origin_mp, "late result")
 
-        # The guard must allow delivery — process() was called exactly once.
-        mock_process.assert_called_once()
-        # The turn_id argument passed to process() must equal the originating turn_id.
-        _call_args = mock_process.call_args
-        called_turn_id = _call_args[0][3]  # 4th positional argument
-        assert called_turn_id == turn_id
-
-
-def test_no_execution_row_allows_delivery(db: sqlite3.Connection) -> None:
-    """A delegate finishing when no ``turn_executions`` row exists for the
-    originating turn must deliver the result — fail-open: absence of evidence
-    never suppresses delivery.
-
-    Seeds no row at all for the turn, then calls ``_deliver``. The guard
-    probes the row, sees ``None`` (no row), and allows delivery to proceed.
-    """
-    assert db is not None  # fixture is taken for its binding side effect (real DB gateway)
-    config = UserConfig()
-    channel = config.channel
-    turn_id = 9003
-
-    # No row seeded — the turn has no execution record at all.
-
-    origin_mp = MessageProcessor(config, turn_id)
-
-    with patch(_PROCESS, new_callable=MagicMock) as mock_process:
-        from services.async_delegate_runner import async_delegate_runner
-        async_delegate_runner._deliver(origin_mp, "late result")
-
-        # The guard must allow delivery — process() was called.
-        mock_process.assert_called_once()
-        _call_args = mock_process.call_args
-        called_turn_id = _call_args[0][3]  # 4th positional argument
-        assert called_turn_id == turn_id
-
-
-def test_cancelled_origin_turn_allows_delivery(db: sqlite3.Connection) -> None:
-    """A delegate finishing after its originating turn was cancelled normally
-    must deliver the result — ``process()`` must be called.
-
-    Seeds a CANCELLED ``turn_executions`` row, then calls ``_deliver``. The
-    guard probes the row, sees ``CANCELLED`` (not ``CRASHED``), and allows
-    delivery to proceed. This is important: the cancelled-DELEGATE notice path
-    in ``_run``'s ``cancel_event`` branch must keep delivering.
-    """
-    assert db is not None  # fixture is taken for its binding side effect (real DB gateway)
-    config = UserConfig()
-    channel = config.channel
-    turn_id = 9004
-
-    # Seed a CANCELLED turn.
-    _seed_turn_execution(
-        db,
-        channel,
-        turn_id,
-        state=TurnExecution.CANCELLED,
-        started_at=datetime.utcnow() - timedelta(minutes=3),
-        ended_at=datetime.utcnow() - timedelta(minutes=2),
-    )
-
-    origin_mp = MessageProcessor(config, turn_id)
-
-    with patch(_PROCESS, new_callable=MagicMock) as mock_process:
-        from services.async_delegate_runner import async_delegate_runner
-        async_delegate_runner._deliver(origin_mp, "late result")
-
-        # The guard must allow delivery — process() was called.
-        mock_process.assert_called_once()
-        _call_args = mock_process.call_args
-        called_turn_id = _call_args[0][3]  # 4th positional argument
-        assert called_turn_id == turn_id
-
-
-def test_working_origin_turn_allows_delivery(db: sqlite3.Connection) -> None:
-    """A delegate finishing while its originating turn is still WORKING must
-    deliver the result — ``process()`` must be called.
-
-    Seeds a WORKING ``turn_executions`` row (no ``ended_at``), then calls
-    ``_deliver``. The guard probes the row, sees ``WORKING`` (not ``CRASHED``),
-    and allows delivery to proceed. This handles the edge case where a
-    backgrounded tool finishes before the foreground turn completes — the
-    synthesis reply must still land.
-    """
-    assert db is not None  # fixture is taken for its binding side effect (real DB gateway)
-    config = UserConfig()
-    channel = config.channel
-    turn_id = 9005
-
-    # Seed a WORKING turn (no ended_at).
-    _seed_turn_execution(
-        db,
-        channel,
-        turn_id,
-        state=TurnExecution.WORKING,
-        started_at=datetime.utcnow(),
-        ended_at=None,
-    )
-
-    origin_mp = MessageProcessor(config, turn_id)
-
-    with patch(_PROCESS, new_callable=MagicMock) as mock_process:
-        from services.async_delegate_runner import async_delegate_runner
-        async_delegate_runner._deliver(origin_mp, "late result")
-
-        # The guard must allow delivery — process() was called.
-        mock_process.assert_called_once()
-        _call_args = mock_process.call_args
-        called_turn_id = _call_args[0][3]  # 4th positional argument
-        assert called_turn_id == turn_id
+    mock_process.assert_called_once()
+    assert mock_process.call_args[0][3] == _TURN_ID  # originating turn_id, 4th positional


### PR DESCRIPTION
## Problem (TKT-1541)

`AsyncDelegateRunner._deliver` calls `MessageProcessor.process()` unconditionally when a backgrounded tool finishes. When the originating turn was already stamped `CRASHED` (RunAwayLoop killed a looping tool), the late result respawns the exact doomed work the guard just stopped.

Nightly run 1006 evidence: six `[MessageProcessor]` turn-crashed cycles at ~20–40s spacing after the scenario ended; the channel stayed busy for minutes, `data-working` stayed lit, and the composer wedged — the next five scenarios' sends never opened a turn. Run 1012 reproduced the same wedge on gemini-flash.

## Fix

Before spawning the synthesis turn, `_deliver` probes the originating `(channel, turn_id)`'s latest `turn_executions` row via an inert `MessageProcessor` (the established `cancel()` probe pattern — no `begin()`, zero side effects):

- Row exists with `state == CRASHED` → suppress delivery with a loud warning naming the turn and its `stop_reason`.
- No row, `WORKING`, `COMPLETED`, `CANCELLED` → deliver exactly as before (fail-open; the cancelled-DELEGATE notice path in `_run` is untouched).

The guard only engages for a real originating `turn_id` (`>= 0`).

## Tests

New `backend/tests/test_async_delegate_crash_guard.py` — real SQLite DB and real `TurnExecutionService` reads; the only substitution is patching `MessageProcessor.process` to observe the guard's decision:

- CRASHED origin → `process()` not called
- COMPLETED / CANCELLED / WORKING origin → `process()` called once with the originating turn_id
- No execution row → delivered (fail-open)

`pytest tests/test_async_delegate_crash_guard.py tests/test_async_delegate_runner.py tests/test_message_processor_cancel_mid_provider_call.py` → **10 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)