### PR TITLE
fix: steer model off repeated identical tool calls before runaway kill (TKT-1543)

### DIFF
--- a/backend/controllers/message_processor.py
+++ b/backend/controllers/message_processor.py
@@ -165,7 +165,10 @@ class MessageProcessor:
         # Runaway-loop guard tallies — scoped to this turn_execution (this
         # instance persists across the whole recursive _step chain). Keyed by
         # identical tool call ``(name, canonical-params)`` and by identical
-        # (stripped, non-empty) response text; read only in _guard_runaway.
+        # (stripped, non-empty) response text. ``_invocation_key`` is the shared
+        # key constructor; ``repeat_call_count`` is the read path used by
+        # DispatchService to steer from the second identical call;
+        # ``_guard_runaway`` is the only writer.
         self._tool_invocations: Counter[tuple[str, str]] = Counter()
         self._text_emissions: Counter[str] = Counter()
 
@@ -408,6 +411,32 @@ class MessageProcessor:
             return markdown_to_html(text)
         return text or ""
 
+    @staticmethod
+    def _invocation_key(name: str, canonical: dict[str, object]) -> tuple[str, str]:
+        """The guard's per-tool tally key: ``(name, canonical-params-json)``.
+
+        Keyed on the CANONICAL (sanitised + key-healed) params dispatch will
+        actually execute, not the raw provider args: a model cycling synonym
+        keys (city/loc/place/region → location) would otherwise mint a fresh
+        key each step while running byte-identical calls, evading the tally.
+        ``canonical`` must therefore be the output of
+        ``DispatchService.canonical_params`` — this is the sole key constructor,
+        shared by the writer (``_guard_runaway``) and the reader
+        (``DispatchService._repeat_call_steer`` via ``repeat_call_count``)."""
+        return (name, json.dumps(canonical, sort_keys=True, default=str))
+
+    def repeat_call_count(self, tool_name: str, canonical_params: dict[str, object]) -> int:
+        """How many times this tool has been invoked with these exact canonical
+        params this turn.
+
+        Read by :meth:`~services.dispatch_service.DispatchService._repeat_call_steer`
+        to steer the model from the second identical call. The count was tallied
+        by :meth:`_guard_runaway` BEFORE dispatch, so a call that has not yet
+        dispatched has not yet been counted. Dispatches bypassing ``_step``
+        (compactor, document upload, async delegate's dedicated mp) have zero
+        tally and never steer here."""
+        return self._tool_invocations[self._invocation_key(tool_name, canonical_params)]
+
     def _guard_runaway(self, text: str, tool_calls: list[dict[str, object]]) -> None:
         """Trip a loud ``RunAwayLoop`` when this turn's step chain is repeating
         itself instead of converging — the hard backstop for the uncapped loop.
@@ -433,14 +462,10 @@ class MessageProcessor:
                 )
         for call in tool_calls:
             name = cast("str", call["name"])
-            # Key on the CANONICAL (sanitised + key-healed) params dispatch will
-            # actually execute, not the raw provider args: a model cycling synonym
-            # keys (city/loc/place/region → location) would otherwise mint a fresh
-            # key each step while running byte-identical calls, evading the tally.
             canonical = self.dispatch_service.canonical_params(
                 name, cast("dict[str, object]", call.get("input") or {}),
             )
-            key = (name, json.dumps(canonical, sort_keys=True, default=str))
+            key = self._invocation_key(name, canonical)
             self._tool_invocations[key] += 1
             if self._tool_invocations[key] >= _RUNAWAY_TOOL_CALL_LIMIT:
                 raise RunAwayLoop(

--- a/backend/services/dispatch_service.py
+++ b/backend/services/dispatch_service.py
@@ -88,24 +88,30 @@ class DispatchService:
         unknown) so the rendered trail tells the model what happened and it does
         not retry a blocked tool forever. No cancel check — the loop guards
         should_stop() one line before calling this.
-        """
+
+        Appends a steering suffix to the persisted result when the same tool
+        has already fired with identical params this turn, breaking the loop
+        before the hard runaway-kill threshold. The steer is persisted into the
+        tool_calls row so the model re-reads it on its next step (see
+        ``prompt_service`` rendering ``call.result``); the return value carries
+        the same string so callers see what the model will see."""
         params, act_summary, ability = self._prepare(tool_name, params)
         if ability is None:
             result_text = f"Unknown tool: {tool_name}"
-            steer = self._repeat_error_steer(tool_name, result_text)
+            steer = self._repeat_error_steer(tool_name, result_text) or self._repeat_call_steer(tool_name, params)
             self.mp.tool_call_service.record(
-                tool_name=tool_name, params=params, result=result_text,
+                tool_name=tool_name, params=params, result=result_text + steer,
                 summary=act_summary, state=ToolCall.ERROR, emit=False,
             )
             return result_text + steer
 
         result_text, call_id, state = self._dispatch_bound(tool_name, ability, params, act_summary)
-        steer = self._repeat_error_steer(tool_name, result_text)
+        steer = self._repeat_error_steer(tool_name, result_text) or self._repeat_call_steer(tool_name, params)
         if call_id is not None:
-            self.mp.tool_call_service.finish(call_id=call_id, result=result_text, state=state)
+            self.mp.tool_call_service.finish(call_id=call_id, result=result_text + steer, state=state)
         else:
             self.mp.tool_call_service.record(
-                tool_name=tool_name, params=params, result=result_text,
+                tool_name=tool_name, params=params, result=result_text + steer,
                 summary=act_summary, state=state, emit=True,
             )
         return result_text + steer
@@ -218,6 +224,28 @@ class DispatchService:
             for call in self.mp.tool_call_service.by_exchange()
         )
         return _REPEAT_ERROR_STEER if seen else ""
+
+    def _repeat_call_steer(self, tool_name: str, params: dict[str, object]) -> str:
+        """Steering suffix when the runaway guard has already tallied this many
+        identical calls this turn — else ``""``.
+
+        Reads the tally set by :meth:`~controllers.message_processor.MessageProcessor._guard_runaway`
+        BEFORE dispatch, so the steer fires on the SECOND identical call —
+        before the hard kill threshold at ``_RUNAWAY_TOOL_CALL_LIMIT``.
+
+        ``params`` is the post-``_prepare`` identity (sanitised + act_summary-
+        lifted + key-healed) — only ``async`` remains to be stripped to byte-
+        match the guard's key. A copy is taken and ``async`` popped on the copy
+        so the live ``params`` dict is never mutated.
+
+        Dispatches that bypass ``_step`` (the compactor, document upload, or
+        the async delegate's dedicated mp) have zero tally on this mp and so
+        never steer here."""
+        identity = dict(params)
+        identity.pop("async", None)
+        if self.mp.repeat_call_count(tool_name, identity) >= _REPEAT_CALL_STEER_THRESHOLD:
+            return _REPEAT_CALL_STEER
+        return ""
 
     # ── Policy gate ─────────────────────────────────────────────────────────────
 
@@ -495,6 +523,21 @@ _REPEAT_ERROR_STEER = (
     "inputs with the `find_tools` tool and fix your input, then try once more. If "
     "it still fails, stop retrying: tell the user what error you are getting, that "
     "this tool may not be working right now, and ask them how they want to proceed."
+)
+
+#: Repeat-call steer fires when the runaway guard has already tallied this many
+#: identical calls this turn. Below this threshold every call dispatches normally.
+_REPEAT_CALL_STEER_THRESHOLD = 2
+
+# Appended to the SECOND (and later) identical call a tool makes in one turn —
+# BEFORE the runaway kill threshold — to steer the model out of the loop rather
+# than waiting for the hard crash. Written plainly so smaller models act on it.
+_REPEAT_CALL_STEER = (
+    "\n\n[loop-guard] You already invoked this exact tool with these exact "
+    "parameters this turn and got the result above. Do NOT call it again with "
+    "the same parameters. Change the parameters, use a different tool, or stop "
+    "calling tools and answer with what you already have. Repeating the identical "
+    "call again will abort this turn."
 )
 
 

--- a/backend/tests/test_dispatch_repeat_call_steer.py
+++ b/backend/tests/test_dispatch_repeat_call_steer.py
@@ -1,0 +1,347 @@
+# Copyright 2026 Chalie AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Feature test: the repeat-call steer.
+
+The runaway guard kills a turn at ``_RUNAWAY_TOOL_CALL_LIMIT`` (5) identical
+calls — but the model never sees the steer that would break the loop before
+that. This test verifies the new behaviour:
+
+* The second identical call gets a steering suffix appended to the persisted
+  ``tool_calls.result`` row, so the model re-reads it on its next step.
+* The steer persists into the row (not just the return value), fixing the
+  dead-letter defect where the ACT loop discarded the steer.
+* The steer covers BOTH paths: bound-tool success/error AND unknown-tool.
+* The runaway kill still works — five identical calls in one batch crash the
+  turn before any dispatch, zero steer_probe rows.
+
+Drives the real production entry point (construct inertly, ``begin()``,
+``result()``) against the real SQLite DB, with the real ``DispatchService`` and
+``ToolCallService``. The only substitution is the LLM network boundary:
+``services.provider_service.build_client``. The fake client replays a scripted
+sequence of provider responses, one per step. Each ``steer_probe`` test seeds a
+CHAT-channel ``allow`` policy row first (see ``_allow_steer_probe``) — the
+production grant path through the real gate.
+
+The registered ability ``steer_probe`` is a real ``Ability`` subclass at module
+level — ``DISCOVERABLE`` is its default (``True``), so it is permanently visible
+to ``Ability.__subclasses__()`` for the rest of the process once collected. No
+custom ``__init__``: ``DispatchService._bind()`` always builds a FRESH instance
+via ``type(template)(mp=...)`` for the real dispatch-by-name seam. The ability
+returns a deterministic ``ToolResult.ok("steer probe done")`` so the persisted
+row carries the success envelope and the steer can be asserted on it."""
+
+import sqlite3
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+from abilities._ability import Ability
+from abilities._result import ToolResult
+from configs.channels.user import UserConfig
+from configs.enums.policy_channel import PolicyChannel
+from controllers.message_processor import (
+    _RUNAWAY_TOOL_CALL_LIMIT,
+    MessageProcessor,
+)
+from models.policy import Policy
+from models.provider_response import ProviderResponse
+from models.turn_execution import TurnExecution
+from services.dispatch_service import _REPEAT_CALL_STEER
+
+pytestmark = pytest.mark.unit
+
+# ProviderService builds its thin transport client via this factory call — the
+# real network boundary (see test_message_processor_runaway_loop.py).
+_BUILD_CLIENT = "services.provider_service.build_client"
+
+
+def _tool(name: str, **params: object) -> dict[str, object]:
+    """A provider-shaped tool call: ``{"name": ..., "input": {...}}``."""
+    return {"name": name, "input": params}
+
+
+class _ScriptedProvider:
+    """Replays one scripted ``ProviderResponse`` per ``send()`` call, in order.
+
+    Past the end of the script it returns a benign terminal (no-tool, empty)
+    response rather than raising: a completed ``user`` turn spawns a
+    fire-and-forget skill-suggestion turn (``_proactive_suggestion``) that makes
+    its own provider call on a daemon thread this test does not script for. This
+    tolerance cannot mask a steer failure — a steer that failed to append would
+    instead leave the row bare, which every steer test asserts against."""
+
+    _TERMINAL = ProviderResponse(text="", model="scripted-repeat-call", tool_calls=None)
+
+    def __init__(self, *responses: ProviderResponse) -> None:
+        self._responses = list(responses)
+        self.sends = 0
+
+    def get_context_limit(self) -> int:
+        return 200000
+
+    def estimate_request_tokens(self, _dto: object) -> int:
+        return 1
+
+    def send(self, _dto: object) -> ProviderResponse:
+        if self.sends >= len(self._responses):
+            return self._TERMINAL
+        response = self._responses[self.sends]
+        self.sends += 1
+        return response
+
+
+def _drain_background_turns(timeout_s: float = 10.0) -> None:
+    """Join the fire-and-forget post-turn daemon turns a completed ``user`` turn
+    spawns (skill suggestion, thread gist) so they run to completion inside THIS
+    test's provider+DB patch and never leak into the next test.
+
+    ``_end`` starts them unjoined (``services.skill_suggestion_message_processor``
+    / ``thread_gist_message_processor``): each is a whole ``MessageProcessor``
+    turn on its own daemon (named ``skill-suggest``/``thread-gist`` and,
+    transitively, a ``turn-*`` drive thread). Left running, such a turn would call
+    ``build_client`` while the *next* test holds the patch, hitting that test's
+    scripted provider and repatched DB — the exact cross-test corruption this
+    guards against."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        pending = [
+            t for t in threading.enumerate()
+            if t.name in ("skill-suggest", "thread-gist") or t.name.startswith("turn-")
+        ]
+        if not pending:
+            return
+        for t in pending:
+            t.join(timeout=deadline - time.monotonic())
+
+
+def _run(provider: _ScriptedProvider, raw_input: str) -> MessageProcessor:
+    """Drive a real user turn to termination against *provider*, then quiesce any
+    post-turn daemon turns inside the patch so the test stays hermetic."""
+    mp = MessageProcessor(UserConfig(), raw_input=raw_input)  # inert (I2)
+    with patch(_BUILD_CLIENT, return_value=provider):
+        mp.begin()
+        mp.result()
+        _drain_background_turns()
+    return mp
+
+
+def _allow_steer_probe() -> None:
+    """Seed the CHAT-channel ``allow`` policy row for ``steer_probe``.
+
+    A registered, non-INTERNAL ability dispatched on the CHAT channel otherwise
+    lazily seeds an ``ask`` row (``Policy.get_or_create_default``) and parks the
+    turn on the interactive permission gate (``PolicyManager._ask_user``),
+    waiting on a human approval pytest never supplies — the turn thread never
+    terminates and ``mp.result()`` joins it forever. Seeding ``allow`` is the
+    production grant path, not a bypass: the gate still runs on every dispatch
+    and reads this row. (``noop_probe`` needs no row — unknown tools never
+    reach the gate.)"""
+    Policy.upsert(PolicyChannel.CHAT.value, "steer_probe", "allow")
+
+
+# ── The registered ability ──────────────────────────────────────────────────────
+
+
+class steer_probe(Ability):
+    """A real, DISCOVERABLE ability for the repeat-call steer tests.
+
+    Returns ``ToolResult.ok("steer probe done")`` deterministically. No custom
+    ``__init__``: ``DispatchService._bind()`` always builds a FRESH instance via
+    ``type(template)(mp=...)`` for the real dispatch-by-name seam, so any state
+    lives on the class (not needed here) rather than on a per-instance
+    constructor the binder can no longer supply."""
+
+    def get_name(self) -> str:
+        return "steer_probe"
+
+    def get_search_tooltip(self) -> str:
+        return "repeat-call steer test fixture"
+
+    def get_summary(self) -> str:
+        return "Repeat-call steer test fixture — returns a fixed success."
+
+    def get_examples(self) -> list[str]:
+        return [
+            "probe the steer",
+            "test the repeat guard",
+            "fire the steer probe",
+            "run the steer probe",
+            "hit the steer probe",
+            "trigger the steer probe",
+            "use the steer probe",
+        ]
+
+    def get_parameters(self) -> dict[str, object]:
+        return {
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": [],
+        }
+
+    def run(self, params: dict[str, object]) -> ToolResult:
+        return ToolResult.ok("steer probe done")
+
+
+# ── Test: steer fires on the second identical call ─────────────────────────────
+
+
+def test_second_identical_call_gets_steer(db: sqlite3.Connection) -> None:
+    """Two sequential steps each calling ``steer_probe(q="x")`` once, then a
+    terminal no-tool response: the first row's result does NOT contain
+    ``[loop-guard]``; the second row's result ENDS WITH ``_REPEAT_CALL_STEER``;
+    the turn completes normally (COMPLETED state).
+
+    Proves the steer is persisted into the row (not just returned), that it
+    fires on the SECOND identical call (threshold=2), and that steering below
+    the kill threshold never crashes."""
+    assert db is not None
+    _allow_steer_probe()
+    provider = _ScriptedProvider(
+        ProviderResponse(text="", model="scripted", tool_calls=[_tool("steer_probe", q="x")]),
+        ProviderResponse(text="", model="scripted", tool_calls=[_tool("steer_probe", q="x")]),
+        ProviderResponse(text="All done.", model="scripted", tool_calls=None),
+    )
+
+    mp = _run(provider, "test the steer")
+
+    execution = mp.turn_execution_service.latest_for_turn()
+    assert execution is not None
+    assert execution.state == TurnExecution.COMPLETED
+
+    rows = [c for c in mp.tool_call_service.by_turn() if c.tool_name == "steer_probe"]
+    assert len(rows) == 2
+    assert "[loop-guard]" not in rows[0].result
+    assert rows[1].result.endswith(_REPEAT_CALL_STEER)
+
+
+def test_four_identical_calls_across_steps_all_steer_below_kill(db: sqlite3.Connection) -> None:
+    """Four identical calls across four steps then terminal: the first row is
+    bare and every later row carries the steer, turn COMPLETED.
+
+    Proves the steer fires on every call at or above the threshold (not just
+    once), and that steering below the kill threshold never crashes — the turn
+    completes normally with all four calls dispatched."""
+    assert db is not None
+    _allow_steer_probe()
+    steps = [
+        ProviderResponse(text="", model="scripted", tool_calls=[_tool("steer_probe", q="x")])
+        for _ in range(4)
+    ]
+    steps.append(ProviderResponse(text="All done.", model="scripted", tool_calls=None))
+    provider = _ScriptedProvider(*steps)
+
+    mp = _run(provider, "test the steer")
+
+    execution = mp.turn_execution_service.latest_for_turn()
+    assert execution is not None
+    assert execution.state == TurnExecution.COMPLETED
+
+    rows = [c for c in mp.tool_call_service.by_turn() if c.tool_name == "steer_probe"]
+    assert len(rows) == 4
+    # First call: tally=1, below threshold, no steer.
+    assert "[loop-guard]" not in rows[0].result
+    # Calls 2-4: tally>=2, steer appended.
+    assert rows[1].result.endswith(_REPEAT_CALL_STEER)
+    assert rows[2].result.endswith(_REPEAT_CALL_STEER)
+    assert rows[3].result.endswith(_REPEAT_CALL_STEER)
+
+
+# ── Test: five identical calls in one batch still crashes ──────────────────────
+
+
+def test_five_identical_calls_in_one_batch_crashes(db: sqlite3.Connection) -> None:
+    """Five identical calls in one batch: ``RunAwayLoop`` escalation intact —
+    turn CRASHED, zero ``steer_probe`` rows (guard fires BEFORE dispatch).
+
+    Same shape as ``test_identical_tool_call_at_limit_crashes_the_turn`` in
+    ``test_message_processor_runaway_loop.py``. Proves the new steer does NOT
+    interfere with the hard kill: five identical calls in one batch crash the
+    turn before any of them dispatch, so zero steer_probe rows exist."""
+    assert db is not None
+    # Seeded even though the kill should fire BEFORE any dispatch: if the kill
+    # ever regresses, the calls dispatch and the row assert fails loudly instead
+    # of the turn parking forever on the ask gate.
+    _allow_steer_probe()
+    batch = [_tool("steer_probe", q="x") for _ in range(_RUNAWAY_TOOL_CALL_LIMIT)]
+    provider = _ScriptedProvider(ProviderResponse(text="", model="scripted", tool_calls=batch))
+
+    mp = _run(provider, "test the steer")
+
+    execution = mp.turn_execution_service.latest_for_turn()
+    assert execution is not None
+    assert execution.state == TurnExecution.CRASHED
+    assert execution.stop_reason is not None
+    assert "identical parameters" in execution.stop_reason
+    assert "steer_probe" in execution.stop_reason
+    # Guard trips before dispatch: no steer_probe call executed.
+    assert [c for c in mp.tool_call_service.by_turn() if c.tool_name == "steer_probe"] == []
+
+
+# ── Test: different params do NOT steer ────────────────────────────────────────
+
+
+def test_different_params_do_not_steer(db: sqlite3.Connection) -> None:
+    """Two steps with DIFFERENT params (``q="a"`` then ``q="b"``) then terminal:
+    NO row contains ``[loop-guard]``.
+
+    Proves the steer keys on the FULL canonical params (not just the tool
+    name), so a model varying a parameter is not steered away."""
+    assert db is not None
+    _allow_steer_probe()
+    provider = _ScriptedProvider(
+        ProviderResponse(text="", model="scripted", tool_calls=[_tool("steer_probe", q="a")]),
+        ProviderResponse(text="", model="scripted", tool_calls=[_tool("steer_probe", q="b")]),
+        ProviderResponse(text="All done.", model="scripted", tool_calls=None),
+    )
+
+    mp = _run(provider, "test the steer")
+
+    execution = mp.turn_execution_service.latest_for_turn()
+    assert execution is not None
+    assert execution.state == TurnExecution.COMPLETED
+
+    rows = [c for c in mp.tool_call_service.by_turn() if c.tool_name == "steer_probe"]
+    assert len(rows) == 2
+    for row in rows:
+        assert "[loop-guard]" not in row.result
+
+
+# ── Test: unknown-tool path gets the call-steer ────────────────────────────────
+
+
+def test_unknown_tool_gets_call_steer(db: sqlite3.Connection) -> None:
+    """Two sequential steps calling an UNREGISTERED tool (``noop_probe``): the
+    second row's persisted result ends with ``_REPEAT_CALL_STEER``.
+
+    Proves the call-steer covers the unknown-tool path, which the error-steer's
+    envelope check misses (unknown-tool returns plain text ``"Unknown tool: X"``,
+    not the ``[<tool>(status=error`` envelope the error-steer requires). The
+    runaway guard tallies unknown tools, so the call-steer fires on the second
+    identical unknown call."""
+    assert db is not None
+    provider = _ScriptedProvider(
+        ProviderResponse(text="", model="scripted", tool_calls=[_tool("noop_probe", q="loop")]),
+        ProviderResponse(text="", model="scripted", tool_calls=[_tool("noop_probe", q="loop")]),
+        ProviderResponse(text="All done.", model="scripted", tool_calls=None),
+    )
+
+    mp = _run(provider, "test the steer")
+
+    execution = mp.turn_execution_service.latest_for_turn()
+    assert execution is not None
+    assert execution.state == TurnExecution.COMPLETED
+
+    rows = [c for c in mp.tool_call_service.by_turn() if c.tool_name == "noop_probe"]
+    assert len(rows) == 2
+    # First call: tally=1, below threshold, no steer.
+    assert "[loop-guard]" not in rows[0].result
+    # Second call: tally=2, steer appended.
+    assert rows[1].result.endswith(_REPEAT_CALL_STEER)


### PR DESCRIPTION
## Summary

Fixes TKT-1543: when the model repeats an identical tool call, nothing corrective happened until the hard runaway kill at 5 identical calls. Two defects compounded:

1. **No early signal.** `MessageProcessor._guard_runaway` tallies identical invocations but only acts at the kill threshold — the model got zero feedback that it was looping until the turn was aborted.
2. **Dead-letter steer.** The existing `_repeat_error_steer` (fires on repeated identical *result* text) returned its steer to a caller that discards it: `_dispatch_tools` ignores `dispatch()`'s return value, and the steer was never persisted to the trail. The model never saw any steer text at all.

## Changes

- **`backend/controllers/message_processor.py`** — new static `_invocation_key(name, canonical)`: the single shared tally-key constructor, keyed on the CANONICAL (sanitised + key-healed) params dispatch actually executes, so a model cycling synonym keys (`city`/`loc`/`place` → `location`) cannot mint fresh keys while running byte-identical calls. New public `repeat_call_count(tool_name, canonical_params)` reader. `_guard_runaway` refactored onto the shared key. Kill threshold (`_RUNAWAY_TOOL_CALL_LIMIT = 5`) untouched.
- **`backend/services/dispatch_service.py`** — new `_repeat_call_steer(tool_name, params)`: from the **2nd** byte-identical invocation of the same tool in a turn, appends a `[loop-guard]` steer instructing the model to change parameters or approach. On every dispatch path the steer (error-steer takes precedence, call-steer otherwise) is now **persisted with the tool result**, so the model reads it on its next step via the trail rendering — fixing the dead-letter defect for the error-steer too.
- **`backend/tests/test_dispatch_repeat_call_steer.py`** — 5 new end-to-end tests through the real dispatch pipeline (no mocks of the steer path): steer appears at the 2nd identical call; every repeat below the kill threshold carries the steer while the first row stays bare; 5 identical calls in one batch still hard-kill; different params never steer; unknown tools get the call-steer as well. Each `steer_probe` test seeds a CHAT-channel `allow` policy row first — a registered non-`INTERNAL` ability otherwise lazily mints an `ask` row and parks the turn on the interactive permission gate, which no pytest run can answer (the production grant path, not a gate bypass — the gate still runs and reads the row).

## Verification

Full targeted suite green — 18 tests across the new file plus `test_message_processor_runaway_loop.py`, `test_dispatcher_follow_up.py`, `test_dispatch_alias_binding_regression.py`:

```
python3 -m pytest backend/tests/test_dispatch_repeat_call_steer.py \
  backend/tests/test_message_processor_runaway_loop.py \
  backend/tests/test_dispatcher_follow_up.py \
  backend/tests/test_dispatch_alias_binding_regression.py -v
```

Taskie: TKT-1543

🤖 Generated with [Claude Code](https://claude.com/claude-code)
