### PR TITLE
fix(memory): value-addressed coexist supersede via `replaces` store param (TKT-1540)

### DIFF
--- a/backend/abilities/memory.py
+++ b/backend/abilities/memory.py
@@ -78,10 +78,9 @@ class MemoryAbility(Ability):
             Keys.key: {
                 "type": "string",
                 "description": (
-                    "For store/forget: the canonical key from the list in the "
-                    "tool description (e.g. 'residence', 'food_and_drink', "
-                    "'employment'). Use the exact canonical key when the fact "
-                    "fits one of the 27 concepts."
+                    "For store/forget: the canonical key naming the fact "
+                    "(e.g. 'residence', 'food_and_drink', 'employment'). "
+                    "Use the exact canonical key when the fact fits one of the canonical concepts."
                 ),
             },
             Keys.value_: {
@@ -92,6 +91,15 @@ class MemoryAbility(Ability):
                     "'loves pasta and pizza'). "
                     "For forget: required when removing one value from a "
                     "multi-value key."
+                ),
+            },
+            Keys.replaces: {
+                "type": "string",
+                "description": (
+                    "For store: when correcting a fact already stored under "
+                    "this key, the OLD value being replaced. The old value is "
+                    "demoted and the new value takes its place. Omit when "
+                    "adding a genuinely new fact."
                 ),
             },
             Keys.query: {

--- a/backend/configs/enums/param_key.py
+++ b/backend/configs/enums/param_key.py
@@ -113,6 +113,7 @@ class Keys(StrEnum):
     query = "query"
     quota_mb = "quota_mb"
     recurrence = "recurrence"
+    replaces = "replaces"
     rule = "rule"
     rule_id = "rule_id"
     section = "section"
@@ -261,6 +262,7 @@ VARIANTS: "dict[str, frozenset[str]]" = {
     Keys.permissions: frozenset({"chmod", "perms"}),
     Keys.port_idx: frozenset({"port_id", "port_number"}),
     Keys.recurrence: frozenset({"frequency", "repeat", "rrule", "schedule"}),
+    Keys.replaces: frozenset({"old_value", "previous_value"}),
     Keys.sender: frozenset({"author", "from", "from_address", "from_email"}),
     Keys.to: frozenset({"dest", "recipient", "recipients"}),
     Keys.triage: frozenset({"category", "label"}),

--- a/backend/models/fact.py
+++ b/backend/models/fact.py
@@ -86,6 +86,55 @@ class FactRow(DataGraphRow):
         return row, ("appended" if live_rows else "created"), cls.active_values(key)
 
     @classmethod
+    def supersede_value(cls, key: str, old_value: str, value: str,
+                        source: str | None = None) -> tuple[Self, str, str] | None:
+        """Value-addressed demote+insert on the live rows of ``key``.
+
+        Finds a target row among the live set (``active = 1 AND deleted_at IS
+        NULL``) of the given key via a three-rung ladder: (a) exact case-folded
+        equality of the row's value with ``old_value``; (b) exactly one live row
+        whose case-folded value contains the case-folded ``old_value`` as a
+        substring — unique-substring; (c) absent or ambiguous → ``None`` so the
+        caller may fall back.
+
+        If the matched row's value is an exact (case-folded) match for the *new*
+        ``value`` the row is reinforced (the same path :meth:`store_coexist` takes
+        on an exact duplicate) and ``(row, "reinforced", matched_old_value)`` is
+        returned. Otherwise the matched row is demoted via :meth:`demote` (no
+        side-effect reimplementation) and the new value is inserted through
+        :meth:`store_coexist` so dedup+insert stay single-sourced;
+        ``(new_row, "superseded", matched_old_value)`` is returned."""
+        norm_old = (old_value or "").lower().strip()
+        norm_new = (value or "").lower().strip()
+        live_rows = cls.live().filter("key", key).get()
+        # (a) exact case-folded equality
+        target: Self | None = None
+        matched_old: str | None = None
+        for row in live_rows:
+            if (row.value or "").lower().strip() == norm_old:
+                target = row
+                matched_old = row.value
+                break
+        # (b) unique-substring
+        if target is None:
+            matches: list[Self] = []
+            for row in live_rows:
+                if norm_old and norm_old in (row.value or "").lower().strip():
+                    matches.append(row)
+            if len(matches) == 1:
+                target = matches[0]
+                matched_old = target.value
+        if target is None:
+            return None
+        # new value equals matched row → reinforce
+        if norm_new == (target.value or "").lower().strip():
+            return target.reinforce(), "reinforced", matched_old
+        # demote the old row, then insert new via store_coexist
+        target.demote()
+        new_row, _status, _ = cls.store_coexist(key, value, source=source)
+        return new_row, "superseded", matched_old
+
+    @classmethod
     def store_immutable(cls, key: str, value: str,
                         source: str | None = None) -> tuple[Self, str, str | None]:
         """Immutable single-value upsert at the canonical ``key``. No live row →

--- a/backend/services/fact_service.py
+++ b/backend/services/fact_service.py
@@ -165,7 +165,7 @@ class FactService:
         self.mp = mp
 
     def store(self, key: str, value: str, source: str | None = None,
-              canonicalize: bool = True) -> dict[str, object]:
+              canonicalize: bool = True, replaces: str | None = None) -> dict[str, object]:
         """Upsert one fact; return the typed status envelope.
 
         ``canonicalize=True`` (default — the LLM memory tool and ``save_graph``)
@@ -181,7 +181,15 @@ class FactService:
         ``canonicalize=False`` (the fact-extraction worker, which already shows
         the extraction model the real neighbour keys) short-circuits to the
         exact-key temporal store with NO LUT — re-canonicalizing there would
-        fight the model's choice and break exact-key supersession targeting."""
+        fight the model's choice and break exact-key supersession targeting.
+
+        ``replaces`` (optional) is consumed only by the coexist branch: when
+        truthy it is forwarded to :meth:`FactRow.supersede_value` so the caller
+        can name a stale value to demote before inserting the new one. A hit
+        returns ``superseded``/``reinforced`` with ``old_value`` set to the
+        matched row's value; a miss falls back to ``store_coexist`` and the
+        envelope carries ``replaces_missed`` so the caller knows the hint was
+        ignored."""
         if not canonicalize:
             row, status, old_value = FactRow.store(key, value, source=source)
             return self._store_envelope(status, key, key, value, old_value, None, None, row)
@@ -199,8 +207,20 @@ class FactService:
         canonical_key = cast(str, hit["canonical_key"])
         rule = cast(str, hit["rule"])
         if rule == "coexist":
+            if replaces:
+                supersede_result = FactRow.supersede_value(canonical_key, replaces, value, source=source)
+                if supersede_result is not None:
+                    new_row, supersede_status, matched_old = supersede_result
+                    return self._store_envelope(supersede_status, key, canonical_key, value, matched_old, rule, None, new_row)
             row, status, all_values = FactRow.store_coexist(canonical_key, value, source=source)
-            return self._store_envelope(status, key, canonical_key, value, None, rule, all_values, row)
+            result = self._store_envelope(status, key, canonical_key, value, None, rule, all_values, row)
+            if replaces:
+                # The hint failed on EVERY fallback outcome — reinforced included:
+                # the new value already being live says nothing about the stale
+                # one the caller asked to demote. Silence here would read as a
+                # clean store while the stale value stays live.
+                result["replaces_missed"] = replaces
+            return result
         if rule == "immutable":
             row, status, old_value = FactRow.store_immutable(canonical_key, value, source=source)
             return self._store_envelope(status, key, canonical_key, value, old_value, rule, None, row)

--- a/backend/services/memory_retrieval.py
+++ b/backend/services/memory_retrieval.py
@@ -100,7 +100,8 @@ def handle_store(channel: str, params: dict[str, object]) -> ToolResult:
     result: dict[str, object]
     if kind == "user_specific":
         from services.fact_service import FactService
-        result = FactService().store(key, str(value), source=source)  # full envelope
+        replaces_val = params.get("replaces")
+        result = FactService().store(key, str(value), source=source, replaces=replaces_val)  # full envelope
     elif kind == "system":
         from services.system_service import SystemService
         result = SystemService().store(key, str(value), source=source)  # full envelope
@@ -136,6 +137,7 @@ def _format_store_response(result: dict[str, object]) -> str:
     provided = result.get("provided_key", "")
     value = result.get("value", "")
     date = result.get("date")
+    replaces_missed = result.get("replaces_missed")
 
     if canonical != provided:
         key_display = f"'{canonical}' (canonical of '{provided}')"
@@ -143,34 +145,38 @@ def _format_store_response(result: dict[str, object]) -> str:
         key_display = f"'{canonical}'"
 
     if status == "created":
-        return f"{key_display} saved as '{value}'."
-
-    if status == "reinforced":
-        return f"{key_display} was already set on {date}. Memory reinforced."
-
-    if status == "superseded":
+        body = f"{key_display} saved as '{value}'."
+    elif status == "reinforced":
+        body = f"{key_display} was already set on {date}. Memory reinforced."
+    elif status == "superseded":
         old = result.get("old_value", "")
-        return f"{key_display} updated to '{value}'. Supersedes '{old}' (previously set on {date})."
-
-    if status == "conflict":
+        body = f"{key_display} updated to '{value}'. Supersedes '{old}' (previously set on {date})."
+    elif status == "conflict":
         old = result.get("old_value", "")
-        return (
+        body = (
             f"{key_display} is immutable. Existing value '{old}' (set {date}) kept. "
             f"New value '{value}' rejected. Use 'forget' first if you're sure."
         )
-
-    if status == "appended":
+    elif status == "appended":
         all_vals = cast("list[object]", result.get("all_values") or [])
         vals_str = ", ".join(f"'{v}'" for v in all_vals)
-        return f"{key_display} updated. Values now: [{vals_str}] (previously updated on {date})."
+        body = f"{key_display} updated. Values now: [{vals_str}] (previously updated on {date})."
+    elif status == "lut_miss_created":
+        body = f"'{provided}' saved as '{value}'."
+    else:
+        # A bare store for the other data_graph kinds yields no status and falls
+        # through to this plain confirmation. The `lut_miss_reinforced`/
+        # `lut_miss_appended` statuses were never emitted and stay unhandled by design.
+        body = f"'{provided}' stored."
 
-    if status == "lut_miss_created":
-        return f"'{provided}' saved as '{value}'."
+    if replaces_missed:
+        body += (
+            f" Could not find old value '{replaces_missed}' under this key — "
+            f"it was NOT removed and may still be stored. Use 'forget' with "
+            f"the exact old value to remove it."
+        )
 
-    # A bare store for the other data_graph kinds yields no status and falls
-    # through to this plain confirmation. The `lut_miss_reinforced`/
-    # `lut_miss_appended` statuses were never emitted and stay unhandled by design.
-    return f"'{provided}' stored."
+    return body
 
 
 # ── Forget ───────────────────────────────────────────────────────────

--- a/backend/tests/test_fact_supersede_value.py
+++ b/backend/tests/test_fact_supersede_value.py
@@ -6,12 +6,12 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
-"""Feature test: value-addressed coexist supersede (TKT-1540).
+"""Feature test: value-addressed coexist supersede.
 
 Coexist-rule concept keys (``relationships``, ``family``, ``name``) append
 values with no revision path: a corrected fact stored under the same canonical
-key kept the stale value live forever (run 1015: "Married to Tom" stayed live
-next to "Married to Thomas (goes by Tom)"). :meth:`FactRow.supersede_value`
+key kept the stale value live forever ("Married to Tom" observed live next to
+"Married to Thomas (goes by Tom)"). :meth:`FactRow.supersede_value`
 plus the memory tool's optional ``replaces`` store param give the model a
 deterministic demote+insert — no thresholds, no similarity heuristics.
 
@@ -19,7 +19,7 @@ Part 1 exercises the FactRow matching ladder pure-DB: the canonical key is
 given directly, so no LUT or key-embedding sits in the loop. Part 2 drives the
 real production path via ``DispatchService.dispatch("memory")`` with zero
 mocks — real concept LUT, real embeddings — on the canonical coexist key
-``relationships``, the exact key of the run-1015 failure (precedent:
+``relationships``, the exact key of the observed failure (precedent:
 ``test_memory_recall_guardrail_and_seed_radius.py``)."""
 
 import sqlite3
@@ -149,7 +149,7 @@ def test_same_value_reinforces_instead_of_churning(db: sqlite3.Connection) -> No
 
 
 def test_store_with_replaces_supersedes_on_canonical_coexist_key(db: sqlite3.Connection) -> None:
-    """The run-1015 shape, fixed: a correction stored under the canonical
+    """The observed defect shape, fixed: a correction stored under the canonical
     coexist key ``relationships`` with ``replaces`` demotes the stale value
     instead of accumulating next to it."""
     mp = _build_user_mp("actually he goes by Tom, his name is Thomas")

--- a/backend/tests/test_fact_supersede_value.py
+++ b/backend/tests/test_fact_supersede_value.py
@@ -1,0 +1,209 @@
+# Copyright 2026 Chalie AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Feature test: value-addressed coexist supersede (TKT-1540).
+
+Coexist-rule concept keys (``relationships``, ``family``, ``name``) append
+values with no revision path: a corrected fact stored under the same canonical
+key kept the stale value live forever (run 1015: "Married to Tom" stayed live
+next to "Married to Thomas (goes by Tom)"). :meth:`FactRow.supersede_value`
+plus the memory tool's optional ``replaces`` store param give the model a
+deterministic demote+insert — no thresholds, no similarity heuristics.
+
+Part 1 exercises the FactRow matching ladder pure-DB: the canonical key is
+given directly, so no LUT or key-embedding sits in the loop. Part 2 drives the
+real production path via ``DispatchService.dispatch("memory")`` with zero
+mocks — real concept LUT, real embeddings — on the canonical coexist key
+``relationships``, the exact key of the run-1015 failure (precedent:
+``test_memory_recall_guardrail_and_seed_radius.py``)."""
+
+import sqlite3
+
+import pytest
+
+from configs.channels import UserConfig
+from controllers.message_processor import MessageProcessor
+from models.fact import FactRow
+
+pytestmark = pytest.mark.unit
+
+_KEY = "relationships"
+
+
+def _build_user_mp(text: str) -> MessageProcessor:
+    """Real MessageProcessor with the synchronous half of begin() replayed —
+    same idiom as test_memory_recall_guardrail_and_seed_radius.py."""
+    mp = MessageProcessor(UserConfig(), raw_input=text)
+    mp.active_tools = list(mp.config.always_available or [])
+    with mp.db.transaction():
+        mp.turn_id = mp.transcript_service.allocate_turn()
+        mp.uid = mp.transcript_service.append_input(mp.raw_input)
+        mp.current_transcript_id = mp.uid
+    return mp
+
+
+def _row_state(db: sqlite3.Connection, row_id: int) -> tuple[int, float, str | None]:
+    row = db.execute(
+        "SELECT active, retrieval_weight, valid_to FROM data_graph WHERE id = ?",
+        (row_id,),
+    ).fetchone()
+    assert row is not None
+    return row[0], row[1], row[2]
+
+
+# ── Part 1: the FactRow matching ladder, pure DB ────────────────────────────────
+
+
+def test_exact_match_demotes_old_and_inserts_new(db: sqlite3.Connection) -> None:
+    old_row, _, _ = FactRow.store_coexist(_KEY, "Married to Tom")
+    FactRow.store_coexist(_KEY, "Son named Max")
+    _, rw_before, _ = _row_state(db, old_row.id)
+
+    result = FactRow.supersede_value(_KEY, "Married to Tom", "Married to Thomas (goes by Tom)")
+
+    assert result is not None
+    new_row, status, matched_old = result
+    assert status == "superseded"
+    assert matched_old == "Married to Tom"
+    # Old row demoted: active=0, retrieval_weight halved, valid_to stamped.
+    active, rw_after, valid_to = _row_state(db, old_row.id)
+    assert active == 0
+    assert rw_after == pytest.approx(rw_before * 0.5)
+    assert valid_to is not None
+    # Live set: the new value replaced the old; the unrelated value survived.
+    live = FactRow.active_values(_KEY)
+    assert sorted(live) == sorted(["Married to Thomas (goes by Tom)", "Son named Max"])
+    assert new_row.value == "Married to Thomas (goes by Tom)"
+
+
+def test_case_folded_match(db: sqlite3.Connection) -> None:
+    assert db is not None
+    FactRow.store_coexist(_KEY, "Married to Tom")
+
+    result = FactRow.supersede_value(_KEY, "  MARRIED TO TOM ", "Married to Thomas")
+
+    assert result is not None
+    assert result[1] == "superseded"
+    assert FactRow.active_values(_KEY) == ["Married to Thomas"]
+
+
+def test_unique_substring_match(db: sqlite3.Connection) -> None:
+    assert db is not None
+    FactRow.store_coexist(_KEY, "Married to Tom")
+    FactRow.store_coexist(_KEY, "Son named Max")
+
+    # "Tom" appears in exactly one live value — rung (b) resolves it.
+    result = FactRow.supersede_value(_KEY, "Tom", "Married to Thomas")
+
+    assert result is not None
+    _, status, matched_old = result
+    assert status == "superseded"
+    assert matched_old == "Married to Tom"
+    assert sorted(FactRow.active_values(_KEY)) == sorted(["Married to Thomas", "Son named Max"])
+
+
+def test_ambiguous_substring_returns_none(db: sqlite3.Connection) -> None:
+    assert db is not None
+    FactRow.store_coexist(_KEY, "Married to Tom")
+    FactRow.store_coexist(_KEY, "Tommy is my cat")
+
+    # "tom" is a substring of BOTH live values — ambiguous, no write.
+    result = FactRow.supersede_value(_KEY, "tom", "Married to Thomas")
+
+    assert result is None
+    assert sorted(FactRow.active_values(_KEY)) == sorted(["Married to Tom", "Tommy is my cat"])
+
+
+def test_absent_value_returns_none(db: sqlite3.Connection) -> None:
+    assert db is not None
+    FactRow.store_coexist(_KEY, "Married to Tom")
+
+    result = FactRow.supersede_value(_KEY, "Best friend is Alice", "Best friend is Alicia")
+
+    assert result is None
+    assert FactRow.active_values(_KEY) == ["Married to Tom"]
+
+
+def test_same_value_reinforces_instead_of_churning(db: sqlite3.Connection) -> None:
+    row, _, _ = FactRow.store_coexist(_KEY, "Married to Tom")
+
+    # Old and new resolve to the same live row — reinforce, never demote+reinsert.
+    result = FactRow.supersede_value(_KEY, "Married to Tom", "married to tom")
+
+    assert result is not None
+    reinforced, status, matched_old = result
+    assert status == "reinforced"
+    assert matched_old == "Married to Tom"
+    assert reinforced.id == row.id
+    active, _, _ = _row_state(db, row.id)
+    assert active == 1
+    assert FactRow.active_values(_KEY) == ["Married to Tom"]
+
+
+# ── Part 2: end-to-end through dispatch("memory") — real LUT, real embeddings ──
+
+
+def test_store_with_replaces_supersedes_on_canonical_coexist_key(db: sqlite3.Connection) -> None:
+    """The run-1015 shape, fixed: a correction stored under the canonical
+    coexist key ``relationships`` with ``replaces`` demotes the stale value
+    instead of accumulating next to it."""
+    mp = _build_user_mp("actually he goes by Tom, his name is Thomas")
+
+    mp.dispatch_service.dispatch(
+        "memory", {"action": "store", "key": _KEY, "value": "Married to Tom"}
+    )
+    out = mp.dispatch_service.dispatch(
+        "memory",
+        {
+            "action": "store",
+            "key": _KEY,
+            "value": "Married to Thomas (goes by Tom)",
+            "replaces": "Married to Tom",
+        },
+    )
+
+    live = FactRow.active_values(_KEY)
+    assert "Married to Thomas (goes by Tom)" in live
+    assert "Married to Tom" not in live
+    # The demoted row still exists, closed out bi-temporally.
+    row = db.execute(
+        "SELECT active, valid_to FROM data_graph "
+        "WHERE kind = 'user_specific' AND key = ? AND value = ?",
+        (_KEY, "Married to Tom"),
+    ).fetchone()
+    assert row is not None
+    assert row[0] == 0
+    assert row[1] is not None
+    # The response names the superseded value so the model sees the demotion.
+    assert "Married to Tom" in out
+
+
+def test_store_with_missed_replaces_appends_and_warns(db: sqlite3.Connection) -> None:
+    """A ``replaces`` hint that matches nothing must fail LOUDLY: the new value
+    is stored alongside, the response quotes the missed value and points at the
+    ``forget`` action — never a silent clean-store."""
+    assert db is not None
+    mp = _build_user_mp("my best friend is Alice")
+
+    mp.dispatch_service.dispatch(
+        "memory", {"action": "store", "key": _KEY, "value": "Married to Tom"}
+    )
+    out = mp.dispatch_service.dispatch(
+        "memory",
+        {
+            "action": "store",
+            "key": _KEY,
+            "value": "Best friend is Alice",
+            "replaces": "Colleague named Dave",
+        },
+    )
+
+    live = FactRow.active_values(_KEY)
+    assert sorted(live) == sorted(["Married to Tom", "Best friend is Alice"])
+    assert "Colleague named Dave" in out
+    assert "forget" in out


### PR DESCRIPTION
## TKT-1540 — coexist-rule facts had no revision path: corrections accumulated next to stale values

### Root cause (proven, run 1015)

The concept LUT maps `relationships`, `family`, `name` to rule=**coexist**; coexist routes to `FactRow.store_coexist`, which appends values and has **no revision path** (its only dedup is exact case-folded value equality). Run 1015 stored the marriage correction under the exact canonical key `relationships` → coexist → append: `"Married to Tom"` stayed live next to `"Married to Thomas (goes by Tom)"`. The passing run 1013 only passed because its key (`marriage`) was a LUT miss that fell into the raw-key **temporal** supersede path.

Embedding auto-detection of revisions was measured and rejected on the production pipeline (gte-modernbert-base ONNX / mean-pool / L2-norm): revision-pair min cosine 0.6954 sits **below** distinct-pair max 0.8610 — the distributions interleave, no threshold exists.

### Mechanism (deterministic, zero thresholds)

An optional `replaces` param on the memory tool's `store` action, naming the OLD value — mirroring `forget`'s existing multi-value selector contract:

- **`FactRow.supersede_value(key, old_value, value)`** — value-addressed demote+insert over the key's live rows. Match ladder: (a) exact case-folded equality; (b) unique-substring (exactly one live row contains the old value); (c) absent/ambiguous → `None`, no write. Same-value hit reinforces instead of churning. Demotion goes through the existing `demote()` (active=0, retrieval_weight halved, `valid_to` stamped); insert delegates to `store_coexist` so dedup stays single-sourced.
- **`FactService.store(..., replaces=)`** — consumed only by the coexist branch. A miss falls back to the normal append and the envelope carries `replaces_missed` **unconditionally** (even on `reinforced` — the new value being live says nothing about the stale one the caller asked to demote).
- **Render** — a missed `replaces` appends a loud warning quoting the missed value and pointing at `forget`. All other statuses render exactly as before.
- **Schema** — `replaces` exposed on the memory tool (optional; `old_value`/`previous_value` heal to it via the key-variant registry). Temporal/immutable/LUT-miss branches ignore it.

Also fixed in passing: the `key` param description claimed a canonical-key list "in the tool description" that no code renders, with a hardcoded concept count that had already drifted (says 27; the LUT ships 28).

### Tests

`backend/tests/test_fact_supersede_value.py` — 8 feature tests, zero mocks:

- Part 1 (pure DB): exact-match demote+insert with rw-halving and `valid_to` assertions, case-folded match, unique-substring match, ambiguous substring → no write, absent value → no write, same-value reinforce.
- Part 2 (end-to-end via `DispatchService.dispatch("memory")`, real LUT + real embeddings, on the exact run-1015 key `relationships`): correction with `replaces` demotes the stale value bi-temporally; a missed `replaces` appends, quotes the missed value, and points at `forget`.

### Out of scope

The pronoun-misresolution half of the ticket is model behaviour with no deterministic mechanism to assert on; this fix removes the stale-value fuel that made those misresolutions sticky.

Taskie: TKT-1540

🤖 Generated with [Claude Code](https://claude.com/claude-code)
