### PR TITLE
fix(turn): never settle a completely empty completion — bounded steer, then loud crash (TKT-1538)

### DIFF
--- a/backend/controllers/message_processor.py
+++ b/backend/controllers/message_processor.py
@@ -66,6 +66,7 @@ from configs.enums.channels import Channel
 from configs.enums.provider_type import ProviderType
 from configs.enums.thinking_level import ThinkingLevel
 from exceptions import (
+    EmptyCompletionLoop,
     ProviderResponseError,
     ProviderRetriesExhaustedError,
     RequestOverCapError,
@@ -109,6 +110,17 @@ _SEED_UPLOAD_ID_RE = re.compile(r'"id":"([0-9a-f]+)"')
 #: trips a loud ``RunAwayLoop`` (a CRASHED turn).
 _RUNAWAY_TOOL_CALL_LIMIT = 5
 _RUNAWAY_TEXT_LIMIT = 3
+
+#: Empty-completion steers granted before the turn trips ``EmptyCompletionLoop``
+#: (a CRASHED turn): a completion with no tool calls and no text, on a turn with
+#: no tool activity at all, is steered into a retry — the steer text enters the
+#: next request body, since without it the re-send would be byte-identical.
+_EMPTY_COMPLETION_STEER_LIMIT = 2
+_EMPTY_COMPLETION_STEER = (
+    "Your previous reply was empty — no message and no tool calls. An empty "
+    "reply is never a valid answer. Address the user's request now: call the "
+    "tools you need, or write your reply."
+)
 
 
 class _TurnCancelled(Exception):
@@ -168,6 +180,13 @@ class MessageProcessor:
         # (stripped, non-empty) response text; read only in _guard_runaway.
         self._tool_invocations: Counter[tuple[str, str]] = Counter()
         self._text_emissions: Counter[str] = Counter()
+
+        # Empty-completion guard — scoped to this turn_execution like the tallies
+        # above: counts completions with no tool calls and no text on a turn with
+        # no tool activity at all; the flag arms a one-shot steer for the next
+        # _build_messages.
+        self._empty_completions: int = 0
+        self._empty_completion_steer: bool = False
 
         # Infrastructure handles.
         self.db = Database()
@@ -305,6 +324,26 @@ class MessageProcessor:
             raise _TurnCancelled()
         tool_calls = response.tool_calls
         if not tool_calls:
+            if not (response.text or "").strip() and not self._tool_invocations:
+                # The model did NOTHING this turn: no text, no tool calls now,
+                # and no tool activity on any earlier step (the tally is
+                # populated by every tool-bearing step). Settling would render
+                # silence as an answered turn (run 1011: empty assistant row
+                # stored, turn COMPLETED). A turn that DID run tools may still
+                # finish silently — background channels end that way by design.
+                self._empty_completions += 1
+                if self._empty_completions > _EMPTY_COMPLETION_STEER_LIMIT:
+                    raise EmptyCompletionLoop(
+                        f"turn {self.turn_id}: model returned "
+                        f"{self._empty_completions} empty completions (no text, "
+                        f"no tool calls) — refusing to settle an unanswered turn",
+                    )
+                logger.warning(
+                    "[MessageProcessor] turn %s: empty completion %s/%s — steering a retry",
+                    self.turn_id, self._empty_completions, _EMPTY_COMPLETION_STEER_LIMIT,
+                )
+                self._empty_completion_steer = True
+                return self._step()
             formatted = self._store(response.text)
             self._end(response.text)
             return formatted
@@ -382,6 +421,9 @@ class MessageProcessor:
         (history + tool-result re-feed live inside ``prompt_service``) wrapped by
         the compaction checkpoint, plus this turn's image when one is attached."""
         body = self.compaction_service.checkpoint(self.prompt_service.user_prompt())
+        if self._empty_completion_steer:
+            self._empty_completion_steer = False
+            body += "\n\n" + _EMPTY_COMPLETION_STEER
         message: dict[str, object] = {"role": "user", "content": body}
         image = self.prompt_service.image()
         if image is not None:

--- a/backend/controllers/message_processor.py
+++ b/backend/controllers/message_processor.py
@@ -327,10 +327,10 @@ class MessageProcessor:
             if not (response.text or "").strip() and not self._tool_invocations:
                 # The model did NOTHING this turn: no text, no tool calls now,
                 # and no tool activity on any earlier step (the tally is
-                # populated by every tool-bearing step). Settling would render
-                # silence as an answered turn (run 1011: empty assistant row
-                # stored, turn COMPLETED). A turn that DID run tools may still
-                # finish silently — background channels end that way by design.
+                # populated by every tool-bearing step). Settling would store
+                # an empty assistant row and render silence as an answered
+                # turn. A turn that DID run tools may still finish silently —
+                # background channels end that way by design.
                 self._empty_completions += 1
                 if self._empty_completions > _EMPTY_COMPLETION_STEER_LIMIT:
                     raise EmptyCompletionLoop(

--- a/backend/exceptions/__init__.py
+++ b/backend/exceptions/__init__.py
@@ -11,6 +11,7 @@ only re-exports so callers never depend on the internal file layout.
 from exceptions.chalie_exception import ChalieException
 from exceptions.exception import (
     DownloadTooLarge,
+    EmptyCompletionLoop,
     EndpointError,
     FetchBlocked,
     ForbiddenError,
@@ -40,6 +41,7 @@ from exceptions.exception import (
 __all__ = [
     "ChalieException",
     "DownloadTooLarge",
+    "EmptyCompletionLoop",
     "EndpointError",
     "FetchBlocked",
     "ForbiddenError",

--- a/backend/exceptions/exception.py
+++ b/backend/exceptions/exception.py
@@ -138,6 +138,17 @@ class RunAwayLoop(ChalieException):
     """
 
 
+class EmptyCompletionLoop(ChalieException):
+    """The model keeps returning completely empty completions.
+
+    A completion with no tool calls and no text, on a turn that has run no
+    tools at all, means the model did nothing whatsoever — settling it
+    would render silence as an answered turn. The MessageProcessor steers
+    a bounded retry first; when the model stays empty past the limit it
+    trips this loudly and ``_drive`` stamps the turn CRASHED.
+    """
+
+
 # ── Search layer ──────────────────────────────────────────────────────────────
 
 

--- a/backend/tests/test_message_processor_empty_completion.py
+++ b/backend/tests/test_message_processor_empty_completion.py
@@ -1,0 +1,217 @@
+# Copyright 2026 Chalie AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Feature test: the empty-completion guard (TKT-1538).
+
+A completion with no tool calls and no text, on a turn that has run no tools at
+all, means the model did nothing whatsoever. Settling it renders silence as an
+answered turn (nightly run 1011: empty assistant row stored, turn COMPLETED, the
+only tool row the pre-turn auto recall seed). The guard steers a bounded retry —
+the steer text enters the NEXT request body, since without it the re-send would
+be byte-identical — and past ``_EMPTY_COMPLETION_STEER_LIMIT`` steers trips a
+loud ``EmptyCompletionLoop`` (CRASHED turn, same path as ``RunAwayLoop``). A
+turn that DID run tools may still finish silently — background channels end
+that way by design.
+
+Same harness as ``test_message_processor_runaway_loop.py``: the real production
+entry point (inert construct, ``begin()``, ``result()``) against the real DB and
+services; the only substitution is the LLM network boundary via
+``services.provider_service.build_client``. The scripted client here also
+records every request so steer injection is asserted on the actual bodies sent.
+"""
+
+import sqlite3
+import threading
+import time
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+
+from configs.channels.user import UserConfig
+from controllers.message_processor import (
+    _EMPTY_COMPLETION_STEER,
+    _EMPTY_COMPLETION_STEER_LIMIT,
+    MessageProcessor,
+)
+from models.provider_response import ProviderResponse
+from models.transcript import Transcript
+from models.turn_execution import TurnExecution
+
+pytestmark = pytest.mark.unit
+
+_BUILD_CLIENT = "services.provider_service.build_client"
+
+
+class _ScriptedProvider:
+    """Replays one scripted ``ProviderResponse`` per ``send()``, in order, and
+    records every request DTO. Past the end of the script it returns an empty
+    terminal — under this guard a zero-tool turn hitting it repeatedly CRASHES
+    (never hangs), so the overflow tolerance for unscripted post-turn daemon
+    turns still terminates them."""
+
+    _TERMINAL = ProviderResponse(text="", model="scripted-overflow", tool_calls=None)
+
+    def __init__(self, *responses: ProviderResponse) -> None:
+        self._responses = list(responses)
+        self.requests: list[object] = []
+
+    def get_context_limit(self) -> int:
+        return 200000
+
+    def estimate_request_tokens(self, _dto: object) -> int:
+        return 1
+
+    def send(self, dto: object) -> ProviderResponse:
+        self.requests.append(dto)
+        if len(self.requests) > len(self._responses):
+            return self._TERMINAL
+        return self._responses[len(self.requests) - 1]
+
+
+def _drain_background_turns(timeout_s: float = 10.0) -> None:
+    """Join the fire-and-forget post-turn daemon turns a completed ``user`` turn
+    spawns, so they run to completion inside THIS test's provider+DB patch (see
+    ``test_message_processor_runaway_loop.py`` for the full rationale)."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        pending = [
+            t for t in threading.enumerate()
+            if t.name in ("skill-suggest", "thread-gist") or t.name.startswith("turn-")
+        ]
+        if not pending:
+            return
+        for t in pending:
+            t.join(timeout=deadline - time.monotonic())
+
+
+def _run(provider: _ScriptedProvider, raw_input: str) -> MessageProcessor:
+    mp = MessageProcessor(UserConfig(), raw_input=raw_input)  # inert (I2)
+    with patch(_BUILD_CLIENT, return_value=provider):
+        mp.begin()
+        mp.result()
+        _drain_background_turns()
+    return mp
+
+
+def _assistant_rows(mp: MessageProcessor) -> list[dict[str, object]]:
+    return [r for r in Transcript.by_turn(mp.channel, mp.turn_id) if r["role"] == "assistant"]
+
+
+def _body(provider: _ScriptedProvider, i: int) -> str:
+    """The user-message content of the i-th request actually sent. Requests are
+    appended in send order, and the asserted turn's sends all precede any
+    post-turn daemon turn's (those spawn inside the terminal step)."""
+    request = provider.requests[i]
+    messages = cast("list[dict[str, object]]", getattr(request, "messages"))
+    return cast("str", messages[0]["content"])
+
+
+def _tool(name: str, **params: object) -> dict[str, object]:
+    return {"name": name, "input": params}
+
+
+# ── Steered recovery ──────────────────────────────────────────────────────────
+
+
+def test_empty_completion_is_steered_then_settles(db: sqlite3.Connection) -> None:
+    """The run-1011 shape, recovered: the first completion is completely empty
+    (no tool calls, no text), the guard steers instead of settling, and the
+    model's second response answers. The turn COMPLETES with the real answer;
+    the steer text entered exactly the second request body."""
+    assert db is not None
+    provider = _ScriptedProvider(
+        ProviderResponse(text="", model="scripted", tool_calls=None),
+        ProviderResponse(text="Here is my answer.", model="scripted", tool_calls=None),
+    )
+
+    mp = _run(provider, "tell me about the docs")
+
+    assert mp.result() == "Here is my answer."
+    execution = mp.turn_execution_service.latest_for_turn()
+    assert execution is not None
+    assert execution.state == TurnExecution.COMPLETED
+    # Exactly one assistant row — the answer; the steered empty step stored nothing.
+    rows = _assistant_rows(mp)
+    assert len(rows) == 1
+    assert "Here is my answer." in cast("str", rows[0]["content"])
+    # The steer entered the retry request and ONLY the retry request.
+    assert _EMPTY_COMPLETION_STEER not in _body(provider, 0)
+    assert _EMPTY_COMPLETION_STEER in _body(provider, 1)
+
+
+def test_whitespace_only_completion_counts_as_empty(db: sqlite3.Connection) -> None:
+    """Whitespace-only text is no answer: it steers exactly like the empty
+    completion instead of being stored as the turn's prose."""
+    assert db is not None
+    provider = _ScriptedProvider(
+        ProviderResponse(text="  \n\t ", model="scripted", tool_calls=None),
+        ProviderResponse(text="Real answer.", model="scripted", tool_calls=None),
+    )
+
+    mp = _run(provider, "hello?")
+
+    assert mp.result() == "Real answer."
+    execution = mp.turn_execution_service.latest_for_turn()
+    assert execution is not None
+    assert execution.state == TurnExecution.COMPLETED
+    assert _EMPTY_COMPLETION_STEER in _body(provider, 1)
+
+
+# ── Bounded: persistent emptiness crashes ─────────────────────────────────────
+
+
+def test_persistent_empty_completions_crash_the_turn(db: sqlite3.Connection) -> None:
+    """A model that stays empty past the steer limit trips ``EmptyCompletionLoop``:
+    the turn ends CRASHED with the reason naming the empty completions, no
+    assistant row is ever written, and the send count is exactly
+    ``1 + _EMPTY_COMPLETION_STEER_LIMIT`` — the guard is bounded, never an
+    infinite re-send loop."""
+    assert db is not None
+    provider = _ScriptedProvider()  # every send returns the empty terminal
+
+    mp = _run(provider, "say something")
+
+    execution = mp.turn_execution_service.latest_for_turn()
+    assert execution is not None
+    assert execution.state == TurnExecution.CRASHED
+    assert execution.stop_reason is not None
+    assert "empty completions" in execution.stop_reason
+    assert _assistant_rows(mp) == []
+    # First send unsteered, every steered retry after it, then the raise — a
+    # crashed turn spawns no post-turn daemons, so these are ALL the sends.
+    assert len(provider.requests) == 1 + _EMPTY_COMPLETION_STEER_LIMIT
+    assert _EMPTY_COMPLETION_STEER not in _body(provider, 0)
+    for i in range(1, len(provider.requests)):
+        assert _EMPTY_COMPLETION_STEER in _body(provider, i)
+
+
+# ── Silent finish after real tool work stays legitimate ───────────────────────
+
+
+def test_silent_finish_after_tool_work_settles(db: sqlite3.Connection) -> None:
+    """An empty terminal completion AFTER a tool-bearing step settles exactly as
+    before — background channels end silently by design once their work ran. The
+    guard keys on the turn-wide tool tally, not on the terminal step alone."""
+    assert db is not None
+    provider = _ScriptedProvider(
+        ProviderResponse(text="", model="scripted", tool_calls=[_tool("noop_probe", q="x")]),
+        ProviderResponse(text="", model="scripted", tool_calls=None),
+    )
+
+    mp = _run(provider, "run the probe")
+
+    execution = mp.turn_execution_service.latest_for_turn()
+    assert execution is not None
+    assert execution.state == TurnExecution.COMPLETED
+    # The silent settle stored the (empty) assistant row, as today.
+    assert len(_assistant_rows(mp)) == 1
+    # The main turn was never steered: neither of its two requests carries the
+    # steer text (post-turn daemon turns may be steered — different turns).
+    assert _EMPTY_COMPLETION_STEER not in _body(provider, 0)
+    assert _EMPTY_COMPLETION_STEER not in _body(provider, 1)

--- a/backend/tests/test_message_processor_empty_completion.py
+++ b/backend/tests/test_message_processor_empty_completion.py
@@ -6,12 +6,12 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
-"""Feature test: the empty-completion guard (TKT-1538).
+"""Feature test: the empty-completion guard.
 
 A completion with no tool calls and no text, on a turn that has run no tools at
 all, means the model did nothing whatsoever. Settling it renders silence as an
-answered turn (nightly run 1011: empty assistant row stored, turn COMPLETED, the
-only tool row the pre-turn auto recall seed). The guard steers a bounded retry —
+answered turn (an empty assistant row stored, turn COMPLETED, the only tool row
+the pre-turn auto recall seed). The guard steers a bounded retry —
 the steer text enters the NEXT request body, since without it the re-send would
 be byte-identical — and past ``_EMPTY_COMPLETION_STEER_LIMIT`` steers trips a
 loud ``EmptyCompletionLoop`` (CRASHED turn, same path as ``RunAwayLoop``). A
@@ -120,7 +120,7 @@ def _tool(name: str, **params: object) -> dict[str, object]:
 
 
 def test_empty_completion_is_steered_then_settles(db: sqlite3.Connection) -> None:
-    """The run-1011 shape, recovered: the first completion is completely empty
+    """The observed defect shape, recovered: the first completion is completely empty
     (no tool calls, no text), the guard steers instead of settling, and the
     model's second response answers. The turn COMPLETES with the real answer;
     the steer text entered exactly the second request body."""


### PR DESCRIPTION
## TKT-1538 — empty completion settled as an answered turn

### Root cause (run 1011)

On every failing `test_chalie_docs` turn (4/4 runs on minimax-m3) the model emitted a **completely empty completion** — zero tool calls, zero text — and Chalie settled the turn as COMPLETED with an empty assistant row. The `memory` row on those turns carries `"_auto": true` (the pre-turn recall seed, not a model decision), so the model did nothing whatsoever and silence was rendered as an answered turn. The ticket's "discovery step skipped" framing was a symptom: nothing was discovered because nothing at all was attempted.

### Mechanism (termination-path guard, no prompt band-aids)

The terminal branch of `MessageProcessor._step` now guards the truly-empty case. The guard fires only when **all three** hold:

1. the completion has no tool calls,
2. the completion has no non-whitespace text,
3. the turn's tool tally is empty — no tool-bearing step ran at all (the tally is populated by every tool-bearing step; the pre-turn auto seed bypasses `_step` and never counts).

When it fires:

- **Bounded steer** — up to `_EMPTY_COMPLETION_STEER_LIMIT` (2) retries. The steer text is injected into the next request body (without it the re-send would be byte-identical) and disarms after one injection.
- **Loud crash past the limit** — a new `EmptyCompletionLoop` trips on the same path as `RunAwayLoop`: `_drive` stamps the turn CRASHED with the reason. Silence is never again a valid answer.

A turn that DID run tools may still finish silently — background channels end that way by design; the guard keys on the turn-wide tally, not the terminal step alone.

**Interaction with TKT-1537 (PR #1980):** complementary — once the think-leak fix strips an unclosed think block, a completion that was all think-leak becomes empty text and now steers instead of settling silently.

### Tests

`backend/tests/test_message_processor_empty_completion.py` — 4 zero-mock feature tests through the real production entry point (`begin()`/`result()`, real DB and services, scripted provider at the `services.provider_service.build_client` seam, same harness as the runaway-loop suite):

- the run-1011 shape recovered: empty first completion → steer → real answer, turn COMPLETED, steer text present in exactly the retry request;
- whitespace-only text counts as empty;
- persistent emptiness crashes the turn after exactly `1 + limit` sends with the reason naming the empty completions — bounded, never an infinite re-send loop;
- an empty terminal completion after real tool work settles exactly as before.

Also verified green: the runaway-loop suite, cancel-mid-provider-call, seed consolidation (including the empty-encoder tolerance test), and the async delegate runner — every suite that scripts the provider seam (20/20).

Taskie: TKT-1538

🤖 Generated with [Claude Code](https://claude.com/claude-code)
