### PR TITLE
refactor: consolidate duplicated boilerplate in mail capability and schema convergence

### DIFF
--- a/backend/capabilities/mail_capability/capability.py
+++ b/backend/capabilities/mail_capability/capability.py
@@ -18,6 +18,8 @@ from services.file_mapper_service import FileMapperService
 from utils.data_utils import parse_json_column
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from capabilities.mail_capability.caldav_handler import _CalDAVClient  # noqa: PLC2701
     from capabilities.mail_capability.imap_handler import _ImapClient  # noqa: PLC2701
     from capabilities.mail_capability.carddav_handler import _CaldavClientProto  # noqa: PLC2701
@@ -502,7 +504,9 @@ class MailCapability(AbstractCapability):
     # Tools — IMAP handler methods
     # ------------------------------------------------------------------
 
-    def _th_search_email(self, params: dict[str, object], telemetry: object = None) -> dict[str, object]:
+    def _run_imap(
+        self, fn: Callable[[_ImapClient], dict[str, object]],
+    ) -> dict[str, object]:
         if not self._imap_ok:
             return {"error": _ERR_IMAP_NOT_CONNECTED}
         try:
@@ -510,7 +514,7 @@ class MailCapability(AbstractCapability):
             if client is None:
                 return {"error": "Failed to open IMAP connection."}
             try:
-                return self._imap_handler.search(client, params)
+                return fn(client)
             finally:
                 try:
                     client.logout()
@@ -518,60 +522,20 @@ class MailCapability(AbstractCapability):
                     pass
         except Exception as exc:
             return {"error": str(exc)}
+
+    def _th_search_email(self, params: dict[str, object], telemetry: object = None) -> dict[str, object]:
+        return self._run_imap(lambda client: self._imap_handler.search(client, params))
 
     def _th_read_email(self, params: dict[str, object], telemetry: object = None) -> dict[str, object]:
-        if not self._imap_ok:
-            return {"error": _ERR_IMAP_NOT_CONNECTED}
-        try:
-            client = self._open_imap_client()
-            if client is None:
-                return {"error": "Failed to open IMAP connection."}
-            try:
-                return self._imap_handler.read_email(client, params)
-            finally:
-                try:
-                    client.logout()
-                except Exception:
-                    pass
-        except Exception as exc:
-            return {"error": str(exc)}
+        return self._run_imap(lambda client: self._imap_handler.read_email(client, params))
 
     def _th_draft_email(self, params: dict[str, object], telemetry: object = None) -> dict[str, object]:
-        if not self._imap_ok:
-            return {"error": _ERR_IMAP_NOT_CONNECTED}
-        try:
-            _email = self.load_credential(_K_EMAIL)
-            client = self._open_imap_client()
-            if client is None:
-                return {"error": "Failed to open IMAP connection."}
-            try:
-                return self._imap_handler.draft_email(
-                    client, from_addr=cast(str, _email), params=params,
-                )
-            finally:
-                try:
-                    client.logout()
-                except Exception:
-                    pass
-        except Exception as exc:
-            return {"error": str(exc)}
+        return self._run_imap(lambda client: self._imap_handler.draft_email(
+            client, from_addr=cast(str, self.load_credential(_K_EMAIL)), params=params,
+        ))
 
     def _th_manage_email(self, params: dict[str, object], telemetry: object = None) -> dict[str, object]:
-        if not self._imap_ok:
-            return {"error": _ERR_IMAP_NOT_CONNECTED}
-        try:
-            client = self._open_imap_client()
-            if client is None:
-                return {"error": "Failed to open IMAP connection."}
-            try:
-                return self._imap_handler.manage_email(client, params)
-            finally:
-                try:
-                    client.logout()
-                except Exception:
-                    pass
-        except Exception as exc:
-            return {"error": str(exc)}
+        return self._run_imap(lambda client: self._imap_handler.manage_email(client, params))
 
     # ------------------------------------------------------------------
     # Tools — SMTP handler methods
@@ -680,60 +644,33 @@ class MailCapability(AbstractCapability):
     # Tools — CalDAV handler methods
     # ------------------------------------------------------------------
 
-    def _th_create_event(self, params: dict[str, object], telemetry: object = None) -> dict[str, object]:
+    def _run_caldav(
+        self, fn: Callable[[_CalDAVClient], dict[str, object]],
+    ) -> dict[str, object]:
         if not self._caldav_ok:
             return {"error": _ERR_CALDAV_NOT_CONNECTED}
         try:
             client = self._open_caldav_client()
             if client is None:
                 return {"error": _ERR_CALDAV_OPEN_FAILED}
-            return self._caldav_handler.create_event(client, params)
+            return fn(client)
         except Exception as exc:
             return {"error": str(exc)}
+
+    def _th_create_event(self, params: dict[str, object], telemetry: object = None) -> dict[str, object]:
+        return self._run_caldav(lambda client: self._caldav_handler.create_event(client, params))
 
     def _th_update_event(self, params: dict[str, object], telemetry: object = None) -> dict[str, object]:
-        if not self._caldav_ok:
-            return {"error": _ERR_CALDAV_NOT_CONNECTED}
-        try:
-            client = self._open_caldav_client()
-            if client is None:
-                return {"error": _ERR_CALDAV_OPEN_FAILED}
-            return self._caldav_handler.update_event(client, params)
-        except Exception as exc:
-            return {"error": str(exc)}
+        return self._run_caldav(lambda client: self._caldav_handler.update_event(client, params))
 
     def _th_delete_event(self, params: dict[str, object], telemetry: object = None) -> dict[str, object]:
-        if not self._caldav_ok:
-            return {"error": _ERR_CALDAV_NOT_CONNECTED}
-        try:
-            client = self._open_caldav_client()
-            if client is None:
-                return {"error": _ERR_CALDAV_OPEN_FAILED}
-            return self._caldav_handler.delete_event(client, params)
-        except Exception as exc:
-            return {"error": str(exc)}
+        return self._run_caldav(lambda client: self._caldav_handler.delete_event(client, params))
 
     def _th_list_events(self, params: dict[str, object], telemetry: object = None) -> dict[str, object]:
-        if not self._caldav_ok:
-            return {"error": _ERR_CALDAV_NOT_CONNECTED}
-        try:
-            client = self._open_caldav_client()
-            if client is None:
-                return {"error": _ERR_CALDAV_OPEN_FAILED}
-            return self._caldav_handler.list_events(client, params)
-        except Exception as exc:
-            return {"error": str(exc)}
+        return self._run_caldav(lambda client: self._caldav_handler.list_events(client, params))
 
     def _th_get_event(self, params: dict[str, object], telemetry: object = None) -> dict[str, object]:
-        if not self._caldav_ok:
-            return {"error": _ERR_CALDAV_NOT_CONNECTED}
-        try:
-            client = self._open_caldav_client()
-            if client is None:
-                return {"error": _ERR_CALDAV_OPEN_FAILED}
-            return self._caldav_handler.get_event(client, params)
-        except Exception as exc:
-            return {"error": str(exc)}
+        return self._run_caldav(lambda client: self._caldav_handler.get_event(client, params))
 
     def _th_find_free_slots(self, params: dict[str, object], telemetry: object = None) -> dict[str, object]:
         if not self._caldav_ok:

--- a/backend/services/schema_convergence_service.py
+++ b/backend/services/schema_convergence_service.py
@@ -7,7 +7,7 @@ import logging
 import os
 import re
 import sqlite3
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, ClassVar, Literal, TypeAlias
 
 from services.database import Database
 from services.file_mapper_service import FileMapperService
@@ -59,6 +59,29 @@ def _load_sqlite_vec(conn: sqlite3.Connection) -> None:
 
 
 class SchemaConvergenceService:
+
+    _DdlObjType: TypeAlias = Literal["table", "virtual_table", "trigger"]
+
+    # Comments are stripped before matching because schema.sql comments can
+    # contain semicolons (e.g. "-- dropped by migration 026; kept here."),
+    # which would otherwise terminate a [^;]+ match early.
+    _DDL_PATTERNS: ClassVar[dict[_DdlObjType, str]] = {
+        "table": (
+            r"(CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+            r"{name}\s*\([^;]+;)"
+        ),
+        "virtual_table": (
+            r"(CREATE\s+VIRTUAL\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+            r"{name}[^;]+;)"
+        ),
+        # Trigger bodies contain semicolons inside their BEGIN...END block, so
+        # [^;]+ (used for table/virtual_table) would truncate mid-body. Match
+        # through the closing END instead and consume the trailing semicolon.
+        "trigger": (
+            r"(CREATE\s+TRIGGER\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+            r"{name}\b.+?END\s*;)"
+        ),
+    }
 
     def __init__(self) -> None:
         self._schema_path = FileMapperService.get_schema_path()
@@ -320,7 +343,7 @@ class SchemaConvergenceService:
 
         for table_name, desired_cols in desired.items():
             if table_name not in actual:
-                ddl = self._extract_table_ddl(schema_sql, table_name)
+                ddl = self._extract_ddl(schema_sql, "table", table_name)
                 if ddl:
                     try:
                         live_conn.execute(ddl)
@@ -589,7 +612,7 @@ class SchemaConvergenceService:
 
         for table_name, desired_ddl in desired.items():
             if table_name not in actual:
-                raw_ddl = self._extract_virtual_table_ddl(schema_sql, table_name)
+                raw_ddl = self._extract_ddl(schema_sql, "virtual_table", table_name)
                 if not raw_ddl:
                     logger.warning(
                         f"[convergence] No DDL found for missing virtual table: {table_name}"
@@ -622,7 +645,7 @@ class SchemaConvergenceService:
                             f"[convergence] FTS5 column list changed for {table_name}: "
                             f"{live_cols} -> {desired_cols}. Rebuilding."
                         )
-                        raw_ddl = self._extract_virtual_table_ddl(schema_sql, table_name)
+                        raw_ddl = self._extract_ddl(schema_sql, "virtual_table", table_name)
                         if raw_ddl:
                             try:
                                 live_conn.execute(f"DROP TABLE IF EXISTS {table_name}")
@@ -660,7 +683,7 @@ class SchemaConvergenceService:
 
         for trigger_name, desired_ddl in desired.items():
             if trigger_name not in actual:
-                raw_ddl = self._extract_trigger_ddl(schema_sql, trigger_name)
+                raw_ddl = self._extract_ddl(schema_sql, "trigger", trigger_name)
                 if not raw_ddl:
                     logger.warning(
                         f"[convergence] No DDL found for missing trigger: {trigger_name}"
@@ -673,7 +696,7 @@ class SchemaConvergenceService:
                 except Exception as exc:
                     logger.error(f"[convergence] Failed to create trigger {trigger_name}: {exc}")
             elif actual[trigger_name] != desired_ddl:
-                raw_ddl = self._extract_trigger_ddl(schema_sql, trigger_name)
+                raw_ddl = self._extract_ddl(schema_sql, "trigger", trigger_name)
                 if not raw_ddl:
                     logger.warning(
                         f"[convergence] No DDL found for changed trigger: {trigger_name}"
@@ -840,42 +863,15 @@ class SchemaConvergenceService:
     # DDL extraction from schema.sql
     # ──────────────────────────────────────────────────────────────────────────
 
-    def _extract_table_ddl(self, schema_sql: str, table_name: str) -> str | None:
-        """Extract the CREATE TABLE ... ; block for a normal table from schema.sql."""
-        # Strip single-line SQL comments first — they can contain semicolons
-        # (e.g. "-- dropped by migration 026; kept here") which break [^;]+.
-        stripped = re.sub(_RE_SQL_COMMENTS, "",schema_sql)
-        pattern = re.compile(
-            r"(CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?" + re.escape(table_name) + r"\s*\([^;]+;)",
-            re.IGNORECASE | re.DOTALL,
-        )
-        match = pattern.search(stripped)
-        return match.group(1).strip() if match else None
+    def _extract_ddl(self, schema_sql: str, obj_type: _DdlObjType, name: str) -> str | None:
+        """Extract a DDL block from schema.sql for the given object type.
 
-    def _extract_virtual_table_ddl(self, schema_sql: str, table_name: str) -> str | None:
-        """Extract the CREATE VIRTUAL TABLE ... ; block for a virtual table from schema.sql."""
-        # Strip SQL comments before regex matching (same as _extract_table_ddl)
-        clean_sql = re.sub(_RE_SQL_COMMENTS, "",schema_sql)
-        pattern = re.compile(
-            r"(CREATE\s+VIRTUAL\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?" + re.escape(table_name) + r"[^;]+;)",
-            re.IGNORECASE | re.DOTALL,
-        )
-        match = pattern.search(clean_sql)
-        if not match:
-            return None
-        return match.group(1).strip()
-
-    def _extract_trigger_ddl(self, schema_sql: str, trigger_name: str) -> str | None:
-        """Extract the CREATE TRIGGER ... END ; block for a trigger from schema.sql.
-
-        SQLite trigger bodies contain semicolons inside the BEGIN...END block, so
-        we cannot rely on the simple split-on-semicolon approach used elsewhere.
-        Instead we match from CREATE TRIGGER <name> through the END keyword that
-        closes the outermost block, then consume the trailing semicolon.
+        See ``_DDL_PATTERNS`` for the regex templates used per type.
         """
-        stripped = re.sub(_RE_SQL_COMMENTS, "",schema_sql)
+        stripped = re.sub(_RE_SQL_COMMENTS, "", schema_sql)
+        template = self._DDL_PATTERNS[obj_type]
         pattern = re.compile(
-            r"(CREATE\s+TRIGGER\s+(?:IF\s+NOT\s+EXISTS\s+)?" + re.escape(trigger_name) + r"\b.+?END\s*;)",
+            template.format(name=re.escape(name)),
             re.IGNORECASE | re.DOTALL,
         )
         match = pattern.search(stripped)


### PR DESCRIPTION
## Summary

- Mail capability's IMAP tool methods (`_th_search_email`, `_th_read_email`, `_th_manage_email`, `_th_draft_email`) and CalDAV tool methods (`_th_create_event`, `_th_update_event`, `_th_delete_event`, `_th_list_events`, `_th_get_event`) each repeated the same open-client / call-handler / logout / error-handling shell around a different handler call. Extracted into `_run_imap` / `_run_caldav` helpers that take the varying call as a closure; the other mail-capability methods that don't share this shape were left untouched.
- Schema convergence's three DDL-extraction methods (`_extract_table_ddl`, `_extract_virtual_table_ddl`, `_extract_trigger_ddl`) repeated the same strip-comments/regex-search/return-or-None shape, differing only in the regex per object type. Consolidated into one `_extract_ddl` method backed by a `Literal`-typed pattern table, so the object-type argument can't be mistyped or accidentally crossed with an unrelated method's differently-scoped `obj_type` parameter of the same name.
- No behavior change. Net -67 lines.

## Test plan

- [x] `ruff check .` — zero new findings vs. `main` (existing findings for these two files went down, none went up)
- [x] `mypy .` (strict) — identical to `main` baseline (2 pre-existing, unrelated errors elsewhere; none introduced)
- [x] `pytest -m unit` — failure set identical to `main` baseline (one pre-existing, unrelated failure)
- [x] Consolidated DDL-extraction regexes verified against the real schema (all tables/virtual tables/triggers extract identically to the three original methods)