### PR TITLE
refactor: consolidate duplicate functions (2026-08-07)

### DIFF
--- a/backend/abilities/_result.py
+++ b/backend/abilities/_result.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
+    from pathlib import Path
 
 # Scalar types permitted in the flat ``meta`` map (rendered into the open tag).
 _SCALAR = (str, int, float, bool)
@@ -131,3 +132,19 @@ class ToolResult:
             hint=hint,
             valid=tuple(valid),
         )
+
+    @classmethod
+    def not_found(cls, target: Path) -> ToolResult:
+        return cls.err(
+            f"No such file or directory: {target}",
+            code="not-found",
+            hint="pass an absolute path to an existing file or directory.",
+        )
+
+    @classmethod
+    def permission_denied(cls, verb: str, target: Path, exc: PermissionError, *, hint: str) -> ToolResult:
+        return cls.err(f"Permission denied {verb} {target}: {exc}", code="permission-denied", hint=hint)
+
+    @classmethod
+    def path_os_error(cls, verb: str, target: Path, exc: OSError, *, code: str, hint: str) -> ToolResult:
+        return cls.err(f"Could not {verb} {target}: {exc}", code=code, hint=hint)

--- a/backend/abilities/delete.py
+++ b/backend/abilities/delete.py
@@ -95,11 +95,7 @@ class DeleteAbility(Ability[DeleteParamsBag]):
             return target
 
         if not target.exists():
-            return ToolResult.err(
-                f"No such file or directory: {target}",
-                code="not-found",
-                hint="pass an absolute path to an existing file or directory.",
-            )
+            return ToolResult.not_found(target)
 
         try:
             if target.is_dir():
@@ -107,16 +103,8 @@ class DeleteAbility(Ability[DeleteParamsBag]):
             else:
                 target.unlink()
         except PermissionError as exc:
-            return ToolResult.err(
-                f"Permission denied deleting {target}: {exc}",
-                code="permission-denied",
-                hint=f"you do not own {target} or cannot remove it.",
-            )
+            return ToolResult.permission_denied("deleting", target, exc, hint=f"you do not own {target} or cannot remove it.")
         except OSError as exc:
-            return ToolResult.err(
-                f"Could not delete {target}: {exc}",
-                code="not-found",
-                hint="the path may have been removed by another process.",
-            )
+            return ToolResult.path_os_error("delete", target, exc, code="not-found", hint="the path may have been removed by another process.")
 
         return ToolResult.ok({"path": str(target), "deleted": True})

--- a/backend/abilities/make_dir.py
+++ b/backend/abilities/make_dir.py
@@ -119,17 +119,12 @@ class MakeDirAbility(Ability[MakeDirParamsBag]):
                 hint="choose a different path, or delete the existing one first.",
             )
         except PermissionError as exc:
-            return ToolResult.err(
-                f"Permission denied creating {target}: {exc}",
-                code="permission-denied",
-                hint=f"you do not have write access to {target.parent}.",
-            )
+            return ToolResult.permission_denied("creating", target, exc, hint=f"you do not have write access to {target.parent}.")
         except OSError as exc:
             # NotADirectoryError lands here: a path component is a file, so no
             # directory can be created below it.
-            return ToolResult.err(
-                f"Could not create {target}: {exc}",
-                code="invalid-path",
+            return ToolResult.path_os_error(
+                "create", target, exc, code="invalid-path",
                 hint="check the path shape and that its parent can hold a directory.",
             )
 

--- a/backend/abilities/move.py
+++ b/backend/abilities/move.py
@@ -106,16 +106,8 @@ class MoveAbility(Ability[MoveParamsBag]):
             dst.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(str(src), str(dst))
         except PermissionError as exc:
-            return ToolResult.err(
-                f"Permission denied moving {src}: {exc}",
-                code="permission-denied",
-                hint="you do not have the required permissions to move this item.",
-            )
+            return ToolResult.permission_denied("moving", src, exc, hint="you do not have the required permissions to move this item.")
         except OSError as exc:
-            return ToolResult.err(
-                f"Could not move {src}: {exc}",
-                code="invalid-path",
-                hint="check the path shape and that its parent can hold the destination.",
-            )
+            return ToolResult.path_os_error("move", src, exc, code="invalid-path", hint="check the path shape and that its parent can hold the destination.")
 
         return ToolResult.ok({"from": str(src), "to": str(dst), "moved": True})

--- a/backend/abilities/set_permissions.py
+++ b/backend/abilities/set_permissions.py
@@ -105,11 +105,7 @@ class SetPermissionsAbility(Ability[SetPermissionsParamsBag]):
             return target
 
         if not target.exists():
-            return ToolResult.err(
-                f"No such file or directory: {target}",
-                code="not-found",
-                hint="pass an absolute path to an existing file or directory.",
-            )
+            return ToolResult.not_found(target)
 
         mode = self._parse_octal(params.permission_code)
         if mode is None:
@@ -122,27 +118,15 @@ class SetPermissionsAbility(Ability[SetPermissionsParamsBag]):
         try:
             before = target.stat().st_mode & 0o7777
         except PermissionError as exc:
-            return ToolResult.err(
-                f"Permission denied reading {target}: {exc}",
-                code="permission-denied",
-                hint=f"you do not own {target} or cannot stat it.",
-            )
+            return ToolResult.permission_denied("reading", target, exc, hint=f"you do not own {target} or cannot stat it.")
 
         try:
             os.chmod(target, mode)
             after = target.stat().st_mode & 0o7777
         except PermissionError as exc:
-            return ToolResult.err(
-                f"Permission denied changing {target}: {exc}",
-                code="permission-denied",
-                hint=f"you must own {target} to change its permissions.",
-            )
+            return ToolResult.permission_denied("changing", target, exc, hint=f"you must own {target} to change its permissions.")
         except OSError as exc:
-            return ToolResult.err(
-                f"Could not change permissions on {target}: {exc}",
-                code="invalid-param",
-                hint="check the path exists and is a regular file or directory.",
-            )
+            return ToolResult.path_os_error("change permissions on", target, exc, code="invalid-param", hint="check the path exists and is a regular file or directory.")
 
         return ToolResult.ok(
             {"path": str(target), "mode_octal": self._format_octal(after)},

--- a/backend/abilities/write_file.py
+++ b/backend/abilities/write_file.py
@@ -123,17 +123,9 @@ class WriteFileAbility(Ability[WriteFileParamsBag]):
                 f.write(contents)
             bytes_written = target.stat().st_size
         except PermissionError as exc:
-            return ToolResult.err(
-                f"Permission denied writing to {target}: {exc}",
-                code="permission-denied",
-                hint=f"you do not have write access to {target} or its parent directory.",
-            )
+            return ToolResult.permission_denied("writing to", target, exc, hint=f"you do not have write access to {target} or its parent directory.")
         except OSError as exc:
-            return ToolResult.err(
-                f"Could not write to {target}: {exc}",
-                code="invalid-path",
-                hint="check the path shape and that its parent can hold a file.",
-            )
+            return ToolResult.path_os_error("write to", target, exc, code="invalid-path", hint="check the path shape and that its parent can hold a file.")
 
         return ToolResult.ok(
             {"path": str(target), "bytes": bytes_written, "created": not existed}

--- a/backend/capabilities/base.py
+++ b/backend/capabilities/base.py
@@ -19,6 +19,9 @@ operations can succeed.
 
 import logging
 from abc import ABC, abstractmethod
+from pathlib import Path
+
+import yaml
 
 from models.tool_config import ToolConfig
 from exceptions import VaultLockedError
@@ -29,8 +32,10 @@ logger = logging.getLogger(__name__)
 class AbstractCapability(ABC):
     """Abstract base class that every capability plugin must subclass."""
 
-    def __init__(self) -> None:
+    def __init__(self, manifest_path: Path) -> None:
+        self._manifest_path = manifest_path
         self._connected: bool = False
+        self._manifest_cache: dict[str, object] | None = None
 
     # ------------------------------------------------------------------
     # Abstract interface — must be implemented by every subclass
@@ -38,10 +43,6 @@ class AbstractCapability(ABC):
 
     @abstractmethod
     def get_id(self) -> str:
-        ...
-
-    @abstractmethod
-    def get_manifest(self) -> dict[str, object]:
         ...
 
     @abstractmethod
@@ -99,6 +100,12 @@ class AbstractCapability(ABC):
     # ------------------------------------------------------------------
     # Concrete helpers — credential management & connection state
     # ------------------------------------------------------------------
+
+    def get_manifest(self) -> dict[str, object]:
+        if self._manifest_cache is None:
+            with open(self._manifest_path, encoding="utf-8") as fh:
+                self._manifest_cache = yaml.safe_load(fh)
+        return self._manifest_cache
 
     def store_credential(self, key: str, value: str) -> None:
         """Encrypt *value* with AES-256-GCM via VaultService and persist

--- a/backend/capabilities/home_capability/capability.py
+++ b/backend/capabilities/home_capability/capability.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import logging
 from typing import cast
 
-import yaml
-
 from capabilities.base import AbstractCapability
 from capabilities.home_capability import ha_rest_handler as rest
 from capabilities.home_capability.ha_ws_handler import HaWebSocketHandler
@@ -24,8 +22,7 @@ _K_VERIFY_SSL = "home:verify_ssl"
 class HomeCapability(AbstractCapability):
 
     def __init__(self) -> None:
-        super().__init__()
-        self._manifest_cache: dict[str, object] | None = None
+        super().__init__(_MANIFEST_PATH)
         self._ws_handler = HaWebSocketHandler(on_event=self._on_ha_event)
         self._url: str = ""
         self._token: str = ""
@@ -48,12 +45,6 @@ class HomeCapability(AbstractCapability):
 
     def get_id(self) -> str:
         return "home"
-
-    def get_manifest(self) -> dict[str, object]:
-        if self._manifest_cache is None:
-            with open(_MANIFEST_PATH, encoding="utf-8") as fh:
-                self._manifest_cache = yaml.safe_load(fh)
-        return self._manifest_cache
 
     # ── Lifecycle ────────────────────────────────────────────────────
 

--- a/backend/capabilities/mail_capability/capability.py
+++ b/backend/capabilities/mail_capability/capability.py
@@ -6,8 +6,6 @@ import json
 import logging
 from typing import TYPE_CHECKING, cast
 
-import yaml
-
 from capabilities.base import AbstractCapability
 from capabilities.mail_capability.caldav_handler import CaldavHandler
 from capabilities.mail_capability.carddav_handler import CarddavHandler
@@ -66,8 +64,7 @@ _K_WATERMARK = _K_IMAP_WATERMARK  # alias used by MailCapability
 class MailCapability(AbstractCapability):
 
     def __init__(self) -> None:
-        super().__init__()
-        self._manifest_cache: dict[str, object] | None = None
+        super().__init__(_MANIFEST_PATH)
         self._imap_handler = ImapHandler()
         self._caldav_handler = CaldavHandler()
         self._carddav_handler = CarddavHandler()
@@ -82,12 +79,6 @@ class MailCapability(AbstractCapability):
 
     def get_id(self) -> str:
         return "mail"
-
-    def get_manifest(self) -> dict[str, object]:
-        if self._manifest_cache is None:
-            with open(_MANIFEST_PATH, "r", encoding="utf-8") as fh:
-                self._manifest_cache = yaml.safe_load(fh)
-        return self._manifest_cache
 
     # ------------------------------------------------------------------
     # Provider resolution

--- a/backend/capabilities/ubiquiti_capability/capability.py
+++ b/backend/capabilities/ubiquiti_capability/capability.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, cast
 
-import yaml
-
 from capabilities.base import AbstractCapability
 from capabilities.ubiquiti_capability import unifi_rest_handler as rest
 from services.file_mapper_service import FileMapperService
@@ -36,8 +34,7 @@ _K_VERIFY_SSL = "ubiquiti:verify_ssl"
 class UbiquitiCapability(AbstractCapability):
 
     def __init__(self) -> None:
-        super().__init__()
-        self._manifest_cache: dict[str, object] | None = None
+        super().__init__(_MANIFEST_PATH)
         self._url: str = ""
         self._auth_method: str = "api_key"
         self._api_key: str | None = None
@@ -50,12 +47,6 @@ class UbiquitiCapability(AbstractCapability):
 
     def get_id(self) -> str:
         return "ubiquiti"
-
-    def get_manifest(self) -> dict[str, object]:
-        if self._manifest_cache is None:
-            with open(_MANIFEST_PATH, encoding="utf-8") as fh:
-                self._manifest_cache = cast(dict[str, object], yaml.safe_load(fh))
-        return self._manifest_cache
 
     # ── Auth helpers ─────────────────────────────────────────────────
 

--- a/backend/contracts/capability.py
+++ b/backend/contracts/capability.py
@@ -2,11 +2,11 @@
 
 Declares the complete method surface of the capability family:
 
-- ``get_id`` / ``get_manifest`` / ``configure`` / ``connect`` / ``disconnect`` /
-  ``ingest`` / ``understand`` / ``_do_monitor`` / ``get_tools`` — **required**.
-  Each concrete capability supplies them (enforced by
+- ``get_id`` / ``configure`` / ``connect`` / ``disconnect`` / ``ingest`` /
+  ``understand`` / ``_do_monitor`` / ``get_tools`` — **required**. Each
+  concrete capability supplies them (enforced by
   :class:`capabilities.base.AbstractCapability`'s ``@abstractmethod``).
-- ``monitor`` / ``store_credential`` / ``load_credential`` /
+- ``get_manifest`` / ``monitor`` / ``store_credential`` / ``load_credential`` /
   ``delete_credentials`` / ``is_connected`` — **shared**. Supplied by the
   ``AbstractCapability`` ABC base, which every capability inherits.
 


### PR DESCRIPTION
## Summary

Two duplicate-code clusters consolidated into shared implementations. Both were caught by comparing near-identical logic across sibling files; each is verified byte-identical in observable behavior at every call site it replaces.

- **Manifest loading** (`backend/capabilities/base.py`): three capability plugins (home, mail, ubiquiti) each implemented the same "load and cache a YAML manifest file" method verbatim. It's now a single concrete method on the shared abstract base class; each plugin passes its own manifest path into the base constructor instead of duplicating the method body. The base constructor now requires that path explicitly, so a future plugin that forgets to wire it fails loudly at construction time instead of silently.

- **Filesystem error mapping** (`backend/abilities/_result.py`): five filesystem-facing tools (delete, move, set_permissions, write_file, make_dir) each hand-rolled the same `PermissionError`/`OSError`-to-error-response mapping in their exception handlers. Extracted into three small constructors on the shared result type, parameterized by each caller's own verb and hint text — no branching, no behavior change, just the boilerplate removed.

A third candidate cluster (two near-duplicate provider-resolution methods) was attempted and then reverted after review — merging them behind a boolean flag replaced one kind of duplication with a harder-to-read conditional, which wasn't a net improvement, so those two methods were left as they were on `main`.

## Test plan

- [x] `mypy --strict` on the full backend: identical to `main` (2 pre-existing, unrelated errors; same files, same messages)
- [x] `ruff check` on the full backend: identical finding set to `main` (same total count, same file/rule pairs — verified as a set diff, not just a count match)
- [x] `pytest -m unit` on the full backend: identical failing-test set to `main` (one pre-existing, unrelated failure; 1203 passed either way)
- [x] Net LOC vs `main`: -52 (50 insertions, 102 deletions across 11 files)
- [x] Independent architecture review of the diff against this repo's contribution guidelines, completed and passed after one round of revisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)