### PR TITLE
refactor: remove pass-through wrappers, call targets directly

### DIFF
--- a/backend/contracts/search_config.py
+++ b/backend/contracts/search_config.py
@@ -118,13 +118,6 @@ def register_kind(kind: str, config: SearchConfig | None) -> None:
     _REGISTRY[kind] = config
 
 
-def config_for_kind(kind: str) -> SearchConfig | None:
-    """The declared config for ``kind``, or ``None`` when the kind is
-    non-searchable OR not yet registered (its model not imported). Callers that
-    need to distinguish those two cases must ensure the model is imported."""
-    return _REGISTRY.get(kind)
-
-
 def is_searchable(kind: str) -> bool:
     """Whether rows of ``kind`` earn a search-index posting — the single
     authority the write-side engine consults, mirroring the save path's

--- a/backend/services/locale_service.py
+++ b/backend/services/locale_service.py
@@ -162,20 +162,6 @@ def format_date(dt: datetime | str | None, fmt: str = "%Y-%m-%d %H:%M", for_ui: 
     return dt.strftime(fmt)
 
 
-def to_utc(dt: datetime | str) -> datetime:
-    """Ensure a datetime is timezone-aware UTC.
-
-    Use this before ANY database write involving a timestamp.
-
-    Args:
-        dt: A datetime (naive or aware), or ISO string.
-
-    Returns:
-        Timezone-aware UTC datetime.
-    """
-    return parse_utc(dt)
-
-
 def to_local(dt: datetime | str) -> datetime:
     """Convert a datetime to the user's local timezone.
 
@@ -205,9 +191,9 @@ def parse_local(dt: datetime | str) -> datetime:
 
     Use for user/LLM-supplied wall-clock values (e.g. the scheduler "Start
     Time", which the World State surfaces in local time and which is never
-    timezone-converted upstream). This is the inverse intent of ``to_utc``,
-    which assumes a naive input is already UTC — here a naive input is assumed
-    to be in the user's timezone. Aware inputs are converted as-is.
+    timezone-converted upstream). This is the inverse of ``parse_utc`` in that
+    a naive input is assumed to be in the user's timezone rather than UTC.
+    Aware inputs are converted as-is.
 
     Args:
         dt: A naive local datetime, an aware datetime, or an ISO string.

--- a/backend/services/memory_recall_service.py
+++ b/backend/services/memory_recall_service.py
@@ -112,10 +112,6 @@ def _composite_score(row: DataGraphRow, signals: RecallSignals) -> float:
     return base * retrieval_weight * (1 + _ACTR_SIGMOID_WEIGHT * _sigmoid(actr_boost))
 
 
-def _cos_score(key_cos: float, value_cos: float) -> float:
-    return max(key_cos, value_cos)
-
-
 def _project(row: DataGraphRow, composite: float, signals: RecallSignals) -> dict[str, object]:
     """The data-graph recall hit shape (mirrors the deleted ``recall()``'s
     return dict) — the one contract both ``MemoryService._search_data_graph``
@@ -130,7 +126,7 @@ def _project(row: DataGraphRow, composite: float, signals: RecallSignals) -> dic
         "retrieval_weight": row.retrieval_weight,
         "evidence_count": row.evidence_count,
         "composite_score": composite,
-        "cos_score": _cos_score(signals.key_cos, signals.value_cos),
+        "cos_score": max(signals.key_cos, signals.value_cos),
     }
 
 


### PR DESCRIPTION
## What this does

An automated mechanical sweep that finds module-level functions whose entire body is a pure pass-through (`def a(x): return b(x)`), deletes them, and rewires their callers to call the target directly. Detection is AST-based with conservative skip rules (no decorators, no default args, no dynamic dispatch, no test callers, no string/registry references, skips when the callee itself is private and has external callers). Every candidate is verified post-edit for zero dangling references before being accepted.

## Wrappers removed

| Wrapper | File | Target |
|---|---|---|
| `config_for_kind` | `backend/contracts/search_config.py` | `_REGISTRY.get` |
| `to_utc` | `backend/services/locale_service.py` | `parse_utc` |
| `_cos_score` | `backend/services/memory_recall_service.py` | `max` |

`config_for_kind` and `to_utc` had zero callers anywhere in the repo (including within their own defining file), so their removal is a plain deletion with nothing to rewire. `_cos_score` had one call site, rewired to call `max(...)` directly with the same arguments in the same order. A dangling docstring cross-reference to the deleted `to_utc` (in `parse_local`'s docstring, same file) was updated to point at `parse_utc` instead.

## Counts

- Detected: 6
- Queued (eligible): 3
- Attempted: 3
- Deleted: 3
- Skipped: 0
- Reverted: 0
- Failed: 0
- Unprocessed: 0

The other 3 detected candidates were auto-skipped by the detector (private callee with external callers) and never attempted.

## Verification performed

- Full unit test suite (`pytest -m unit`) run before and after: identical failure set both times (one pre-existing, unrelated failure), same pass/deselect counts (1203 passed, 101 deselected).
- `ruff check` on all three changed files, compared against the pre-edit versions in place (via `git stash`, preserving project import-sort config): identical violation set, zero new violations introduced.
- Every changed file cross-checked against the tool's own per-candidate caller list; no file outside the deleted wrappers' caller sets was modified.
- Grepped the full repository post-edit for all three removed names: zero remaining references anywhere (code, docs, config).
- Checked `docs/` and every `__init__.py` for the removed names: none are documented or re-exported public API.
- Net diff: 4 insertions, 29 deletions across 3 files — deletion-only, no added logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)