### PR TITLE
refactor: consolidate duplicate functions (2026-08-08)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ venv/
 .vscode/
 .DS_Store
 .claude/
+.coding_agent/
 Claude.md
 CLAUDE.md
 

--- a/backend/models/contact.py
+++ b/backend/models/contact.py
@@ -22,14 +22,6 @@ class ContactRow(DataGraphRow):
     KIND: ClassVar[str] = "contact"
 
     @classmethod
-    def active_by_key(cls, key: str) -> Self | None:
-        """The single active row for this kind's exact ``key`` — the store
-        lookup (mirrors ``_SELECT_ACTIVE_BY_KIND_KEY_SQL``: ``active = 1`` only,
-        NOT ``deleted_at``-filtered)."""
-        return (cls.filter("kind", cls.KIND).filter("key", key)
-                   .filter("active", 1).first())
-
-    @classmethod
     def store(cls, key: str, value: str, source: str | None = None) -> Self:
         """Exact-key upsert, ported from the non-superseding branch of
         ``DataGraph.store`` (``"contact"`` is not in ``_SUPERSEDING_KINDS``): no

--- a/backend/models/data_graph.py
+++ b/backend/models/data_graph.py
@@ -2,8 +2,9 @@
 
 :class:`DataGraphRow` is the abstract base every per-kind vertical subclasses:
 it owns the table binding, the column set, the reinforce path, the kind-bound
-live/exact-key/FTS reads (scoped to the subclass's :attr:`~DataGraphRow.KIND`)
-and the post-commit FTS/vec write-sync. :class:`DataGraph` is the thin generic
+live/exact-key/FTS reads (scoped to the subclass's :attr:`~DataGraphRow.KIND`),
+the shared power-law retrieval_weight decay loop, and the post-commit FTS/vec
+write-sync. :class:`DataGraph` is the thin generic
 gateway that still spans every not-yet-ported kind: it leaves ``KIND`` unset and
 overrides the kind-bound reads with kind-parametrised ones, and carries the
 supersede machinery (``store``/``demote``/``_SUPERSEDING_KINDS``) and the
@@ -29,6 +30,7 @@ import logging
 import math
 import re
 import sqlite3
+from datetime import timedelta
 from typing import ClassVar, Self, cast
 
 from contracts.search_config import DATA_GRAPH_SEARCH, SearchConfig, register_kind
@@ -38,15 +40,16 @@ from models.query import Query
 from services._fts_delete import fts5_external_delete
 from services.embedding_utils import pack_embedding
 from services.search_expander_service import enqueue
-from services.time_utils import utc_now
+from services.time_utils import parse_utc, utc_now
 
 logger = logging.getLogger(__name__)
 
 
 class DataGraphRow(Model):
     """The shared ``data_graph`` shell: field storage + CRUD + the reinforce
-    path, the kind-bound reads a concrete vertical inherits, and the post-commit
-    FTS/vec write-sync. Concrete verticals set :attr:`KIND` and read their own
+    path, the kind-bound reads a concrete vertical inherits, the shared
+    power-law decay loop (:meth:`_decay_live_rw`), and the post-commit FTS/vec
+    write-sync. Concrete verticals set :attr:`KIND` and read their own
     lane with a bare ``live()`` / ``search()``; the generic :class:`DataGraph`
     gateway leaves ``KIND`` unset and passes the kind explicitly to
     :meth:`live`."""
@@ -95,6 +98,11 @@ class DataGraphRow(Model):
 
     # Evidence-diminishing reinforcement boost numerator (``_reinforce_row``).
     _REINFORCE_BOOST: ClassVar[float] = 0.05
+
+    # Minimum retrieval_weight delta a power-law decay pass writes back
+    # (``_decay_live_rw``) — every decaying vertical shares this threshold,
+    # unlike ``d_base``/``salience_floor`` which are per-kind curve shape.
+    _DECAY_RW_EPSILON: ClassVar[float] = 0.0001
 
     def __init_subclass__(cls, **kwargs: object) -> None:
         """Register each concrete vertical's ``KIND → __search__`` mapping so the
@@ -186,6 +194,14 @@ class DataGraphRow(Model):
         passes the kind explicitly."""
         resolved = kind if kind is not None else cls.KIND
         return cls.filter("kind", resolved).filter("active", 1).filter("deleted_at", None, "IS")
+
+    @classmethod
+    def active_by_key(cls, key: str) -> Self | None:
+        """The single active row for this kind's exact ``key`` — the store lookup
+        (mirrors ``_SELECT_ACTIVE_BY_KIND_KEY_SQL``: ``active = 1`` only, NOT
+        ``deleted_at``-filtered)."""
+        return (cls.filter("kind", cls.KIND).filter("key", key)
+                   .filter("active", 1).first())
 
     @classmethod
     def search(cls, query: str, k: int) -> list[Self]:
@@ -403,3 +419,43 @@ class DataGraphRow(Model):
         self.last_confirmed_at = now
         self.last_accessed_at = now
         return self.save()
+
+    # ── decay ───────────────────────────────────────────────────────────
+
+    @classmethod
+    def _decay_live_rw(cls, d_base: float, salience_floor: float) -> int:
+        """Absolute power-law decay of this kind's live rows' retrieval_weight
+        (idempotent): ``rw = max(salience_floor, max(1, age_days) ** -d_base)``
+        from ``last_confirmed_at``. Only rows last confirmed > 1h ago, and only
+        when the new weight actually moves (> :attr:`_DECAY_RW_EPSILON`).
+        Returns rows updated. ``d_base``/``salience_floor`` are the calling
+        vertical's own decay curve (its ``_DECAY_D_BASE``/
+        ``_DECAY_SALIENCE_FLOOR``) — not every kind decays, so they stay
+        subclass ``ClassVar``s rather than living here."""
+        now = utc_now()
+        cutoff = (now - timedelta(hours=1)).isoformat()
+        now_ts = now.timestamp()
+        updated = 0
+        for row in cls.live().filter("last_confirmed_at", cutoff, "<").get():
+            new_rw = cls._decayed_rw(row.last_confirmed_at, now_ts, d_base, salience_floor)
+            if new_rw is not None and abs(new_rw - row.retrieval_weight) > cls._DECAY_RW_EPSILON:
+                row.retrieval_weight = new_rw
+                row.save()
+                updated += 1
+        return updated
+
+    @classmethod
+    def _decayed_rw(cls, confirmed_at: str | None, now_ts: float, d_base: float, salience_floor: float) -> float | None:
+        """The single-row power-law formula behind :meth:`_decay_live_rw`;
+        ``None`` when ``confirmed_at`` is absent, unparseable, or not yet in
+        the past."""
+        if not confirmed_at:
+            return None
+        try:
+            confirmed_ts = parse_utc(confirmed_at).timestamp()
+        except Exception:
+            return None
+        age_days = (now_ts - confirmed_ts) / 86400.0
+        if age_days <= 0:
+            return None
+        return max(salience_floor, float(max(1.0, age_days) ** (-d_base)))

--- a/backend/models/discovery.py
+++ b/backend/models/discovery.py
@@ -41,15 +41,6 @@ class DiscoveryRow(DataGraphRow):
     # identical d_base/salience_floor to FACTS (KIND_USER_SPECIFIC).
     _DECAY_D_BASE: ClassVar[float] = 0.5
     _DECAY_SALIENCE_FLOOR: ClassVar[float] = 0.2
-    _DECAY_RW_EPSILON: ClassVar[float] = 0.0001
-
-    @classmethod
-    def active_by_key(cls, key: str) -> Self | None:
-        """The single active row for this kind's exact ``key`` — the store lookup
-        (mirrors ``_SELECT_ACTIVE_BY_KIND_KEY_SQL``: ``active = 1`` only, NOT
-        ``deleted_at``-filtered)."""
-        return (cls.filter("kind", cls.KIND).filter("key", key)
-                   .filter("active", 1).first())
 
     @classmethod
     def store(cls, key: str, value: str, source: str | None = None) -> tuple[Self, str, str | None]:
@@ -78,29 +69,4 @@ class DiscoveryRow(DataGraphRow):
         when the new weight actually moves (> epsilon). Returns rows updated.
         The shared superseded-decay and 90-day hard-GC are the DecayEngine's
         job, not here."""
-        from datetime import timedelta  # noqa: PLC0415
-        now = utc_now()
-        cutoff = (now - timedelta(hours=1)).isoformat()
-        now_ts = now.timestamp()
-        updated = 0
-        for row in cls.live().filter("last_confirmed_at", cutoff, "<").get():
-            new_rw = cls._decayed_rw(row.last_confirmed_at, now_ts)
-            if new_rw is not None and abs(new_rw - row.retrieval_weight) > cls._DECAY_RW_EPSILON:
-                row.retrieval_weight = new_rw
-                row.save()
-                updated += 1
-        return updated
-
-    @classmethod
-    def _decayed_rw(cls, confirmed_at: str | None, now_ts: float) -> float | None:
-        from services.time_utils import parse_utc  # noqa: PLC0415
-        if not confirmed_at:
-            return None
-        try:
-            confirmed_ts = parse_utc(confirmed_at).timestamp()
-        except Exception:
-            return None
-        age_days = (now_ts - confirmed_ts) / 86400.0
-        if age_days <= 0:
-            return None
-        return max(cls._DECAY_SALIENCE_FLOOR, float(max(1.0, age_days) ** (-cls._DECAY_D_BASE)))
+        return cls._decay_live_rw(cls._DECAY_D_BASE, cls._DECAY_SALIENCE_FLOOR)

--- a/backend/models/exact_key.py
+++ b/backend/models/exact_key.py
@@ -24,14 +24,6 @@ class ExactKeyRow(DataGraphRow):
     _SUPERSEDE_RW_FACTOR: ClassVar[float] = 0.5
 
     @classmethod
-    def active_by_key(cls, key: str) -> Self | None:
-        """The single active row for this kind's exact ``key`` — the store lookup
-        (mirrors ``_SELECT_ACTIVE_BY_KIND_KEY_SQL``: ``active = 1`` only, NOT
-        ``deleted_at``-filtered)."""
-        return (cls.filter("kind", cls.KIND).filter("key", key)
-                   .filter("active", 1).first())
-
-    @classmethod
     def store(cls, key: str, value: str, source: str | None = None) -> tuple[Self, str, str | None]:
         """Exact-key upsert. Returns ``(row, status, old_value)`` where status is
         ``created`` | ``reinforced`` | ``superseded`` (this lane always temporally

--- a/backend/models/fact.py
+++ b/backend/models/fact.py
@@ -23,15 +23,6 @@ class FactRow(DataGraphRow):
     # ttl 30d gates that decay runs at all; d_base/salience_floor set the curve.
     _DECAY_D_BASE: ClassVar[float] = 0.5
     _DECAY_SALIENCE_FLOOR: ClassVar[float] = 0.2
-    _DECAY_RW_EPSILON: ClassVar[float] = 0.0001
-
-    @classmethod
-    def active_by_key(cls, key: str) -> Self | None:
-        """The single active row for this kind's exact ``key`` — the store lookup
-        (mirrors ``_SELECT_ACTIVE_BY_KIND_KEY_SQL``: ``active = 1`` only, NOT
-        ``deleted_at``-filtered)."""
-        return (cls.filter("kind", cls.KIND).filter("key", key)
-                   .filter("active", 1).first())
 
     @classmethod
     def active_values(cls, key: str) -> list[str]:
@@ -187,29 +178,4 @@ class FactRow(DataGraphRow):
         ``last_confirmed_at``. Only rows last confirmed > 1h ago, and only when the
         new weight actually moves (> epsilon). Returns rows updated. The shared
         superseded-decay and 90-day hard-GC are the DecayEngine's job, not here."""
-        from datetime import timedelta  # noqa: PLC0415
-        now = utc_now()
-        cutoff = (now - timedelta(hours=1)).isoformat()
-        now_ts = now.timestamp()
-        updated = 0
-        for row in cls.live().filter("last_confirmed_at", cutoff, "<").get():
-            new_rw = cls._decayed_rw(row.last_confirmed_at, now_ts)
-            if new_rw is not None and abs(new_rw - row.retrieval_weight) > cls._DECAY_RW_EPSILON:
-                row.retrieval_weight = new_rw
-                row.save()
-                updated += 1
-        return updated
-
-    @classmethod
-    def _decayed_rw(cls, confirmed_at: str | None, now_ts: float) -> float | None:
-        from services.time_utils import parse_utc  # noqa: PLC0415
-        if not confirmed_at:
-            return None
-        try:
-            confirmed_ts = parse_utc(confirmed_at).timestamp()
-        except Exception:
-            return None
-        age_days = (now_ts - confirmed_ts) / 86400.0
-        if age_days <= 0:
-            return None
-        return max(cls._DECAY_SALIENCE_FLOOR, float(max(1.0, age_days) ** (-cls._DECAY_D_BASE)))
+        return cls._decay_live_rw(cls._DECAY_D_BASE, cls._DECAY_SALIENCE_FLOOR)

--- a/backend/models/misc.py
+++ b/backend/models/misc.py
@@ -38,18 +38,9 @@ class MiscRow(DataGraphRow):
     # Power-law live-decay policy (legacy _KIND_POLICY KIND_MISC).
     _DECAY_D_BASE: ClassVar[float] = 1.5
     _DECAY_SALIENCE_FLOOR: ClassVar[float] = 0.0
-    _DECAY_RW_EPSILON: ClassVar[float] = 0.0001
 
     # Hard-purge TTL (legacy _KIND_POLICY KIND_MISC ttl_days).
     _PURGE_TTL_DAYS: ClassVar[int] = 2
-
-    @classmethod
-    def active_by_key(cls, key: str) -> Self | None:
-        """The single active row for this kind's exact ``key`` — the store
-        lookup (mirrors ``_SELECT_ACTIVE_BY_KIND_KEY_SQL``: ``active = 1``
-        only, NOT ``deleted_at``-filtered)."""
-        return (cls.filter("kind", cls.KIND).filter("key", key)
-                   .filter("active", 1).first())
 
     @classmethod
     def store(cls, key: str, value: str, source: str | None = None) -> tuple[Self, str, str | None]:
@@ -81,35 +72,7 @@ class MiscRow(DataGraphRow):
         ``orchestrators.decay_engine.DecayEngine._gc_dead_data_graph``'s
         FTS-then-DELETE idiom. Order matches the legacy ``decay_cycle``
         (power-law then purge); the end state is order-independent."""
-        return cls._decay_live_rw() + cls._purge_expired()
-
-    @classmethod
-    def _decay_live_rw(cls) -> int:
-        now = utc_now()
-        cutoff = (now - timedelta(hours=1)).isoformat()
-        now_ts = now.timestamp()
-        updated = 0
-        for row in cls.live().filter("last_confirmed_at", cutoff, "<").get():
-            new_rw = cls._decayed_rw(row.last_confirmed_at, now_ts)
-            if new_rw is not None and abs(new_rw - row.retrieval_weight) > cls._DECAY_RW_EPSILON:
-                row.retrieval_weight = new_rw
-                row.save()
-                updated += 1
-        return updated
-
-    @classmethod
-    def _decayed_rw(cls, confirmed_at: str | None, now_ts: float) -> float | None:
-        from services.time_utils import parse_utc  # noqa: PLC0415
-        if not confirmed_at:
-            return None
-        try:
-            confirmed_ts = parse_utc(confirmed_at).timestamp()
-        except Exception:
-            return None
-        age_days = (now_ts - confirmed_ts) / 86400.0
-        if age_days <= 0:
-            return None
-        return max(cls._DECAY_SALIENCE_FLOOR, float(max(1.0, age_days) ** (-cls._DECAY_D_BASE)))
+        return cls._decay_live_rw(cls._DECAY_D_BASE, cls._DECAY_SALIENCE_FLOOR) + cls._purge_expired()
 
     @classmethod
     def _purge_expired(cls) -> int:

--- a/backend/models/place.py
+++ b/backend/models/place.py
@@ -25,14 +25,6 @@ class PlaceRow(DataGraphRow):
     _SUPERSEDE_RW_FACTOR: ClassVar[float] = 0.5
 
     @classmethod
-    def active_by_key(cls, key: str) -> Self | None:
-        """The single active row for this kind's exact ``key`` — the store lookup
-        (mirrors ``_SELECT_ACTIVE_BY_KIND_KEY_SQL``: ``active = 1`` only, NOT
-        ``deleted_at``-filtered)."""
-        return (cls.filter("kind", cls.KIND).filter("key", key)
-                   .filter("active", 1).first())
-
-    @classmethod
     def store(cls, key: str, value: str, source: str | None = None) -> tuple[Self, str, str | None]:
         """Exact-key supersede upsert. Returns ``(row, status, old_value)``;
         status is ``created`` | ``reinforced`` | ``superseded``. ``value`` is a


### PR DESCRIPTION
## Clusters consolidated

**1. `active_by_key` — identical classmethod, 6 subclasses**
Members: `models/exact_key.py`, `models/fact.py`, `models/contact.py`, `models/place.py`, `models/discovery.py`, `models/misc.py` — each carried a byte-identical `active_by_key(cls, key)` classmethod.
Pattern: hoisted onto the shared base `DataGraphRow` (`models/data_graph.py`); all 6 subclass copies deleted.

**2. Power-law `decay()` loop — near-identical implementation, 3 subclasses**
Members: `models/fact.py`, `models/discovery.py`, `models/misc.py` — each carried its own copy of the retrieval_weight power-law decay loop and single-row decay formula, differing only in `d_base`/`salience_floor` curve constants (already externalized as per-subclass `ClassVar`s).
Pattern: hoisted the loop (`_decay_live_rw`) and formula (`_decayed_rw`) onto `DataGraphRow`, taking `d_base`/`salience_floor` as explicit parameters — no branching, one code path per call. Each subclass's `decay()` now delegates with its own constants. The shared epsilon threshold (which never varied per subclass, unlike the curve constants) moved to a single `DataGraphRow` ClassVar.

## Net LOC

8 files changed, 65 insertions(+), 137 deletions(-) — net **-72 LOC**.

## Test evidence

- `pytest -m unit`: failure set unchanged vs `origin/main` baseline (1 pre-existing failure, unrelated to this diff: `test_static_typing_gate.py::test_first_party_source_is_strict_clean`, itself caused by 2 pre-existing mypy errors in unrelated files).
- `ruff check`: unique (file, rule) violation pairs net -5 vs baseline (717 → 712); the single relocated pair (`data_graph.py`, `BLE001`) is the same blind-except moved out of the 3 subclasses, which each lost their own occurrence.
- `mypy`: identical output to baseline (2 pre-existing, unrelated errors).
- Behavioral equivalence for the decay consolidation independently verified via a differential test harness (28 rows spanning the cutoff boundary, sub-day clamp, unparseable/future timestamps, at-floor no-write, inactive/soft-deleted rows, TTL purge, and foreign kinds) — before/after outputs identical, harness mutation-tested to confirm it isn't vacuous.

## Review

Opus senior-architecture review, 2 of max-5 rounds. Round 1: `CHANGES_REQUIRED` (4 findings — hoist the shared epsilon constant off the parameter list onto the base, add docstrings under a proper section banner, drop an unnecessary local import, gitignore an untracked tool-state directory). Round 2: `VERDICT: APPROVED` — every fix independently re-verified against both trees (gates re-run from scratch, not taken on faith).

🤖 Generated with [Claude Code](https://claude.com/claude-code)