### PR TITLE
refactor: remove pass-through wrappers, call targets directly

### DIFF
--- a/backend/contracts/search_config.py
+++ b/backend/contracts/search_config.py
@@ -118,13 +118,6 @@ def register_kind(kind: str, config: SearchConfig | None) -> None:
     _REGISTRY[kind] = config
 
 
-def config_for_kind(kind: str) -> SearchConfig | None:
-    """The declared config for ``kind``, or ``None`` when the kind is
-    non-searchable OR not yet registered (its model not imported). Callers that
-    need to distinguish those two cases must ensure the model is imported."""
-    return _REGISTRY.get(kind)
-
-
 def is_searchable(kind: str) -> bool:
     """Whether rows of ``kind`` earn a search-index posting — the single
     authority the write-side engine consults, mirroring the save path's

--- a/backend/services/locale_service.py
+++ b/backend/services/locale_service.py
@@ -162,20 +162,6 @@ def format_date(dt: datetime | str | None, fmt: str = "%Y-%m-%d %H:%M", for_ui: 
     return dt.strftime(fmt)
 
 
-def to_utc(dt: datetime | str) -> datetime:
-    """Ensure a datetime is timezone-aware UTC.
-
-    Use this before ANY database write involving a timestamp.
-
-    Args:
-        dt: A datetime (naive or aware), or ISO string.
-
-    Returns:
-        Timezone-aware UTC datetime.
-    """
-    return parse_utc(dt)
-
-
 def to_local(dt: datetime | str) -> datetime:
     """Convert a datetime to the user's local timezone.
 
@@ -205,8 +191,7 @@ def parse_local(dt: datetime | str) -> datetime:
 
     Use for user/LLM-supplied wall-clock values (e.g. the scheduler "Start
     Time", which the World State surfaces in local time and which is never
-    timezone-converted upstream). This is the inverse intent of ``to_utc``,
-    which assumes a naive input is already UTC — here a naive input is assumed
+    timezone-converted upstream). Here a naive input is assumed
     to be in the user's timezone. Aware inputs are converted as-is.
 
     Args:

--- a/backend/services/memory_recall_service.py
+++ b/backend/services/memory_recall_service.py
@@ -112,10 +112,6 @@ def _composite_score(row: DataGraphRow, signals: RecallSignals) -> float:
     return base * retrieval_weight * (1 + _ACTR_SIGMOID_WEIGHT * _sigmoid(actr_boost))
 
 
-def _cos_score(key_cos: float, value_cos: float) -> float:
-    return max(key_cos, value_cos)
-
-
 def _project(row: DataGraphRow, composite: float, signals: RecallSignals) -> dict[str, object]:
     """The data-graph recall hit shape (mirrors the deleted ``recall()``'s
     return dict) — the one contract both ``MemoryService._search_data_graph``
@@ -130,7 +126,7 @@ def _project(row: DataGraphRow, composite: float, signals: RecallSignals) -> dic
         "retrieval_weight": row.retrieval_weight,
         "evidence_count": row.evidence_count,
         "composite_score": composite,
-        "cos_score": _cos_score(signals.key_cos, signals.value_cos),
+        "cos_score": max(signals.key_cos, signals.value_cos),
     }
 
 


### PR DESCRIPTION
## Summary

Automated daily sweep that detects pure pass-through module-level functions (`def a(x): return b(x)`) and rewires their callers to call the target directly. Behavior-preserving only — no logic changes.

## Removed wrappers

| Wrapper | File | Target |
|---|---|---|
| `config_for_kind` | `backend/contracts/search_config.py` | `_REGISTRY.get` |
| `to_utc` | `backend/services/locale_service.py` | `parse_utc` |
| `_cos_score` | `backend/services/memory_recall_service.py` | `max(...)` |

`config_for_kind` and `to_utc` had no remaining callers anywhere in the tree (unused exports); `to_utc`'s deletion also removed a dangling docstring reference in `parse_local`. `_cos_score`'s single call site (in `_project`) now calls `max()` directly with the same arguments.

## Counts

- Detected: 6
- Queued: 3 (3 skipped by the detector as private-callee patterns, not pass-throughs — left untouched)
- Attempted: 3
- Deleted: 3
- Skipped / reverted / unprocessed: 0

## Verification

- Unit test suite (`pytest -m unit`) failure set unchanged from baseline: 1 pre-existing failure (`test_first_party_source_is_strict_clean`, an unrelated strict-typing gate failure) both before and after. A one-off failure in an unrelated attachment-seeding test did not reproduce on a clean re-run — confirmed as a pre-existing non-deterministic flake unconnected to any changed file.
- `ruff check` on all three changed files: all reported violations are pre-existing (verified by checking each file's original content at the same path — identical violation codes, just shifted line numbers from the deletions). Zero new violations introduced.
- Per-candidate diff review: each diff is exactly the wrapper definition removed, its call site(s) rewired to the same target with the same arguments, and no unrelated changes.
- No public-API exposure: none of the removed names appear in `docs/` or any `__init__.py` re-export.
- Net diff: 3 files changed, 2 insertions(+), 28 deletions(-).

🤖 Generated with [Claude Code](https://claude.com/claude-code)