### PR TITLE
refactor: remove pass-through wrappers, call targets directly

### DIFF
--- a/backend/api/actions/providers/list_models.py
+++ b/backend/api/actions/providers/list_models.py
@@ -25,7 +25,7 @@ from exceptions import EndpointError, NotFoundError
 from api.request import Request
 from api.request.provider_models import ListModelsRequest
 from api.response.provider_models import ListModelsResult, ModelInfo
-from services.llm_clients.registry import client_class_for
+from services.llm_clients.registry import PROVIDERS_BY_PLATFORM
 from services.provider_db_service import ProviderDbService
 
 
@@ -45,7 +45,7 @@ class ProviderListModels(Action):
         # Each client knows how its own vendor lists models, so a new provider
         # is listable the moment its module exists — there is no branch here to
         # forget to extend.
-        client_class = client_class_for(platform)
+        client_class = PROVIDERS_BY_PLATFORM.get(platform)
         if client_class is None:
             raise EndpointError(f"Unsupported platform '{platform}'")
 

--- a/backend/services/llm_clients/factory.py
+++ b/backend/services/llm_clients/factory.py
@@ -15,7 +15,7 @@ Consumed by: services.provider_service (send / _resolve).
 from __future__ import annotations
 
 from contracts.provider_client import ProviderClient
-from services.llm_clients.registry import client_class_for
+from services.llm_clients.registry import PROVIDERS_BY_PLATFORM
 
 
 def build_client(config: dict[str, object]) -> ProviderClient:
@@ -33,7 +33,7 @@ def build_client(config: dict[str, object]) -> ProviderClient:
             "LLM config missing 'model'. Configure it via the providers API"
         )
 
-    client_class = client_class_for(str(platform))
+    client_class = PROVIDERS_BY_PLATFORM.get(str(platform))
     if client_class is None:
         raise ValueError(f"Unknown platform: {platform}")
 

--- a/backend/services/llm_clients/registry.py
+++ b/backend/services/llm_clients/registry.py
@@ -99,11 +99,6 @@ def _build_index() -> dict[str, type[ProviderClient]]:
 PROVIDERS_BY_PLATFORM: dict[str, type[ProviderClient]] = _build_index()
 
 
-def client_class_for(platform: str) -> type[ProviderClient] | None:
-    """The client class serving *platform*, or None when nothing claims it."""
-    return PROVIDERS_BY_PLATFORM.get(platform)
-
-
 def platform_requires_key(platform: str) -> bool:
     """Whether *platform* cannot be reached at all without a credential.
 
@@ -117,5 +112,5 @@ def platform_requires_key(platform: str) -> bool:
     factory with a message naming it, which is a better answer than a complaint
     about a missing key for a provider that does not exist.
     """
-    client = client_class_for(platform)
+    client = PROVIDERS_BY_PLATFORM.get(platform)
     return client is not None and client.REQUIRES_KEY

--- a/backend/services/provider_db_service.py
+++ b/backend/services/provider_db_service.py
@@ -125,9 +125,9 @@ class ProviderDbService:
         host points at no server, and no later edit short of supplying the host
         can make it mean anything.
         """
-        from services.llm_clients.registry import client_class_for  # noqa: PLC0415
+        from services.llm_clients.registry import PROVIDERS_BY_PLATFORM  # noqa: PLC0415
 
-        client = client_class_for(platform)
+        client = PROVIDERS_BY_PLATFORM.get(platform)
         if client is None or not client.REQUIRES_HOST or client.DEFAULT_BASE_URL:
             return
 

--- a/backend/utils/logger.py
+++ b/backend/utils/logger.py
@@ -13,10 +13,6 @@ from typing import Optional, Union
 _correlation_id: ContextVar[Optional[str]] = ContextVar("_correlation_id", default=None)
 
 
-def get_correlation_id() -> Optional[str]:
-    return _correlation_id.get()
-
-
 def set_correlation_id(value: str) -> None:
     _correlation_id.set(value)
 


### PR DESCRIPTION
## Summary

Automated sweep that deletes pure pass-through wrapper functions (a function whose entire body is `return other_thing(...same args...)`) and rewires every caller to call the target directly.

## Removed wrappers

| Wrapper | Target | Callers updated |
|---|---|---|
| `client_class_for` (`backend/services/llm_clients/registry.py`) | `PROVIDERS_BY_PLATFORM.get` | `backend/api/actions/providers/list_models.py`, `backend/services/llm_clients/factory.py`, `backend/services/llm_clients/registry.py` (internal use), `backend/services/provider_db_service.py` |
| `get_correlation_id` (`backend/utils/logger.py`) | `_correlation_id.get` | none (dead code — zero callers anywhere in the tree) |

No behavior change: both wrappers returned their target call verbatim with the same arguments, so every call site now produces an identical result.

## Counts

- Detected: 4 candidates
- Attempted: 2 (2 auto-skipped by the detector — a test-only caller and a private-callee case)
- Deleted: 2
- Skipped / reverted / failed / unprocessed: 0

## Verification

- Unit test suite (`pytest -m unit`) re-run after the change: failure set identical to baseline (empty). Two full-suite runs after the edit each surfaced one unrelated failing test; both were proven, by re-running in isolation and against unmodified `main`, to be pre-existing environmental flakes (SQLite `database is locked` race and a test-order-dependent pollution issue) with zero relation to the files this PR touches.
- `ruff check` on the changed files: identical violation set to unmodified `main`, minus one (a stale `Optional[...]` annotation removed along with the deleted wrapper). No new violations introduced.
- Per-candidate diff review: each deleted wrapper's diff is exactly the function removed, its call sites updated to the target with the same arguments, and imports adjusted — nothing else touched.
- Checked both names against `docs/` and `__init__.py` re-exports: neither is documented or exported public API.
- Net diff: 5 files changed, 7 insertions(+), 16 deletions(-).

🤖 Generated with [Claude Code](https://claude.com/claude-code)