### PR TITLE
Consolidate duplicated json_each queries, create-sentinel guards, and path validation

### DIFF
--- a/backend/abilities/_paths.py
+++ b/backend/abilities/_paths.py
@@ -28,17 +28,19 @@ from pathlib import Path
 from abilities._result import ToolResult
 
 
-def absolute_target(path_str: str) -> Path | ToolResult:
+def absolute_target(path_str: str, label: str = "Path") -> Path | ToolResult:
     """Resolve *path_str* to an absolute :class:`pathlib.Path`, or refuse.
 
     A non-absolute path is rejected with ``code=invalid-path`` and a hint that
     names the fix. The blank-path case cannot happen here: the caller's bag
     rejects a missing or blank ``path`` before this function is reached.
+    *label* names the offending parameter in the error message (default
+    ``"Path"``) for callers validating more than one path argument.
     """
     candidate = Path(path_str)
     if not candidate.is_absolute():
         return ToolResult.err(
-            f"Path is not absolute: {path_str!r}.",
+            f"{label} is not absolute: {path_str!r}.",
             code="invalid-path",
             hint="pass an absolute path (one starting from the filesystem root).",
         )

--- a/backend/abilities/move.py
+++ b/backend/abilities/move.py
@@ -9,10 +9,10 @@ Returns a sealed :class:`abilities._result.ToolResult` (never a wire envelope):
 """
 
 import shutil
-from pathlib import Path
 from typing import ClassVar
 
 from abilities._ability import Ability
+from abilities._paths import absolute_target
 from abilities._result import ToolResult
 from configs.enums.param_key import Keys
 from contracts.params.move_params_bag import MoveParamsBag
@@ -72,21 +72,12 @@ class MoveAbility(Ability[MoveParamsBag]):
         current_path_str = params.current_path
         new_path_str = params.new_path
 
-        if not Path(current_path_str).is_absolute():
-            return ToolResult.err(
-                f"current_path is not absolute: {current_path_str!r}.",
-                code="invalid-path",
-                hint="pass an absolute path (one starting from the filesystem root).",
-            )
-        if not Path(new_path_str).is_absolute():
-            return ToolResult.err(
-                f"new_path is not absolute: {new_path_str!r}.",
-                code="invalid-path",
-                hint="pass an absolute path (one starting from the filesystem root).",
-            )
-
-        src = Path(current_path_str).resolve()
-        dst = Path(new_path_str).resolve()
+        src = absolute_target(current_path_str, label="current_path")
+        if isinstance(src, ToolResult):
+            return src
+        dst = absolute_target(new_path_str, label="new_path")
+        if isinstance(dst, ToolResult):
+            return dst
 
         if not src.exists():
             return ToolResult.err(

--- a/backend/api/actions/mcp_clients/discoverable.py
+++ b/backend/api/actions/mcp_clients/discoverable.py
@@ -15,7 +15,6 @@ from flask.typing import ResponseReturnValue
 
 from api.action import Action
 from api.endpoint import DocumentedResponse
-from exceptions import NotFoundError
 from api.response.mcp_tool import DiscoverableTools
 from services.mcp_client_service import McpClientService
 
@@ -27,7 +26,6 @@ class McpDiscoverable(Action):
     response_dto = {"get": DocumentedResponse(DiscoverableTools)}
 
     def get(self, id: int | str) -> ResponseReturnValue:
-        if not self.is_create(id):
-            raise NotFoundError("Not found")
+        self.require_create_sentinel(id)
         names = McpClientService().get_connected_mcp_tool_names()
         return DiscoverableTools(tools=names, count=len(names)).single()

--- a/backend/api/actions/providers/catalog.py
+++ b/backend/api/actions/providers/catalog.py
@@ -15,7 +15,6 @@ from flask.typing import ResponseReturnValue
 
 from api.action import Action
 from api.endpoint import DocumentedResponse
-from exceptions import NotFoundError
 from api.response.provider_catalog import CatalogEntry
 from services.provider_catalog_service import get_catalog
 
@@ -27,8 +26,7 @@ class ProviderCatalog(Action):
     response_dto = {"get": DocumentedResponse(CatalogEntry, listing=True)}
 
     def get(self, id: int | str) -> ResponseReturnValue:
-        if not self.is_create(id):
-            raise NotFoundError("Not found")
+        self.require_create_sentinel(id)
         items = [
             CatalogEntry(
                 id=cast(str, entry["id"]),

--- a/backend/api/actions/providers/delegate.py
+++ b/backend/api/actions/providers/delegate.py
@@ -42,8 +42,7 @@ class ProviderDelegate(Action):
     }
 
     def get(self, id: int | str) -> ResponseReturnValue:
-        if not self.is_create(id):
-            raise NotFoundError("Not found")
+        self.require_create_sentinel(id)
         status = ProviderDbService().get_delegate_provider_status()
         row = cast("dict[str, object] | None", status['provider'])
         return ProviderRole(
@@ -52,8 +51,7 @@ class ProviderDelegate(Action):
         ).single()
 
     def post(self, id: int | str, data: Request | None) -> ResponseReturnValue:
-        if not self.is_create(id):
-            raise NotFoundError("Not found")
+        self.require_create_sentinel(id)
         dto = cast(NullableProviderRef, data)
         service = ProviderDbService()
 

--- a/backend/api/actions/providers/list_models.py
+++ b/backend/api/actions/providers/list_models.py
@@ -21,7 +21,7 @@ from flask.typing import ResponseReturnValue
 
 from api.action import Action
 from api.endpoint import DocumentedResponse
-from exceptions import EndpointError, NotFoundError
+from exceptions import EndpointError
 from api.request import Request
 from api.request.provider_models import ListModelsRequest
 from api.response.provider_models import ListModelsResult, ModelInfo
@@ -37,8 +37,7 @@ class ProviderListModels(Action):
     response_dto = {"post": DocumentedResponse(ListModelsResult)}
 
     def post(self, id: int | str, data: Request | None) -> ResponseReturnValue:
-        if not self.is_create(id):
-            raise NotFoundError("Not found")
+        self.require_create_sentinel(id)
         dto = cast(ListModelsRequest, data)
         platform = dto.platform.strip().lower()
 

--- a/backend/api/actions/providers/selected.py
+++ b/backend/api/actions/providers/selected.py
@@ -41,8 +41,7 @@ class ProviderSelected(Action):
     }
 
     def get(self, id: int | str) -> ResponseReturnValue:
-        if not self.is_create(id):
-            raise NotFoundError("Not found")
+        self.require_create_sentinel(id)
         row = ProviderDbService().get_selected_provider()
         return ProviderRole(
             provider=Provider.from_row(row) if row else None,
@@ -50,8 +49,7 @@ class ProviderSelected(Action):
         ).single()
 
     def post(self, id: int | str, data: Request | None) -> ResponseReturnValue:
-        if not self.is_create(id):
-            raise NotFoundError("Not found")
+        self.require_create_sentinel(id)
         dto = cast(ProviderRef, data)
         service = ProviderDbService()
         row = service.get_provider_by_id(dto.provider_id)

--- a/backend/api/actions/providers/test.py
+++ b/backend/api/actions/providers/test.py
@@ -21,7 +21,6 @@ from flask.typing import ResponseReturnValue
 
 from api.action import Action
 from api.endpoint import DocumentedResponse
-from exceptions import NotFoundError
 from api.request import Request
 from api.request.provider_models import ProviderTestRequest
 from api.response.provider_models import ProviderTestResult
@@ -37,8 +36,7 @@ class ProviderTest(Action):
     response_dto = {"post": DocumentedResponse(ProviderTestResult)}
 
     def post(self, id: int | str, data: Request | None) -> ResponseReturnValue:
-        if not self.is_create(id):
-            raise NotFoundError("Not found")
+        self.require_create_sentinel(id)
         dto = cast(ProviderTestRequest, data)
 
         config: dict[str, object] = {}

--- a/backend/api/actions/providers/vision.py
+++ b/backend/api/actions/providers/vision.py
@@ -45,8 +45,7 @@ class ProviderVision(Action):
     }
 
     def get(self, id: int | str) -> ResponseReturnValue:
-        if not self.is_create(id):
-            raise NotFoundError("Not found")
+        self.require_create_sentinel(id)
         status = ProviderDbService().get_vision_provider_status()
         row = cast("dict[str, object] | None", status['provider'])
         return ProviderRole(
@@ -55,8 +54,7 @@ class ProviderVision(Action):
         ).single()
 
     def post(self, id: int | str, data: Request | None) -> ResponseReturnValue:
-        if not self.is_create(id):
-            raise NotFoundError("Not found")
+        self.require_create_sentinel(id)
         dto = cast(NullableProviderRef, data)
         service = ProviderDbService()
 

--- a/backend/api/actions/scheduler/turns.py
+++ b/backend/api/actions/scheduler/turns.py
@@ -15,7 +15,6 @@ from flask.typing import ResponseReturnValue
 
 from api.action import Action
 from api.endpoint import DocumentedResponse
-from exceptions import NotFoundError
 from api.response.scheduler_turn import SchedulerTurn
 from models.scheduled_item import ScheduledItem
 from models.thread_gist import ThreadGist
@@ -36,8 +35,7 @@ class SchedulerTurns(Action):
         channel=schedule, turn_id) — read separately and merged here, each
         model owning its own table's SQL rather than a cross-table JOIN.
         """
-        if not self.is_create(id):
-            raise NotFoundError("Not found")
+        self.require_create_sentinel(id)
         schedules = ScheduledItem.recent()
         gists = ThreadGist.bulk_get(ScheduledItem.SCHEDULE_CHANNEL, [cast(int, s.id) for s in schedules])
         items = [

--- a/backend/api/endpoint.py
+++ b/backend/api/endpoint.py
@@ -29,7 +29,7 @@ from flask.typing import ResponseReturnValue
 from flask_restx import Namespace, Resource
 from pydantic import ValidationError
 
-from exceptions import EndpointError, ForbiddenError
+from exceptions import EndpointError, ForbiddenError, NotFoundError
 from .auth import require_auth
 from .dto.openapi import register_auth_error, register_dto, register_envelope, register_error_envelope
 from .request import Request
@@ -140,6 +140,11 @@ class Endpoint(ABC):
     def is_create(self, id: int | str) -> bool:
         """True when the id is the create sentinel, regardless of :attr:`id_type`."""
         return id in (-1, "-1")
+
+    def require_create_sentinel(self, id: int | str) -> None:
+        """Raise :class:`NotFoundError` unless ``id`` is the create sentinel."""
+        if not self.is_create(id):
+            raise NotFoundError("Not found")
 
     def namespace(self) -> Namespace:
         """Build the fully-wired Namespace for this endpoint group."""

--- a/backend/models/model.py
+++ b/backend/models/model.py
@@ -17,6 +17,7 @@ freeze a connection themselves.
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from collections.abc import Callable, Sequence
 from typing import ClassVar, Self, TypeVar
@@ -99,6 +100,35 @@ class Model(Serializable, HasTable):
         I/O yet. An empty ``values`` matches nothing (see
         :meth:`~models.query.Query.filter_in`)."""
         return Query(cls).filter_in(key, values)
+
+    @classmethod
+    def _select_where_in_json(cls, column: str, values: Sequence[int], order_by: str | None = None) -> list[Self]:
+        """Every row whose ``column`` is in ``values``, bound as one JSON-array
+        parameter via ``json_each`` (large IN-lists exceed SQLite's bound-variable
+        limit). Empty ``values`` is a clean no-op — no query runs."""
+        if not values:
+            return []
+        safe_column = Query._validate_identifier(column)
+        order = f" ORDER BY {Query._validate_identifier(order_by)}" if order_by else ""
+        rows = cls._bound_connection().execute(
+            f"SELECT * FROM {cls.get_table()} WHERE {safe_column} IN (SELECT value FROM json_each(?)){order}",
+            (json.dumps(list(values)),),
+        ).fetchall()
+        return [cls.hydrate(row) for row in rows]
+
+    @classmethod
+    def _delete_where_in_json(cls, column: str, values: Sequence[int]) -> int:
+        """Hard-delete every row whose ``column`` is in ``values``, bound as one
+        JSON-array parameter via ``json_each``. Empty ``values`` is a clean
+        no-op — no query runs. Returns rows deleted."""
+        if not values:
+            return 0
+        safe_column = Query._validate_identifier(column)
+        cursor = cls._bound_connection().execute(
+            f"DELETE FROM {cls.get_table()} WHERE {safe_column} IN (SELECT value FROM json_each(?))",
+            (json.dumps(list(values)),),
+        )
+        return cursor.rowcount or 0
 
     @classmethod
     def order_by(cls: type[T], terms: str) -> Query[T]:

--- a/backend/models/tool_call.py
+++ b/backend/models/tool_call.py
@@ -176,14 +176,7 @@ class ToolCall(Model):
         ``?`` per id, since a first-run sweep's candidate set can exceed
         SQLite's bound-variable limit. Empty ``transcript_ids`` is a clean
         no-op — no query runs. Returns rows deleted."""
-        if not transcript_ids:
-            return 0
-        cursor = cls._bound_connection().execute(
-            f"DELETE FROM {cls.get_table()} "
-            "WHERE transcript_id IN (SELECT value FROM json_each(?))",
-            (json.dumps(transcript_ids),),
-        )
-        return cursor.rowcount or 0
+        return cls._delete_where_in_json("transcript_id", transcript_ids)
 
     @classmethod
     def decay(cls) -> int:

--- a/backend/models/transcript.py
+++ b/backend/models/transcript.py
@@ -14,7 +14,6 @@ only touches its own table.
 
 from __future__ import annotations
 
-import json
 from typing import ClassVar, Self, cast
 
 from models.model import Model
@@ -389,13 +388,7 @@ class Transcript(Model):
         together with the ``tool_calls`` pre-clear in one
         ``Database.transaction()`` (I6 — ``Database`` owns multi-write
         transactions). Returns rows deleted."""
-        if not ids:
-            return 0
-        cursor = cls._bound_connection().execute(
-            f"DELETE FROM {cls.get_table()} WHERE id IN (SELECT value FROM json_each(?))",
-            (json.dumps(ids),),
-        )
-        return cursor.rowcount or 0
+        return cls._delete_where_in_json("id", ids)
 
     # ── SQL fragment builders (shared, no duplication) ───────────────────────
 

--- a/backend/models/transcript_thinking.py
+++ b/backend/models/transcript_thinking.py
@@ -10,7 +10,6 @@ autoincrement ``id`` (like ``tool_calls``) rather than keyed by
 
 from __future__ import annotations
 
-import json
 from typing import ClassVar, Self
 
 from models.model import Model
@@ -57,15 +56,7 @@ class TranscriptThinking(Model):
         :meth:`~models.tool_call.ToolCall.delete_by_transcripts`) because a
         GC sweep's candidate set can exceed SQLite's bound-variable limit.
         Empty input is a clean no-op — no query runs."""
-        if not transcript_ids:
-            return []
-        rows = cls._bound_connection().execute(
-            "SELECT * FROM transcript_thinking "
-            "WHERE transcript_id IN (SELECT value FROM json_each(?)) "
-            "ORDER BY id",
-            (json.dumps(transcript_ids),),
-        ).fetchall()
-        return [cls.hydrate(row) for row in rows]
+        return cls._select_where_in_json("transcript_id", transcript_ids, order_by="id")
 
     @classmethod
     def by_turn(cls, channel: str, turn_id: int) -> list[Self]:

--- a/backend/models/voice_transcript.py
+++ b/backend/models/voice_transcript.py
@@ -15,7 +15,6 @@ Holds no mp, calls no service (Rule-3 depth).
 
 from __future__ import annotations
 
-import json
 from typing import ClassVar
 
 from models.model import Model
@@ -55,14 +54,7 @@ class VoiceTranscript(Model):
         :meth:`~models.tool_call.ToolCall.delete_by_transcripts`) because a
         GC sweep's candidate set can exceed SQLite's bound-variable limit.
         Empty input is a clean no-op — no query runs."""
-        if not transcript_ids:
-            return []
-        rows = cls._bound_connection().execute(
-            "SELECT * FROM voice_transcript "
-            "WHERE transcript_id IN (SELECT value FROM json_each(?))",
-            (json.dumps(transcript_ids),),
-        ).fetchall()
-        return [cls.hydrate(row) for row in rows]
+        return cls._select_where_in_json("transcript_id", transcript_ids)
 
     @classmethod
     def delete_by_transcripts(cls, transcript_ids: list[int]) -> int:
@@ -76,11 +68,4 @@ class VoiceTranscript(Model):
         whatever the caller does with the transcript row afterwards. Same
         ``json_each`` binding as :meth:`for_transcripts`; empty input is a
         clean no-op. Returns rows deleted."""
-        if not transcript_ids:
-            return 0
-        cursor = cls._bound_connection().execute(
-            "DELETE FROM voice_transcript "
-            "WHERE transcript_id IN (SELECT value FROM json_each(?))",
-            (json.dumps(transcript_ids),),
-        )
-        return cursor.rowcount or 0
+        return cls._delete_where_in_json("transcript_id", transcript_ids)


### PR DESCRIPTION
## Summary
- Four models hand-rolled the same `json_each`-bound IN-list SELECT/DELETE pattern for large candidate-id lists; callers now delegate to two new base-class methods, each keeping its own domain docstring.
- Eight API actions repeated the same create-sentinel guard (`if not self.is_create(id): raise NotFoundError`); consolidated into one `Endpoint` method.
- The move ability's two inline absolute-path checks now reuse the existing shared path-validation helper (extended with a label parameter for its two arguments). The edit-file and run-script abilities were deliberately left untouched — they rely on unresolved-path semantics downstream that the shared helper does not preserve.

Net: 16 files changed, 64 insertions(+), 89 deletions(-) — -25 LOC, no behavior change.

## Test plan
- [x] `pytest -m unit` — full pass, same failure set as baseline
- [x] `ruff` — zero new (file, rule) pairs vs. baseline
- [x] `mypy --strict` — clean, zero overrides
- [x] Reviewed for behavior equivalence (identical SQL shape, identical guard semantics, identical path-resolution timing)